### PR TITLE
Better error message when running xcodebuild fails

### DIFF
--- a/xctool/xctool/XcodeSubjectInfo.m
+++ b/xctool/xctool/XcodeSubjectInfo.m
@@ -716,7 +716,13 @@ containsFilesModifiedSince:(NSDate *)sinceDate
    }];
 
   NSDictionary *result = LaunchTaskAndCaptureOutput(task);
-  return BuildSettingsFromOutput(result[@"stdout"]);
+  NSString *output = result[@"stdout"];
+  NSString *err = result[@"stderr"];
+  if ([output length] == 0 && [err length] > 0) {
+    NSLog(@"Error running xcodebuild: %@", err);
+    abort();
+  }
+  return BuildSettingsFromOutput(output);
 }
 
 - (void)populate


### PR DESCRIPTION
Because this:

```
2013-05-23 22:56:40.209 xctool[40141:f07] Error running xcodebuild: dyld: could not load inserted library: /Users/0xced/Library/Developer/Xcode/DerivedData/xctool-ddidqmmbossgpqamltbydmrbuquk/Build/Products/Debug/xcodebuild-fastsettings-shim.dylib
```

is much more useful than this:

```
Assertion failed: (settings.count == 1), function -[XcodeSubjectInfo populate], file /Users/0xced/Projects/xctool/xctool/xctool/XcodeSubjectInfo.m, line 730.
```
