### PR TITLE
fix otest-shim crash that can happen with multiple threads

### DIFF
--- a/xctool/xctool/OCUnitCrashFilter.m
+++ b/xctool/xctool/OCUnitCrashFilter.m
@@ -89,7 +89,9 @@
     [self.currentTestSuiteEventTimestampStack removeLastObject];
     [self.currentTestSuiteEventTestCountStack removeLastObject];
   } else if ([eventName isEqualToString:kReporter_Events_TestOuput]) {
-    NSAssert(self.currentTestEvent != nil, @"'test-output' event should only come during a test.");
+    NSAssert(_currentTestEvent != nil,
+             @"'test-output' event should only come during a test: %@",
+             event);
     [self.currentTestOutput appendString:event[kReporter_TestOutput_OutputKey]];
   }
 }

--- a/xctool/xctool/OCUnitTestRunner.m
+++ b/xctool/xctool/OCUnitTestRunner.m
@@ -118,7 +118,10 @@
                                                           options:0
                                                             error:&parseError];
     if (parseError) {
-      [NSException raise:NSGenericException format:@"Failed to parse test output: %@", [parseError localizedFailureReason]];
+      [NSException raise:NSGenericException
+                  format:@"Failed to parse test output '%@' with error '%@'.",
+       line,
+       [parseError localizedFailureReason]];
     }
 
     [_reporters makeObjectsPerformSelector:@selector(handleEvent:) withObject:event];


### PR DESCRIPTION
This fixes the crashes found by @bgertzfield.  If tests end up spawning
threads that write to stdout or stderr, some bad things could possibly
happen...

1) the emitted JSON could get corrupted since there was no locking or
serialization there.

2) 'test-output' events could get written outside of the 'begin-test' &
'end-test' boundaries.

Let's setup a GCD queue to serialize all of our events.  We'll always
use dispatch_sync so we can be sure the event gets written.
(dispatch_async would work fine in the positive case, but if the tests
caused a crash, we could lose whatever blocks were in the queue)

Test Plan:
Made some tests that spawned ridiculous numbers of threads that
constantly wrote to stdout.  Observed that I could repro the crash
consistently before I applied this change, and then observed it went
away afterwards.
