### PR TITLE
Added option -simulator for specifying which simulator to launch

### DIFF
--- a/xctool/xctool-tests/OCUnitTestRunnerTests.m
+++ b/xctool/xctool-tests/OCUnitTestRunnerTests.m
@@ -54,6 +54,7 @@
                                            garbageCollection:NO
                                               freshSimulator:NO
                                                 freshInstall:NO
+                                               simulatorType:nil
                                               standardOutput:[NSFileHandle fileHandleWithNullDevice]
                                                standardError:[NSFileHandle fileHandleWithNullDevice]
                                                    reporters:@[]] autorelease];
@@ -105,6 +106,7 @@
                                             garbageCollection:NO
                                                freshSimulator:NO
                                                  freshInstall:NO
+                                                simulatorType:nil
                                                standardOutput:[NSFileHandle fileHandleWithNullDevice]
                                                 standardError:[NSFileHandle fileHandleWithNullDevice]
                                                     reporters:@[]] autorelease];
@@ -157,6 +159,7 @@
                                            garbageCollection:NO
                                               freshSimulator:NO
                                                 freshInstall:NO
+                                               simulatorType:nil
                                               standardOutput:[NSFileHandle fileHandleWithNullDevice]
                                                standardError:[NSFileHandle fileHandleWithNullDevice]
                                                    reporters:@[]] autorelease];
@@ -209,6 +212,7 @@
                                          garbageCollection:NO
                                             freshSimulator:NO
                                               freshInstall:NO
+                                             simulatorType:nil
                                             standardOutput:[NSFileHandle fileHandleWithNullDevice]
                                              standardError:[NSFileHandle fileHandleWithNullDevice]
                                                  reporters:@[]] autorelease];
@@ -257,6 +261,7 @@
              garbageCollection:NO
              freshSimulator:NO
              freshInstall:NO
+             simulatorType:nil
              standardOutput:[NSFileHandle fileHandleWithNullDevice]
              standardError:[NSFileHandle fileHandleWithNullDevice]
              reporters:@[]] autorelease];

--- a/xctool/xctool/OCUnitIOSAppTestRunner.m
+++ b/xctool/xctool/OCUnitIOSAppTestRunner.m
@@ -101,8 +101,7 @@ static void KillSimulatorJobs()
 @implementation OCUnitIOSAppTestRunner
 
 - (NSNumber*)simulatedDeviceFamily {
-  NSString* selectedSimulator = _buildSettings[@"SIMULATOR"];
-  return [[selectedSimulator lowercaseString] isEqualToString:@"ipad"] ? @2 : @1;
+  return [[_simulatorType lowercaseString] isEqualToString:@"ipad"] ? @2 : @1;
 }
 
 - (DTiPhoneSimulatorSessionConfig *)sessionConfigForRunningTestsWithEnvironment:(NSDictionary *)environment

--- a/xctool/xctool/OCUnitTestRunner.h
+++ b/xctool/xctool/OCUnitTestRunner.h
@@ -26,6 +26,7 @@
   BOOL _garbageCollection;
   BOOL _freshSimulator;
   BOOL _freshInstall;
+  NSString* _simulatorType;
   NSFileHandle *_standardOutput;
   NSFileHandle *_standardError;
   NSArray *_reporters;
@@ -39,6 +40,7 @@
           garbageCollection:(BOOL)garbageCollection
              freshSimulator:(BOOL)freshSimulator
                freshInstall:(BOOL)freshInstall
+              simulatorType:(NSString*)simulatorType
              standardOutput:(NSFileHandle *)standardOutput
               standardError:(NSFileHandle *)standardError
                   reporters:(NSArray *)reporters;

--- a/xctool/xctool/OCUnitTestRunner.m
+++ b/xctool/xctool/OCUnitTestRunner.m
@@ -30,6 +30,7 @@
           garbageCollection:(BOOL)garbageCollection
              freshSimulator:(BOOL)freshSimulator
                freshInstall:(BOOL)freshInstall
+              simulatorType:(NSString *)simulatorType
              standardOutput:(NSFileHandle *)standardOutput
               standardError:(NSFileHandle *)standardError
                   reporters:(NSArray *)reporters
@@ -43,6 +44,7 @@
     _garbageCollection = garbageCollection;
     _freshSimulator = freshSimulator;
     _freshInstall = freshInstall;
+    _simulatorType = [simulatorType copy];
     _standardOutput = [standardOutput retain];
     _standardError = [standardError retain];
     _reporters = [reporters retain];
@@ -56,6 +58,7 @@
   [_senTestList release];
   [_arguments release];
   [_environment release];
+  [_simulatorType release];
   [_standardOutput release];
   [_standardError release];
   [_reporters release];

--- a/xctool/xctool/RunTestsAction.h
+++ b/xctool/xctool/RunTestsAction.h
@@ -23,6 +23,7 @@
 @property (nonatomic, assign) BOOL freshSimulator;
 @property (nonatomic, assign) BOOL freshInstall;
 @property (nonatomic, assign) BOOL parallelize;
+@property (nonatomic, copy) NSString* simulatorType;
 @property (nonatomic, retain) NSString *testSDK;
 @property (nonatomic, retain) NSMutableArray *onlyList;
 

--- a/xctool/xctool/RunTestsAction.m
+++ b/xctool/xctool/RunTestsAction.m
@@ -141,6 +141,11 @@ static NSArray *chunkifyArray(NSArray *array, NSUInteger chunkSize) {
                      description:@"Parallelize test class execution within each target if > 0"
                        paramName:@"CHUNK_SIZE"
                            mapTo:@selector(setParallelizeChunkSize:)],
+    [Action actionOptionWithName:@"simulator"
+                         aliases:nil
+                     description:@"Set simulator type (either iphone or ipad)"
+                       paramName:@"SIMULATOR"
+                           mapTo:@selector(setSimulatorType:)],
     ];
 }
 
@@ -425,6 +430,7 @@ static NSArray *chunkifyArray(NSArray *array, NSUInteger chunkSize) {
                                      garbageCollection:garbageCollectionEnabled
                                      freshSimulator:self.freshSimulator
                                      freshInstall:self.freshInstall
+                                     simulatorType:self.simulatorType
                                      standardOutput:nil
                                      standardError:nil
                                      reporters:reportersForConfiguration] autorelease];
@@ -478,6 +484,7 @@ static NSArray *chunkifyArray(NSArray *array, NSUInteger chunkSize) {
             garbageCollection:garbageCollectionEnabled
             freshSimulator:self.freshSimulator
             freshInstall:self.freshInstall
+            simulatorType:self.simulatorType
             standardOutput:nil
             standardError:nil
             reporters:bufferedReporters] autorelease];

--- a/xctool/xctool/TestAction.m
+++ b/xctool/xctool/TestAction.m
@@ -71,6 +71,11 @@
                      description:@"Parallelize test class execution within each target if > 0"
                        paramName:@"CHUNK_SIZE"
                            mapTo:@selector(setParallelizeChunkSize:)],
+    [Action actionOptionWithName:@"simulator"
+                         aliases:nil
+                     description:@"Set simulator type (either iphone or ipad)"
+                       paramName:@"SIMULATOR"
+                           mapTo:@selector(setSimulatorType:)],
     ];
 }
 
@@ -112,6 +117,11 @@
 - (void)setParallelizeChunkSize:(NSString *)chunkSize
 {
   [_runTestsAction setParallelizeChunkSize:chunkSize];
+}
+
+- (void)setSimulatorType:(NSString *)simulatorType
+{
+  [_runTestsAction setSimulatorType:simulatorType];
 }
 
 - (void)setSkipDependencies:(BOOL)skipDependencies


### PR DESCRIPTION
Either "iphone" or "ipad" are supported values. Defaults to "iphone" which is the old behavior.

This makes testing iPad-only apps via xctool possible.
