### PR TITLE
Create the intermediate directory if required

### DIFF
--- a/xctool/xctool/Reporter.m
+++ b/xctool/xctool/Reporter.m
@@ -113,7 +113,20 @@ void ReportMessage(ReporterMessageLevel level, NSString *format, ...) {
     _outputHandle = [standardOutput retain];
     return YES;
   } else {
-    if (![[NSFileManager defaultManager] createFileAtPath:self.outputPath contents:nil attributes:nil]) {
+    NSFileManager *fileManager = [[NSFileManager alloc] init];
+      
+    NSString *path = [self.outputPath stringByDeletingLastPathComponent];
+    BOOL isDirectory;
+    BOOL exists = [fileManager fileExistsAtPath:path isDirectory:&isDirectory];
+    if (!exists) {
+      if (![fileManager createDirectoryAtPath:path withIntermediateDirectories:YES attributes:nil error:nil]) {
+        *error = [NSString stringWithFormat:@"Failed to create folder at '%@'.", path];
+        return NO;
+      }
+      exists = isDirectory = YES;
+    }
+    
+    if (![fileManager createFileAtPath:self.outputPath contents:nil attributes:nil]) {
       *error = [NSString stringWithFormat:@"Failed to create file at '%@'.", self.outputPath];
       return NO;
     }


### PR DESCRIPTION
If the output file for a reporter is in a directory that doesn't yet exist, then the intermediate directories are not created. This commit fixes that. It's useful for when you are running this on a build server which spits out results into a directory within the source repository, but you don't / can't have that directory committed to the repository.
