### PR TITLE
Adding support for passing options to reporter

### DIFF
--- a/xctool/xctool/JSONStreamReporter.m
+++ b/xctool/xctool/JSONStreamReporter.m
@@ -32,6 +32,10 @@
   [self.outputHandle writeData:[@"\n" dataUsingEncoding:NSUTF8StringEncoding]];
 }
 
+- (void)setReporterOptions: (NSDictionary *) data {
+    NSLog(@"%@", data);
+}
+
 - (void)beginAction:(NSDictionary *)event { [self passThrough:event]; }
 - (void)endAction:(NSDictionary *)event { [self passThrough:event]; }
 - (void)beginBuildTarget:(NSDictionary *)event { [self passThrough:event]; }


### PR DESCRIPTION
Quick implementation so that you can provide more options to your formatter then just path of output. 

I use this in a ongoing formatter to give an id to the formatter. But could also be used for giving eg. database credentials to the formatter for direct input on databases.
