### PR TITLE
Set indentation settings to two spaces at the project level

### DIFF
--- a/xctool/xctool.xcodeproj/project.pbxproj
+++ b/xctool/xctool.xcodeproj/project.pbxproj
@@ -296,7 +296,10 @@
 				283CCA4416C2EA3800F2E343 /* Frameworks */,
 				283CCA4316C2EA3800F2E343 /* Products */,
 			);
+			indentWidth = 2;
 			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
 		};
 		283CCA4316C2EA3800F2E343 /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
Since all sane people have set their Xcode indentation preference to tabs/4 :trollface:, this will force them to use spaces/2 instead when contributing to xctool.
