### PR TITLE
fix bug where clean action wasn't cleaning targets set as build for test...

### DIFF
--- a/xctool/xctool/BuildTestsAction.m
+++ b/xctool/xctool/BuildTestsAction.m
@@ -152,26 +152,8 @@
 
 - (BOOL)performActionWithOptions:(Options *)options xcodeSubjectInfo:(XcodeSubjectInfo *)xcodeSubjectInfo
 {
-  NSMutableSet *targetsAdded = [NSMutableSet set];
-  NSMutableArray *buildableList = [NSMutableArray array];
-
-  [xcodeSubjectInfo.buildablesForTest enumerateObjectsUsingBlock:^(NSDictionary *item, NSUInteger idx, BOOL *stop) {
-    NSString *target = item[@"target"];
-    if (![targetsAdded containsObject:target]) {
-      [targetsAdded addObject:target];
-      [buildableList addObject:item];
-    }
-  }];
-
-  [xcodeSubjectInfo.testables enumerateObjectsUsingBlock:^(NSDictionary *item, NSUInteger idx, BOOL *stop) {
-    NSString *target = item[@"target"];
-    if (![targetsAdded containsObject:target]) {
-      [targetsAdded addObject:target];
-      [buildableList addObject:item];
-    }
-  }];
-
-  buildableList = [self buildableList:buildableList matchingTargets:self.onlyList];
+  NSArray *buildableList = [self buildableList:[xcodeSubjectInfo testablesAndBuildablesForTest]
+                               matchingTargets:self.onlyList];
 
   if (![BuildTestsAction buildTestables:buildableList
                                 command:@"build"

--- a/xctool/xctool/CleanAction.m
+++ b/xctool/xctool/CleanAction.m
@@ -38,7 +38,11 @@
     return NO;
   }
 
-  if (![BuildTestsAction buildTestables:xcodeSubjectInfo.testables command:@"clean" options:options xcodeSubjectInfo:xcodeSubjectInfo]) {
+  NSArray *buildables = [xcodeSubjectInfo testablesAndBuildablesForTest];
+  if (![BuildTestsAction buildTestables:buildables
+                                command:@"clean"
+                                options:options
+                       xcodeSubjectInfo:xcodeSubjectInfo]) {
     return NO;
   }
 

--- a/xctool/xctool/XcodeSubjectInfo.h
+++ b/xctool/xctool/XcodeSubjectInfo.h
@@ -44,6 +44,12 @@
 @property (nonatomic, retain) NSArray *reporters;
 
 /**
+ * Returns the contents of 'testables' and 'buildablesForTest' with any
+ * duplicates removed.
+ */
+- (NSArray *)testablesAndBuildablesForTest;
+
+/**
  * Returns a list of paths to .xcodeproj directories in the workspace.
  */
 + (NSArray *)projectPathsInWorkspace:(NSString *)workspace;

--- a/xctool/xctool/XcodeSubjectInfo.m
+++ b/xctool/xctool/XcodeSubjectInfo.m
@@ -841,4 +841,30 @@ containsFilesModifiedSince:(NSDate *)sinceDate
   return _buildablesForTest;
 }
 
+- (NSArray *)testablesAndBuildablesForTest
+{
+  [self populate];
+
+  NSMutableSet *targetsAdded = [NSMutableSet set];
+  NSMutableArray *result = [NSMutableArray array];
+
+  [_buildablesForTest enumerateObjectsUsingBlock:^(NSDictionary *item, NSUInteger idx, BOOL *stop) {
+    NSString *target = item[@"target"];
+    if (![targetsAdded containsObject:target]) {
+      [targetsAdded addObject:target];
+      [result addObject:item];
+    }
+  }];
+
+  [_testables enumerateObjectsUsingBlock:^(NSDictionary *item, NSUInteger idx, BOOL *stop) {
+    NSString *target = item[@"target"];
+    if (![targetsAdded containsObject:target]) {
+      [targetsAdded addObject:target];
+      [result addObject:item];
+    }
+  }];
+
+  return result;
+}
+
 @end


### PR DESCRIPTION
....

In xctool, we have testables (targets added ot the 'Test' pane of the
scheme editor), and we have buildables for tests (targets added to the
'Build' pane in the scheme editor but with 'Test' checked).

For the clean action, we weren't cleaning the latter (targets marked as
build for test).

Also, might as well unify that logic in XcodeSubjectInfo since we're now
using in the build-tests and clean actions.
