### PR TITLE
Ignore instead error on nonexistent reporter

### DIFF
--- a/xctool/xctool-tests/OptionsTests.m
+++ b/xctool/xctool-tests/OptionsTests.m
@@ -216,14 +216,16 @@
 
 - (void)testReporterMustBeValid
 {
-  [[Options optionsFrom:@[
-    @"-reporter", @"pretty"
-    ]] assertReporterOptionsValidate];
+  Options *options = [Options optionsFrom:@[
+                      @"-reporter", @"pretty",
+                      @"-reporter", @"blah"
+                      ]];
 
-  [[Options optionsFrom:@[
-    @"-reporter", @"blah"
-    ]] assertReporterOptionsFailToValidateWithError:
-   @"No reporter with name 'blah' found."];
+  [options assertReporterOptionsValidate];
+
+  NSArray *reporters = [options reporters];
+  assertThatInteger([reporters count], equalToInteger(1));
+  assertThatBool(([reporters[0] isKindOfClass:[PrettyTextReporter class]]), equalToBool(YES));
 }
 
 - (void)testArgumentsFlowThroughToCommonXcodebuildArguments

--- a/xctool/xctool/Options.m
+++ b/xctool/xctool/Options.m
@@ -213,8 +213,7 @@
     Reporter *reporter = [Reporter reporterWithName:name outputPath:outputFile options:self];
 
     if (reporter == nil) {
-      *errorMessage = [NSString stringWithFormat:@"No reporter with name '%@' found.", name];
-      return NO;
+      continue;
     }
 
     [self.reporters addObject:reporter];


### PR DESCRIPTION
Consider running xctool with some automation and you want to change
a reporter. It can be quite some hassle if xctool fails whenever
the reporter is absent.

Ideally xctool should emit a warning about this, but there isn't an
elegant mechanism to do it at that stage.
