### PR TITLE
report crashes that happen outside a test suite

### DIFF
--- a/xctool/xctool-tests/FakeTask.h
+++ b/xctool/xctool-tests/FakeTask.h
@@ -21,6 +21,7 @@
   NSString *_pretendStandardOutput;
   NSString *_pretendStandardError;
   int _pretendExitStatus;
+  NSTaskTerminationReason _pretendTerminationReason;
 }
 
 @property (nonatomic, retain) NSString *launchPath;
@@ -29,6 +30,7 @@
 @property (nonatomic, retain) id standardOutput;
 @property (nonatomic, retain) id standardError;
 @property (nonatomic, assign) int terminationStatus;
+@property (nonatomic, assign) NSTaskTerminationReason terminationReason;
 @property (nonatomic, assign) BOOL isRunning;
 
 /**
@@ -53,7 +55,10 @@
  */
 - (void)pretendExitStatusOf:(int)exitStatus;
 
+- (void)pretendTerminationReason:(NSTaskTerminationReason)reason;
+
 + (NSTask *)fakeTaskWithExitStatus:(int)exitStatus
+                 terminationReason:(NSTaskTerminationReason)reason
                 standardOutputPath:(NSString *)standardOutputPath
                  standardErrorPath:(NSString *)standardErrorPath;
 

--- a/xctool/xctool-tests/FakeTask.m
+++ b/xctool/xctool-tests/FakeTask.m
@@ -24,10 +24,12 @@
 @implementation FakeTask
 
 + (NSTask *)fakeTaskWithExitStatus:(int)exitStatus
+                 terminationReason:(NSTaskTerminationReason)pretendTerminationReason
                 standardOutputPath:(NSString *)standardOutputPath
                  standardErrorPath:(NSString *)standardErrorPath
 {
   FakeTask *task = [[[FakeTask alloc] init] autorelease];
+  [task pretendTerminationReason:pretendTerminationReason];
   [task pretendExitStatusOf:exitStatus];
   [task pretendTaskReturnsStandardOutput:
    [NSString stringWithContentsOfFile:standardOutputPath
@@ -43,6 +45,7 @@
 + (NSTask *)fakeTaskWithExitStatus:(int)exitStatus
 {
   return [self fakeTaskWithExitStatus:exitStatus
+                    terminationReason:NSTaskTerminationReasonExit
                    standardOutputPath:nil
                     standardErrorPath:nil];
 }
@@ -66,6 +69,16 @@
 - (void)pretendExitStatusOf:(int)exitStatus
 {
   _pretendExitStatus = exitStatus;
+}
+
+- (void)pretendTerminationReason:(NSTaskTerminationReason)reason
+{
+  _pretendTerminationReason = reason;
+}
+
+- (NSTaskTerminationReason)terminationReason
+{
+  return _pretendTerminationReason;
 }
 
 - (id)init

--- a/xctool/xctool-tests/TestData/TestsThatCrash/CrashOnStaticInitExit/CrashOnStaticInitExit-Prefix.pch
+++ b/xctool/xctool-tests/TestData/TestsThatCrash/CrashOnStaticInitExit/CrashOnStaticInitExit-Prefix.pch
@@ -1,0 +1,7 @@
+//
+// Prefix header for all source files of the 'CrashOnStaticInitExit' target in the 'CrashOnStaticInitExit' project
+//
+
+#ifdef __OBJC__
+  #import <Foundation/Foundation.h>
+#endif

--- a/xctool/xctool-tests/TestData/TestsThatCrash/CrashOnStaticInitExit/CrashOnStaticInitExit.h
+++ b/xctool/xctool-tests/TestData/TestsThatCrash/CrashOnStaticInitExit/CrashOnStaticInitExit.h
@@ -1,0 +1,21 @@
+//
+// Copyright 2013 Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface CrashOnStaticInitExit : NSObject
+
+@end

--- a/xctool/xctool-tests/TestData/TestsThatCrash/CrashOnStaticInitExit/CrashOnStaticInitExit.m
+++ b/xctool/xctool-tests/TestData/TestsThatCrash/CrashOnStaticInitExit/CrashOnStaticInitExit.m
@@ -1,0 +1,21 @@
+//
+// Copyright 2013 Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "CrashOnStaticInitExit.h"
+
+@implementation CrashOnStaticInitExit
+
+@end

--- a/xctool/xctool-tests/TestData/TestsThatCrash/CrashOnStaticInitExitTests/CrashOnStaticInitExitTests-Info.plist
+++ b/xctool/xctool-tests/TestData/TestsThatCrash/CrashOnStaticInitExitTests/CrashOnStaticInitExitTests-Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.facebook.${PRODUCT_NAME:rfc1034identifier}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/xctool/xctool-tests/TestData/TestsThatCrash/CrashOnStaticInitExitTests/CrashOnStaticInitExitTests.h
+++ b/xctool/xctool-tests/TestData/TestsThatCrash/CrashOnStaticInitExitTests/CrashOnStaticInitExitTests.h
@@ -1,0 +1,21 @@
+//
+// Copyright 2013 Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <SenTestingKit/SenTestingKit.h>
+
+@interface CrashOnStaticInitExitTests : SenTestCase
+
+@end

--- a/xctool/xctool-tests/TestData/TestsThatCrash/CrashOnStaticInitExitTests/CrashOnStaticInitExitTests.mm
+++ b/xctool/xctool-tests/TestData/TestsThatCrash/CrashOnStaticInitExitTests/CrashOnStaticInitExitTests.mm
@@ -1,0 +1,42 @@
+//
+// Copyright 2013 Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "CrashOnStaticInitExitTests.h"
+
+struct CrashOnDestroy {
+  ~CrashOnDestroy() {
+    abort();
+  }
+};
+
+@implementation CrashOnStaticInitExitTests
+
+- (void)setUp
+{
+  [super setUp];
+}
+
+- (void)tearDown
+{
+  [super tearDown];
+}
+
+- (void)testExample
+{
+  static CrashOnDestroy timebomb;
+}
+
+@end

--- a/xctool/xctool-tests/TestData/TestsThatCrash/CrashOnStaticInitExitTests/en.lproj/InfoPlist.strings
+++ b/xctool/xctool-tests/TestData/TestsThatCrash/CrashOnStaticInitExitTests/en.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+/* Localized versions of Info.plist keys */
+

--- a/xctool/xctool-tests/TestData/TestsThatCrash/TestsThatCrash.xcodeproj/project.pbxproj
+++ b/xctool/xctool-tests/TestData/TestsThatCrash/TestsThatCrash.xcodeproj/project.pbxproj
@@ -16,6 +16,15 @@
 		28FFB02916FFC494000CCE2A /* libTestsThatCrash.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 28FFB01016FFC494000CCE2A /* libTestsThatCrash.a */; };
 		28FFB02F16FFC494000CCE2A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 28FFB02D16FFC494000CCE2A /* InfoPlist.strings */; };
 		28FFB03216FFC494000CCE2A /* TestsThatCrashTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 28FFB03116FFC494000CCE2A /* TestsThatCrashTests.m */; };
+		CD5D80A11762743100EF6428 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28FFB01316FFC494000CCE2A /* Foundation.framework */; };
+		CD5D80A61762743100EF6428 /* CrashOnStaticInitExit.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = CD5D80A51762743100EF6428 /* CrashOnStaticInitExit.h */; };
+		CD5D80A81762743100EF6428 /* CrashOnStaticInitExit.m in Sources */ = {isa = PBXBuildFile; fileRef = CD5D80A71762743100EF6428 /* CrashOnStaticInitExit.m */; };
+		CD5D80AF1762743100EF6428 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28FFB02216FFC494000CCE2A /* SenTestingKit.framework */; };
+		CD5D80B01762743100EF6428 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28FFB02416FFC494000CCE2A /* UIKit.framework */; };
+		CD5D80B11762743100EF6428 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28FFB01316FFC494000CCE2A /* Foundation.framework */; };
+		CD5D80B41762743100EF6428 /* libCrashOnStaticInitExit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CD5D80A01762743100EF6428 /* libCrashOnStaticInitExit.a */; };
+		CD5D80BA1762743100EF6428 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = CD5D80B81762743100EF6428 /* InfoPlist.strings */; };
+		CD5D80BD1762743100EF6428 /* CrashOnStaticInitExitTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = CD5D80BC1762743100EF6428 /* CrashOnStaticInitExitTests.mm */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -25,6 +34,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 28FFB00F16FFC494000CCE2A;
 			remoteInfo = TestsThatCrash;
+		};
+		CD5D80B21762743100EF6428 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 28FFB00816FFC494000CCE2A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CD5D809F1762743100EF6428;
+			remoteInfo = CrashOnStaticInitExit;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -36,6 +52,16 @@
 			dstSubfolderSpec = 16;
 			files = (
 				28FFB01916FFC494000CCE2A /* TestsThatCrash.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CD5D809E1762743100EF6428 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/${PRODUCT_NAME}";
+			dstSubfolderSpec = 16;
+			files = (
+				CD5D80A61762743100EF6428 /* CrashOnStaticInitExit.h in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -53,6 +79,15 @@
 		28FFB02C16FFC494000CCE2A /* TestsThatCrashTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "TestsThatCrashTests-Info.plist"; sourceTree = "<group>"; };
 		28FFB02E16FFC494000CCE2A /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		28FFB03116FFC494000CCE2A /* TestsThatCrashTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestsThatCrashTests.m; sourceTree = "<group>"; };
+		CD5D80A01762743100EF6428 /* libCrashOnStaticInitExit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libCrashOnStaticInitExit.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		CD5D80A41762743100EF6428 /* CrashOnStaticInitExit-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CrashOnStaticInitExit-Prefix.pch"; sourceTree = "<group>"; };
+		CD5D80A51762743100EF6428 /* CrashOnStaticInitExit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CrashOnStaticInitExit.h; sourceTree = "<group>"; };
+		CD5D80A71762743100EF6428 /* CrashOnStaticInitExit.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CrashOnStaticInitExit.m; sourceTree = "<group>"; };
+		CD5D80AE1762743100EF6428 /* CrashOnStaticInitExitTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CrashOnStaticInitExitTests.octest; sourceTree = BUILT_PRODUCTS_DIR; };
+		CD5D80B71762743100EF6428 /* CrashOnStaticInitExitTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "CrashOnStaticInitExitTests-Info.plist"; sourceTree = "<group>"; };
+		CD5D80B91762743100EF6428 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		CD5D80BB1762743100EF6428 /* CrashOnStaticInitExitTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CrashOnStaticInitExitTests.h; sourceTree = "<group>"; };
+		CD5D80BC1762743100EF6428 /* CrashOnStaticInitExitTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CrashOnStaticInitExitTests.mm; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -75,6 +110,25 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		CD5D809D1762743100EF6428 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CD5D80A11762743100EF6428 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CD5D80AA1762743100EF6428 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CD5D80AF1762743100EF6428 /* SenTestingKit.framework in Frameworks */,
+				CD5D80B01762743100EF6428 /* UIKit.framework in Frameworks */,
+				CD5D80B11762743100EF6428 /* Foundation.framework in Frameworks */,
+				CD5D80B41762743100EF6428 /* libCrashOnStaticInitExit.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -83,6 +137,8 @@
 			children = (
 				28FFB01516FFC494000CCE2A /* TestsThatCrash */,
 				28FFB02A16FFC494000CCE2A /* TestsThatCrashTests */,
+				CD5D80A21762743100EF6428 /* CrashOnStaticInitExit */,
+				CD5D80B51762743100EF6428 /* CrashOnStaticInitExitTests */,
 				28FFB01216FFC494000CCE2A /* Frameworks */,
 				28FFB01116FFC494000CCE2A /* Products */,
 			);
@@ -93,6 +149,8 @@
 			children = (
 				28FFB01016FFC494000CCE2A /* libTestsThatCrash.a */,
 				28FFB02116FFC494000CCE2A /* TestsThatCrashTests.octest */,
+				CD5D80A01762743100EF6428 /* libCrashOnStaticInitExit.a */,
+				CD5D80AE1762743100EF6428 /* CrashOnStaticInitExitTests.octest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -143,6 +201,43 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		CD5D80A21762743100EF6428 /* CrashOnStaticInitExit */ = {
+			isa = PBXGroup;
+			children = (
+				CD5D80A51762743100EF6428 /* CrashOnStaticInitExit.h */,
+				CD5D80A71762743100EF6428 /* CrashOnStaticInitExit.m */,
+				CD5D80A31762743100EF6428 /* Supporting Files */,
+			);
+			path = CrashOnStaticInitExit;
+			sourceTree = "<group>";
+		};
+		CD5D80A31762743100EF6428 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				CD5D80A41762743100EF6428 /* CrashOnStaticInitExit-Prefix.pch */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		CD5D80B51762743100EF6428 /* CrashOnStaticInitExitTests */ = {
+			isa = PBXGroup;
+			children = (
+				CD5D80BB1762743100EF6428 /* CrashOnStaticInitExitTests.h */,
+				CD5D80BC1762743100EF6428 /* CrashOnStaticInitExitTests.mm */,
+				CD5D80B61762743100EF6428 /* Supporting Files */,
+			);
+			path = CrashOnStaticInitExitTests;
+			sourceTree = "<group>";
+		};
+		CD5D80B61762743100EF6428 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				CD5D80B71762743100EF6428 /* CrashOnStaticInitExitTests-Info.plist */,
+				CD5D80B81762743100EF6428 /* InfoPlist.strings */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -182,6 +277,42 @@
 			productReference = 28FFB02116FFC494000CCE2A /* TestsThatCrashTests.octest */;
 			productType = "com.apple.product-type.bundle";
 		};
+		CD5D809F1762743100EF6428 /* CrashOnStaticInitExit */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CD5D80C21762743100EF6428 /* Build configuration list for PBXNativeTarget "CrashOnStaticInitExit" */;
+			buildPhases = (
+				CD5D809C1762743100EF6428 /* Sources */,
+				CD5D809D1762743100EF6428 /* Frameworks */,
+				CD5D809E1762743100EF6428 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CrashOnStaticInitExit;
+			productName = CrashOnStaticInitExit;
+			productReference = CD5D80A01762743100EF6428 /* libCrashOnStaticInitExit.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		CD5D80AD1762743100EF6428 /* CrashOnStaticInitExitTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CD5D80C31762743100EF6428 /* Build configuration list for PBXNativeTarget "CrashOnStaticInitExitTests" */;
+			buildPhases = (
+				CD5D80A91762743100EF6428 /* Sources */,
+				CD5D80AA1762743100EF6428 /* Frameworks */,
+				CD5D80AB1762743100EF6428 /* Resources */,
+				CD5D80AC1762743100EF6428 /* ShellScript */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CD5D80B31762743100EF6428 /* PBXTargetDependency */,
+			);
+			name = CrashOnStaticInitExitTests;
+			productName = CrashOnStaticInitExitTests;
+			productReference = CD5D80AE1762743100EF6428 /* CrashOnStaticInitExitTests.octest */;
+			productType = "com.apple.product-type.bundle";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -205,6 +336,8 @@
 			targets = (
 				28FFB00F16FFC494000CCE2A /* TestsThatCrash */,
 				28FFB02016FFC494000CCE2A /* TestsThatCrashTests */,
+				CD5D809F1762743100EF6428 /* CrashOnStaticInitExit */,
+				CD5D80AD1762743100EF6428 /* CrashOnStaticInitExitTests */,
 			);
 		};
 /* End PBXProject section */
@@ -218,10 +351,31 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		CD5D80AB1762743100EF6428 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CD5D80BA1762743100EF6428 /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
 		28FFB01F16FFC494000CCE2A /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"\n";
+		};
+		CD5D80AC1762743100EF6428 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -253,6 +407,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		CD5D809C1762743100EF6428 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CD5D80A81762743100EF6428 /* CrashOnStaticInitExit.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CD5D80A91762743100EF6428 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CD5D80BD1762743100EF6428 /* CrashOnStaticInitExitTests.mm in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -261,6 +431,11 @@
 			target = 28FFB00F16FFC494000CCE2A /* TestsThatCrash */;
 			targetProxy = 28FFB02716FFC494000CCE2A /* PBXContainerItemProxy */;
 		};
+		CD5D80B31762743100EF6428 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CD5D809F1762743100EF6428 /* CrashOnStaticInitExit */;
+			targetProxy = CD5D80B21762743100EF6428 /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
@@ -268,6 +443,14 @@
 			isa = PBXVariantGroup;
 			children = (
 				28FFB02E16FFC494000CCE2A /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		CD5D80B81762743100EF6428 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				CD5D80B91762743100EF6428 /* en */,
 			);
 			name = InfoPlist.strings;
 			sourceTree = "<group>";
@@ -379,6 +562,64 @@
 			};
 			name = Release;
 		};
+		CD5D80BE1762743100EF6428 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				DSTROOT = /tmp/CrashOnStaticInitExit.dst;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "CrashOnStaticInitExit/CrashOnStaticInitExit-Prefix.pch";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		CD5D80BF1762743100EF6428 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				DSTROOT = /tmp/CrashOnStaticInitExit.dst;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "CrashOnStaticInitExit/CrashOnStaticInitExit-Prefix.pch";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		CD5D80C01762743100EF6428 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"\"$(SDKROOT)/Developer/Library/Frameworks\"",
+					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "CrashOnStaticInitExit/CrashOnStaticInitExit-Prefix.pch";
+				INFOPLIST_FILE = "CrashOnStaticInitExitTests/CrashOnStaticInitExitTests-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = octest;
+			};
+			name = Debug;
+		};
+		CD5D80C11762743100EF6428 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_ARC = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"\"$(SDKROOT)/Developer/Library/Frameworks\"",
+					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "CrashOnStaticInitExit/CrashOnStaticInitExit-Prefix.pch";
+				INFOPLIST_FILE = "CrashOnStaticInitExitTests/CrashOnStaticInitExitTests-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = octest;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -398,12 +639,30 @@
 				28FFB03716FFC494000CCE2A /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		28FFB03816FFC494000CCE2A /* Build configuration list for PBXNativeTarget "TestsThatCrashTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				28FFB03916FFC494000CCE2A /* Debug */,
 				28FFB03A16FFC494000CCE2A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CD5D80C21762743100EF6428 /* Build configuration list for PBXNativeTarget "CrashOnStaticInitExit" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CD5D80BE1762743100EF6428 /* Debug */,
+				CD5D80BF1762743100EF6428 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		CD5D80C31762743100EF6428 /* Build configuration list for PBXNativeTarget "CrashOnStaticInitExitTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CD5D80C01762743100EF6428 /* Debug */,
+				CD5D80C11762743100EF6428 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 		};

--- a/xctool/xctool/OCUnitIOSAppTestRunner.m
+++ b/xctool/xctool/OCUnitIOSAppTestRunner.m
@@ -209,8 +209,12 @@ static void KillSimulatorJobs()
   return [exitMode[@"via"] isEqualToString:@"exit"] && ([exitMode[@"status"] intValue] == 0);
 }
 
-- (BOOL)runTestsAndFeedOutputTo:(void (^)(NSString *))outputLineBlock error:(NSString **)error
+- (BOOL)runTestsAndFeedOutputTo:(void (^)(NSString *))outputLineBlock
+              gotUncaughtSignal:(BOOL *)gotUncaughtSignal
+                          error:(NSString **)error
 {
+  *gotUncaughtSignal = NO; // no equivalent for simulator
+
   NSString *sdkName = _buildSettings[@"SDK_NAME"];
   NSAssert([sdkName hasPrefix:@"iphonesimulator"], @"Unexpected SDK: %@", sdkName);
 

--- a/xctool/xctool/OCUnitIOSLogicTestRunner.m
+++ b/xctool/xctool/OCUnitIOSLogicTestRunner.m
@@ -49,7 +49,9 @@
   return task;
 }
 
-- (BOOL)runTestsAndFeedOutputTo:(void (^)(NSString *))outputLineBlock error:(NSString **)error
+- (BOOL)runTestsAndFeedOutputTo:(void (^)(NSString *))outputLineBlock
+              gotUncaughtSignal:(BOOL *)gotUncaughtSignal
+                          error:(NSString **)error
 {
   NSString *sdkName = _buildSettings[@"SDK_NAME"];
   NSAssert([sdkName hasPrefix:@"iphonesimulator"], @"Unexpected SDK name: %@", sdkName);
@@ -67,9 +69,11 @@
 
     LaunchTaskAndFeedOuputLinesToBlock(task, outputLineBlock);
 
+    *gotUncaughtSignal = task.terminationReason == NSTaskTerminationReasonUncaughtSignal;
     return [task terminationStatus] == 0 ? YES : NO;
   } else {
     *error = [NSString stringWithFormat:@"Test bundle not found at: %@", testBundlePath];
+    *gotUncaughtSignal = NO;
     return NO;
   }
 }

--- a/xctool/xctool/OCUnitOSXAppTestRunner.m
+++ b/xctool/xctool/OCUnitOSXAppTestRunner.m
@@ -23,7 +23,9 @@
 
 @implementation OCUnitOSXAppTestRunner
 
-- (BOOL)runTestsAndFeedOutputTo:(void (^)(NSString *))outputLineBlock error:(NSString **)error
+- (BOOL)runTestsAndFeedOutputTo:(void (^)(NSString *))outputLineBlock
+              gotUncaughtSignal:(BOOL *)gotUncaughtSignal
+                          error:(NSString **)error
 {
   NSString *sdkName = _buildSettings[@"SDK_NAME"];
   NSAssert([sdkName hasPrefix:@"macosx"], @"Unexpected SDK: %@", sdkName);
@@ -50,6 +52,7 @@
 
   LaunchTaskAndFeedOuputLinesToBlock(task, outputLineBlock);
 
+  *gotUncaughtSignal = task.terminationReason == NSTaskTerminationReasonUncaughtSignal;
   return [task terminationStatus] == 0;
 }
 

--- a/xctool/xctool/OCUnitOSXLogicTestRunner.m
+++ b/xctool/xctool/OCUnitOSXLogicTestRunner.m
@@ -44,7 +44,9 @@
   return task;
 }
 
-- (BOOL)runTestsAndFeedOutputTo:(void (^)(NSString *))outputLineBlock error:(NSString **)error
+- (BOOL)runTestsAndFeedOutputTo:(void (^)(NSString *))outputLineBlock
+              gotUncaughtSignal:(BOOL*)gotUncaughtSignal
+                          error:(NSString **)error
 {
   NSAssert([_buildSettings[@"SDK_NAME"] hasPrefix:@"macosx"], @"Should be a macosx SDK.");
 
@@ -61,9 +63,11 @@
 
     LaunchTaskAndFeedOuputLinesToBlock(task, outputLineBlock);
 
+    *gotUncaughtSignal = task.terminationReason == NSTaskTerminationReasonUncaughtSignal;
     return [task terminationStatus] == 0 ? YES : NO;
   } else {
     *error = [NSString stringWithFormat:@"Test bundle not found at: %@", testBundlePath];
+    *gotUncaughtSignal = NO;
     return NO;
   }
 }

--- a/xctool/xctool/OCUnitTestRunner.m
+++ b/xctool/xctool/OCUnitTestRunner.m
@@ -62,7 +62,9 @@
   [super dealloc];
 }
 
-- (BOOL)runTestsAndFeedOutputTo:(void (^)(NSString *))outputLineBlock error:(NSString **)error
+- (BOOL)runTestsAndFeedOutputTo:(void (^)(NSString *))outputLineBlock
+              gotUncaughtSignal:(BOOL *)gotUncaughtSignal
+                          error:(NSString **)error
 {
   // Subclasses will override this method.
   return NO;
@@ -144,7 +146,10 @@
   NSSet *crashReportsAtStart = [NSSet setWithArray:[self collectCrashReportPaths]];
 
   NSString *runTestsError = nil;
-  BOOL succeeded = [self runTestsAndFeedOutputTo:feedOutputToBlock error:&runTestsError];
+  BOOL didTerminateWithUncaughtSignal = NO;
+  BOOL succeeded = [self runTestsAndFeedOutputTo:feedOutputToBlock
+                               gotUncaughtSignal:&didTerminateWithUncaughtSignal
+                                           error:&runTestsError];
 
   if (runTestsError) {
     *error = runTestsError;
@@ -170,7 +175,7 @@
     succeeded = YES;
   }
 
-  if ([crashFilter testRunWasUnfinished]) {
+  if ([crashFilter testRunWasUnfinished] || didTerminateWithUncaughtSignal) {
     // The test runner must have crashed.
 
     // Wait for a moment to see if a crash report shows up.


### PR DESCRIPTION
Currently crashes that happen outside a test suite (such as those happening when global c++ objects are destroyed) are ignored and run-tests will fail with no error reports. This fixes the issue by detecting that the task has crashed using `terminationReason`, and generating a dummy testsuite and test that reports it.

I have included a dummy project/test which illustrates this issue.

Test Plan:

Running xctool on the included test generates a dummy test that shows
the crash.

```
  xctool run-tests -only CrashOnStaticInitExitTests -project \
    xctool/xctool-tests/TestData/TestsThatCrash/TestsThatCrash.xcodeproj \
    -scheme TestsThatCrash -sdk iphonesimulator6.1 -arch i386
```
