### PR TITLE
Fix detection of when a build is needed with better git fu

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ set -e
 XCTOOL_DIR=$(cd $(dirname $0); pwd)
 
 # Will be a short git hash or just '.' if we're not in a git repo.
-REVISION=$((git log -n 1 --format=%h "$XCTOOL_DIR" 2> /dev/null) || echo ".")
+REVISION=$((git --git-dir="${XCTOOL_DIR}/.git" log -n 1 --format=%h 2> /dev/null) || echo ".")
 
 BUILD_OUTPUT_DIR="$XCTOOL_DIR"/build/$REVISION
 XCTOOL_PATH="$BUILD_OUTPUT_DIR"/Products/Release/xctool

--- a/build_needed.sh
+++ b/build_needed.sh
@@ -6,12 +6,12 @@ set -e
 XCTOOL_DIR=$(cd $(dirname $0); pwd)
 
 # Will be a short git hash or just '.' if we're not in a git repo.
-REVISION=$((git log -n 1 --format=%h "$XCTOOL_DIR" 2> /dev/null) || echo ".")
+REVISION=$((git --git-dir="${XCTOOL_DIR}/.git" log -n 1 --format=%h 2> /dev/null) || echo ".")
 
 # If we're in a git repo, figure out if any changes have been made to xctool.
 if [[ "$REVISION" != "." ]]; then
   NUM_CHANGES=$(\
-    (cd "$XCTOOL_DIR" && git status --porcelain "$XCTOOL_DIR") | wc -l)
+    (cd "$XCTOOL_DIR" && git status --porcelain) | wc -l)
   HAS_GIT_CHANGES=$([[ $NUM_CHANGES -gt 0 ]] && echo YES || echo NO)
 else
   HAS_GIT_CHANGES=NO

--- a/xctool.sh
+++ b/xctool.sh
@@ -43,6 +43,6 @@ if [ "$BUILD_NEEDED" -eq 1 ]; then
 fi
 
 # Will be a short git hash or just '.' if we're not in a git repo.
-REVISION=$((git log -n 1 --format=%h "$XCTOOL_DIR" 2> /dev/null) || echo ".")
+REVISION=$((git --git-dir="${XCTOOL_DIR}/.git" log -n 1 --format=%h 2> /dev/null) || echo ".")
 
 "$XCTOOL_DIR"/build/$REVISION/Products/Release/xctool "$@"


### PR DESCRIPTION
There were a few places where detecting the current git revision just doesn't work when the scripts are run from outside the repo directory. This fixes it. You can now run 'xctool.sh' from wherever you want and it all works fine.
