### PR TITLE
Fixed Travis CI divider length

### DIFF
--- a/xctool.sh
+++ b/xctool.sh
@@ -47,4 +47,8 @@ REVISION=$((\
   git --git-dir="${XCTOOL_DIR}/.git" log -n 1 --format=%h 2> /dev/null) || \
   echo ".")
 
+if [ "$TRAVIS" = "true" ]; then
+  stty columns 60
+fi
+
 "$XCTOOL_DIR"/build/$REVISION/Products/Release/xctool "$@"


### PR DESCRIPTION
Added a check for Travis CI which sets the number of columns below the minimum size of the terminal to ensure that the dividers do not wrap.
