### PR TITLE
adding -freshSimulator and -freshInstall options for test and run-tests.

### DIFF
--- a/xctool/xctool/OCUnitTestRunner.h
+++ b/xctool/xctool/OCUnitTestRunner.h
@@ -21,6 +21,8 @@
   NSString *_senTestList;
   BOOL _senTestInvertScope;
   BOOL _garbageCollection;
+  BOOL _freshSimulator;
+  BOOL _freshInstall;
   NSFileHandle *_standardOutput;
   NSFileHandle *_standardError;
   NSArray *_reporters;
@@ -30,6 +32,8 @@
                 senTestList:(NSString *)senTestList
          senTestInvertScope:(BOOL)senTestInvertScope
           garbageCollection:(BOOL)garbageCollection
+             freshSimulator:(BOOL)freshSimulator
+               freshInstall:(BOOL)freshInstall
              standardOutput:(NSFileHandle *)standardOutput
               standardError:(NSFileHandle *)standardError
                   reporters:(NSArray *)reporters;

--- a/xctool/xctool/OCUnitTestRunner.m
+++ b/xctool/xctool/OCUnitTestRunner.m
@@ -26,6 +26,8 @@
                 senTestList:(NSString *)senTestList
          senTestInvertScope:(BOOL)senTestInvertScope
           garbageCollection:(BOOL)garbageCollection
+             freshSimulator:(BOOL)freshSimulator
+               freshInstall:(BOOL)freshInstall
              standardOutput:(NSFileHandle *)standardOutput
               standardError:(NSFileHandle *)standardError
                   reporters:(NSArray *)reporters
@@ -35,6 +37,8 @@
     _senTestList = [senTestList retain];
     _senTestInvertScope = senTestInvertScope;
     _garbageCollection = garbageCollection;
+    _freshSimulator = freshSimulator;
+    _freshInstall = freshInstall;
     _standardOutput = [standardOutput retain];
     _standardError = [standardError retain];
     _reporters = [reporters retain];

--- a/xctool/xctool/RunTestsAction.h
+++ b/xctool/xctool/RunTestsAction.h
@@ -18,7 +18,8 @@
 
 @interface RunTestsAction : Action
 
-@property (nonatomic, assign) BOOL killSimulator;
+@property (nonatomic, assign) BOOL freshSimulator;
+@property (nonatomic, assign) BOOL freshInstall;
 @property (nonatomic, retain) NSString *testSDK;
 @property (nonatomic, retain) NSMutableArray *onlyList;
 

--- a/xctool/xctool/TestAction.m
+++ b/xctool/xctool/TestAction.m
@@ -48,14 +48,20 @@
                      description:@"SPEC is TARGET[:Class/case[,Class2/case2]]"
                        paramName:@"SPEC"
                            mapTo:@selector(addOnly:)],
-    [Action actionOptionWithName:@"killSimulator"
-                         aliases:nil
-                     description:@"kill simulator before testing starts"
-                         setFlag:@selector(setKillSimulator:)],
     [Action actionOptionWithName:@"skip-deps"
                          aliases:nil
                      description:@"Only build the target, not its dependencies"
                          setFlag:@selector(setSkipDependencies:)],
+    [Action actionOptionWithName:@"freshSimulator"
+                         aliases:nil
+                     description:
+     @"Start fresh simulator for each application test target"
+                         setFlag:@selector(setFreshSimulator:)],
+    [Action actionOptionWithName:@"freshInstall"
+                         aliases:nil
+                     description:
+     @"Use clean install of TEST_HOST for every app test run"
+                         setFlag:@selector(setFreshInstall:)],
     ];
 }
 
@@ -79,9 +85,14 @@
   _runTestsAction.testSDK = testSDK;
 }
 
-- (void)setKillSimulator:(BOOL)killSimulator
+- (void)setFreshSimulator:(BOOL)freshSimulator
 {
-  _runTestsAction.killSimulator = killSimulator;
+  [_runTestsAction setFreshSimulator:freshSimulator];
+}
+
+- (void)setFreshInstall:(BOOL)freshInstall
+{
+  [_runTestsAction setFreshInstall:freshInstall];
 }
 
 - (void)setSkipDependencies:(BOOL)skipDependencies


### PR DESCRIPTION
What used to be -killSimulator is now -freshSimulator.  And, you can
optionally choose whether or not to uninstall the TEST_HOST before
running an application test (it used to be the default).
