### PR TITLE
don't call synchronizeFile if output goes to socket

### DIFF
--- a/xctool/xctool/Reporter.m
+++ b/xctool/xctool/Reporter.m
@@ -207,9 +207,9 @@ void ReportStatusMessageEnd(NSArray *reporters, ReporterMessageLevel level, NSSt
   struct stat fdstat = {0};
   NSAssert(fstat([_outputHandle fileDescriptor], &fdstat) == 0, @"fstat() failed: %s", strerror(errno));
 
-  // Don't call synchronizeFile for pipes - it's not supported.  All of the automated
+  // Don't call synchronizeFile for pipes or sockets - it's not supported.  All of the automated
   // tests pass around pipes, so it's important to have this check.
-  if (!S_ISFIFO(fdstat.st_mode)) {
+  if (!S_ISFIFO(fdstat.st_mode) && !S_ISSOCK(fdstat.st_mode)) {
     [_outputHandle synchronizeFile];
   }
 }


### PR DESCRIPTION
There are situations where stdout might be a socket and sockets don't support synchronizeFile. For example if you have the following nodejs script

``` JS
var sys = require('sys')
var exec = require('child_process').exec;
function puts(error, stdout, stderr) { sys.puts(stdout); sys.puts(stderr) }
exec("xctool.sh -workspace ... -scheme ... ...", puts);
```

You will get the following error:

```
** BUILD SUCCEEDED ** (3868 ms)

2013-06-13 21:48:54.416 xctool[33910:707] *** Terminating app due to uncaught exception 'NSFileHandleOperationException', reason: '*** -[NSConcreteFileHandle synchronizeFile]: Operation not supported'
*** First throw call stack:
(
    0   CoreFoundation                      0x00007fff9378db06 __exceptionPreprocess + 198
    1   libobjc.A.dylib                     0x00007fff8db163f0 objc_exception_throw + 43
    2   CoreFoundation                      0x00007fff9378d8dc +[NSException raise:format:] + 204
    3   xctool                              0x00000001046e4b1c -[Reporter close] + 273
    4   xctool                              0x00000001046e5973 -[TextReporter close] + 67
    5   CoreFoundation                      0x00007fff93789460 -[NSArray makeObjectsPerformSelector:] + 272
    6   xctool                              0x00000001046dfd70 -[XCTool run] + 2471
    7   xctool                              0x00000001046dede0 main + 244
    8   xctool                              0x00000001046dece4 start + 52
)
libc++abi.dylib: terminate called throwing an exception
/Users/frankfa/git/xctool//xctool.sh: line 54: 33910 Abort trap: 6           "$XCTOOL_DIR"/build/$REVISION/Products/Release/xctool "$@"
```

I have filed a corresponding issue against nodejs, where you can find more details:
https://github.com/joyent/node/issues/5689

I am forced to run xctool.sh from within nodejs (please don't ask why), so I hope this can be fixed upstream.
