### PR TITLE
Dynamic formatters

### DIFF
--- a/xctool/xctool/JSONStreamReporter.h
+++ b/xctool/xctool/JSONStreamReporter.h
@@ -18,6 +18,5 @@
 
 #import "Reporter.h"
 
-@interface JSONStreamReporter : Reporter
-
+@interface JSONStreamReporter : Reporter<ExportedReporter>
 @end

--- a/xctool/xctool/JSONStreamReporter.m
+++ b/xctool/xctool/JSONStreamReporter.m
@@ -18,6 +18,10 @@
 
 @implementation JSONStreamReporter
 
++ (NSString *) reporterName {
+    return @"json-stream";
+}
+
 - (void)passThrough:(NSDictionary *)event
 {
   NSError *error = nil;

--- a/xctool/xctool/Options.m
+++ b/xctool/xctool/Options.m
@@ -42,6 +42,15 @@
 
 + (NSArray *)options
 {
+  NSMutableString *reporters = [NSMutableString string];
+  for (NSString *reporterName in [Reporter availableReporters]) {
+    [reporters appendFormat:@"%@,", reporterName];
+  }
+  if ( [reporters length] > 0 ) {
+    [reporters deleteCharactersInRange:NSMakeRange([reporters length]-1, 1)];
+  }
+  
+  
   return
   @[[Action actionOptionWithName:@"help"
                          aliases:@[@"h", @"usage"]
@@ -109,7 +118,7 @@
                            mapTo:@selector(setXcconfig:)],
     [Action actionOptionWithName:@"reporter"
                          aliases:nil
-                     description:@"add reporter"
+                     description:[NSString stringWithFormat:@"add reporter (%@)", reporters]
                        paramName:@"TYPE[:FILE]"
                            mapTo:@selector(addReporter:)],
     [Action actionOptionWithName:@"showBuildSettings"

--- a/xctool/xctool/PhabricatorReporter.h
+++ b/xctool/xctool/PhabricatorReporter.h
@@ -20,7 +20,7 @@
  PhabricatorReporter produces a JSON array which you can plug directly into the
  'arc:unit' diff property in Phabricator.
  */
-@interface PhabricatorReporter : Reporter
+@interface PhabricatorReporter : Reporter<ExportedReporter>
 {
   NSMutableArray *_results;
   NSMutableArray *_currentTargetFailures;

--- a/xctool/xctool/Reporter.h
+++ b/xctool/xctool/Reporter.h
@@ -102,6 +102,10 @@
 @class Action;
 @class Options;
 
+@protocol ExportedReporter
+@optional
++ (NSString *) reporterName;
+@end
 typedef enum {
   REPORTER_MESSAGE_DEBUG,
   REPORTER_MESSAGE_VERBOSE,
@@ -112,6 +116,7 @@ typedef enum {
 
 NSString *ReporterMessageLevelToString(ReporterMessageLevel level);
 
+
 void RegisterReporters(NSArray *reporters);
 void UnregisterReporters(NSArray *reporters);
 
@@ -121,7 +126,7 @@ void ReportMessage(ReporterMessageLevel level, NSString *format, ...) NS_FORMAT_
 {
   NSFileHandle *_outputHandle;
 }
-
++ (NSArray *) availableReporters;
 + (Reporter *)reporterWithName:(NSString *)name outputPath:(NSString *)outputPath options:(Options *)options;
 
 // The reporter will stream output to here.  Usually this will be "-" to route

--- a/xctool/xctool/TextReporter.h
+++ b/xctool/xctool/TextReporter.h
@@ -35,8 +35,8 @@
 
 @end
 
-@interface PrettyTextReporter : TextReporter
+@interface PrettyTextReporter : TextReporter<ExportedReporter>
 @end
 
-@interface PlainTextReporter : TextReporter
+@interface PlainTextReporter : TextReporter<ExportedReporter>
 @end

--- a/xctool/xctool/TextReporter.m
+++ b/xctool/xctool/TextReporter.m
@@ -566,6 +566,11 @@
   return self;
 }
 
++ (NSString *) reporterName {
+  return @"pretty";
+}
+
+
 @end
 
 @implementation PlainTextReporter
@@ -577,5 +582,10 @@
   }
   return self;
 }
+
++ (NSString *) reporterName {
+  return @"plain";
+}
+
 
 @end


### PR DESCRIPTION
What i wanted to accomplish was to remove the need for a static NSDictionary inside Reporter.m for handling new Reporter types. Just because it will cause conflicts when merging in another branch which might have added reporters.

This also removes the need to #import all formatters inside the Reporter.m, ofc this comes with a trade-off or two (nothing is free in this world). 

The trade-offs are: 
- Each reporter which wants to be exposed needs to implement the `@protocol(ExposedReporter)`. This protocol contains 1 optional method which is to give the name of the reporter used on command line. If this is not implemented it will strip "Reporter" from the class name and lowercase it. Eg. `JSONStreamReporter` --> `jsonstream` 
- A tiny performance penalty for using the Runtime instead of Compile time. I can pull out some benchmark numbers if interested but my own reasoning for not doing them in the time of writing this is that the penalty will be so small that its insignificant compared to what machines this will run on.
