### PR TITLE
fix issue where run-tests -only might run only the disabled tests.

### DIFF
--- a/xctool/xctool-tests/TestData/TestProject-Library/TestProject-Library.xcodeproj/project.pbxproj
+++ b/xctool/xctool-tests/TestData/TestProject-Library/TestProject-Library.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		2828293F16B11F0F00426B92 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 2828293D16B11F0F00426B92 /* InfoPlist.strings */; };
 		2828294216B11F0F00426B92 /* SomeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2828294116B11F0F00426B92 /* SomeTests.m */; };
 		28A33D1316CF4FFD00C5EE2A /* OtherTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 28A33D1216CF4FFD00C5EE2A /* OtherTests.m */; };
+		28B3C3AF1731B33C00EC75E5 /* DisabledTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 28B3C3AE1731B33C00EC75E5 /* DisabledTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -47,6 +48,8 @@
 		2828294116B11F0F00426B92 /* SomeTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SomeTests.m; sourceTree = "<group>"; };
 		28A33D1116CF4FFD00C5EE2A /* OtherTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OtherTests.h; sourceTree = "<group>"; };
 		28A33D1216CF4FFD00C5EE2A /* OtherTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OtherTests.m; sourceTree = "<group>"; };
+		28B3C3AD1731B33C00EC75E5 /* DisabledTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DisabledTests.h; sourceTree = "<group>"; };
+		28B3C3AE1731B33C00EC75E5 /* DisabledTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DisabledTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -127,6 +130,8 @@
 				2828293B16B11F0F00426B92 /* Supporting Files */,
 				28A33D1116CF4FFD00C5EE2A /* OtherTests.h */,
 				28A33D1216CF4FFD00C5EE2A /* OtherTests.m */,
+				28B3C3AD1731B33C00EC75E5 /* DisabledTests.h */,
+				28B3C3AE1731B33C00EC75E5 /* DisabledTests.m */,
 			);
 			path = "TestProject-LibraryTests";
 			sourceTree = "<group>";
@@ -246,6 +251,7 @@
 			files = (
 				2828294216B11F0F00426B92 /* SomeTests.m in Sources */,
 				28A33D1316CF4FFD00C5EE2A /* OtherTests.m in Sources */,
+				28B3C3AF1731B33C00EC75E5 /* DisabledTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/xctool/xctool-tests/TestData/TestProject-Library/TestProject-Library.xcodeproj/xcshareddata/xcschemes/TestProject-Library.xcscheme
+++ b/xctool/xctool-tests/TestData/TestProject-Library/TestProject-Library.xcodeproj/xcshareddata/xcschemes/TestProject-Library.xcscheme
@@ -37,6 +37,11 @@
                BlueprintName = "TestProject-LibraryTests"
                ReferencedContainer = "container:TestProject-Library.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "DisabledTests">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/xctool/xctool-tests/TestData/TestProject-Library/TestProject-LibraryTests/DisabledTests.h
+++ b/xctool/xctool-tests/TestData/TestProject-Library/TestProject-LibraryTests/DisabledTests.h
@@ -1,0 +1,13 @@
+//
+//  DisabledTests.h
+//  TestProject-Library
+//
+//  Created by Fred Potter on 5/1/13.
+//
+//
+
+#import <SenTestingKit/SenTestingKit.h>
+
+@interface DisabledTests : SenTestCase
+
+@end

--- a/xctool/xctool-tests/TestData/TestProject-Library/TestProject-LibraryTests/DisabledTests.m
+++ b/xctool/xctool-tests/TestData/TestProject-Library/TestProject-LibraryTests/DisabledTests.m
@@ -1,0 +1,13 @@
+//
+//  DisabledTests.m
+//  TestProject-Library
+//
+//  Created by Fred Potter on 5/1/13.
+//
+//
+
+#import "DisabledTests.h"
+
+@implementation DisabledTests
+
+@end

--- a/xctool/xctool/RunTestsAction.m
+++ b/xctool/xctool/RunTestsAction.m
@@ -147,12 +147,13 @@
     NSMutableArray *newTestables = [NSMutableArray array];
     for (NSDictionary *only in [self onlyListAsTargetsAndSenTestList]) {
       NSDictionary *matchingTestable = [xcodeSubjectInfo testableWithTarget:only[@"target"]];
+
       if (matchingTestable) {
         NSMutableDictionary *newTestable = [NSMutableDictionary dictionaryWithDictionary:matchingTestable];
-        newTestable[@"senTestInvertScope"] = @NO;
 
         if (only[@"senTestList"] != [NSNull null]) {
           newTestable[@"senTestList"] = only[@"senTestList"];
+          newTestable[@"senTestInvertScope"] = @NO;
         }
 
         [newTestables addObject:newTestable];


### PR DESCRIPTION
If you had disabled some test classes in a scheme and then used -only to
run that test target, it was running only the disabled tests.

Tested by...

Adding a new DisabledTests test class to TestProject-Library and
unchecked it in the scheme.  Then ran...

```
./xctool.sh -project xctool/xctool-tests/TestData/TestProject-Library/TestProject-Library.xcodeproj -scheme TestProject-Library -arch i386 -configuration Debug -sdk iphonesimulator run-tests -only TestProject-LibraryTests
```

... and verified it ran the non-disabled tests.

Also checked that you could still run the disabled test if you really
wanted with...

```
./xctool.sh -project xctool/xctool-tests/TestData/TestProject-Library/TestProject-Library.xcodeproj -scheme TestProject-Library -arch i386 -configuration Debug -sdk iphonesimulator run-tests -only TestProject-LibraryTests:DisabledTests
```
