### PR TITLE
make ReportMessage take a list of reporters instead of using globals

### DIFF
--- a/xctool/xctool/OCUnitIOSAppTestRunner.m
+++ b/xctool/xctool/OCUnitIOSAppTestRunner.m
@@ -222,14 +222,16 @@ static void KillSimulatorJobs()
   NSString *testHostBundleID = plist[@"CFBundleIdentifier"];
 
   if (_freshSimulator) {
-    ReportMessage(REPORTER_MESSAGE_INFO,
+    ReportMessage(_reporters,
+                  REPORTER_MESSAGE_INFO,
                   @"Stopping any existing iOS simulator jobs to get a "
                   @"fresh simulator.");
     KillSimulatorJobs();
   }
 
   if (_freshInstall) {
-    ReportMessage(REPORTER_MESSAGE_INFO,
+    ReportMessage(_reporters,
+                  REPORTER_MESSAGE_INFO,
                   @"Uninstalling '%@' to get a fresh install.",
                   testHostBundleID);
     BOOL uninstalled = [self runMobileInstallationHelperWithArguments:@[
@@ -255,7 +257,7 @@ static void KillSimulatorJobs()
   //
   // By making sure the app is already installed, we guarantee the environment
   // is always set correctly.
-  ReportMessage(REPORTER_MESSAGE_INFO, @"Installing '%@' ...", testHostAppPath);
+  ReportMessage(_reporters, REPORTER_MESSAGE_INFO, @"Installing '%@' ...", testHostAppPath);
   BOOL installed = [self runMobileInstallationHelperWithArguments:@[
                     @"install",
                     testHostAppPath,
@@ -267,7 +269,8 @@ static void KillSimulatorJobs()
     return NO;
   }
 
-  ReportMessage(REPORTER_MESSAGE_INFO,
+  ReportMessage(_reporters,
+                REPORTER_MESSAGE_INFO,
                 @"Launching test host and running tests...");
   if (![self runTestsInSimulator:testHostAppPath feedOutputToBlock:outputLineBlock]) {
     *error = [NSString stringWithFormat:@"Failed to run tests"];

--- a/xctool/xctool/Options.m
+++ b/xctool/xctool/Options.m
@@ -258,11 +258,15 @@
     }
 
     if (targetMatch.workspacePath) {
-      ReportMessage(REPORTER_MESSAGE_INFO,
+      ReportMessage(
+        _reporters,
+        REPORTER_MESSAGE_INFO,
         @"Found target %@. Using workspace path %@, scheme %@.",
         self.findTarget, targetMatch.workspacePath, targetMatch.schemeName);
     } else {
-      ReportMessage(REPORTER_MESSAGE_INFO,
+      ReportMessage(
+        _reporters,
+        REPORTER_MESSAGE_INFO,
         @"Found target %@. Using project path %@, scheme %@.",
         self.findTarget, targetMatch.projectPath, targetMatch.schemeName);
     }

--- a/xctool/xctool/Reporter.h
+++ b/xctool/xctool/Reporter.h
@@ -116,10 +116,7 @@ typedef enum {
 
 NSString *ReporterMessageLevelToString(ReporterMessageLevel level);
 
-void RegisterReporters(NSArray *reporters);
-void UnregisterReporters(NSArray *reporters);
-
-void ReportMessage(ReporterMessageLevel level, NSString *format, ...) NS_FORMAT_FUNCTION(2, 3);
+void ReportMessage(NSArray *reporters, ReporterMessageLevel level, NSString *format, ...) NS_FORMAT_FUNCTION(3, 4);
 
 @interface Reporter : NSObject
 {

--- a/xctool/xctool/XCTool.m
+++ b/xctool/xctool/XCTool.m
@@ -165,9 +165,6 @@
     }
   }
 
-  // After this point, we can start reporting messages.
-  RegisterReporters(options.reporters);
-
   // We want to make sure we always unregister the reporters, even if validation fails,
   // so we use a try-finally block.
   @try {
@@ -205,9 +202,6 @@
     }
   } @finally {
     [options.reporters makeObjectsPerformSelector:@selector(close)];
-
-    // After this point, we can no longer report messages.
-    UnregisterReporters(options.reporters);
   }
 }
 


### PR DESCRIPTION
Having the global list of reporters is holding us back in PR #51.
@yiding is parallelizing test runs, buffering their reporter events
until the test is finished, and then flushing all the reporter events at
at the end.  In this case, we need the events from ReportMessage(...)
to feed into the BufferedReporters intead of sidestepping it and going
for the globals.

Tests pass, and via manual testing verified that reporter messages show
up correctly.
