### PR TITLE
fix sporatic hanging in run-tests with parallelization

### DIFF
--- a/xctool/xctool/OCUnitOSXAppTestRunner.m
+++ b/xctool/xctool/OCUnitOSXAppTestRunner.m
@@ -36,7 +36,7 @@
                          [XcodeDeveloperDirPath() stringByAppendingPathComponent:@"Library/PrivateFrameworks/IDEBundleInjection.framework/IDEBundleInjection"],
                          ];
 
-  NSTask *task = [[[NSTask alloc] init] autorelease];
+  NSTask *task = [[NSTask alloc] init];
   [task setLaunchPath:testHostPath];
   [task setArguments:[self otestArguments]];
   [task setEnvironment:[self otestEnvironmentWithOverrides:@{
@@ -55,7 +55,9 @@
   LaunchTaskAndFeedOuputLinesToBlock(task, outputLineBlock);
 
   *gotUncaughtSignal = task.terminationReason == NSTaskTerminationReasonUncaughtSignal;
-  return [task terminationStatus] == 0;
+  int terminationStatus = task.terminationStatus;
+  [task release];
+  return terminationStatus == 0;
 }
 
 @end

--- a/xctool/xctool/OCUnitOSXLogicTestRunner.m
+++ b/xctool/xctool/OCUnitOSXLogicTestRunner.m
@@ -59,14 +59,16 @@
   }
 
   if (bundleExists) {
-    NSTask *task = [self otestTaskWithTestBundle:testBundlePath];
-    // For OSX test bundles only, Xcode will chdir to the project's directory.
-    [task setCurrentDirectoryPath:_buildSettings[@"PROJECT_DIR"]];
+    @autoreleasepool {
+      NSTask *task = [self otestTaskWithTestBundle:testBundlePath];
+      // For OSX test bundles only, Xcode will chdir to the project's directory.
+      [task setCurrentDirectoryPath:_buildSettings[@"PROJECT_DIR"]];
 
-    LaunchTaskAndFeedOuputLinesToBlock(task, outputLineBlock);
+      LaunchTaskAndFeedOuputLinesToBlock(task, outputLineBlock);
 
-    *gotUncaughtSignal = task.terminationReason == NSTaskTerminationReasonUncaughtSignal;
-    return [task terminationStatus] == 0 ? YES : NO;
+      *gotUncaughtSignal = task.terminationReason == NSTaskTerminationReasonUncaughtSignal;
+      return [task terminationStatus] == 0 ? YES : NO;
+    }
   } else {
     *error = [NSString stringWithFormat:@"Test bundle not found at: %@", testBundlePath];
     *gotUncaughtSignal = NO;
@@ -76,11 +78,12 @@
 
 - (NSArray *)runTestClassListQuery
 {
-  NSTask *task = [[[NSTask alloc] init] autorelease];
+  NSTask *task = [[NSTask alloc] init];
   [task setLaunchPath:[PathToXCToolBinaries() stringByAppendingPathComponent:@"otest-query-osx"]];
   [task setArguments:@[self.testBundlePath]];
   [task setEnvironment:[self otestEnvironmentWithOverrides:self.environmentOverrides]];
   NSDictionary *output = LaunchTaskAndCaptureOutput(task);
+  [task release];
   NSData *outputData = [output[@"stdout"] dataUsingEncoding:NSUTF8StringEncoding];
   return [NSJSONSerialization JSONObjectWithData:outputData options:0 error:nil];
 }

--- a/xctool/xctool/RunTestsAction.m
+++ b/xctool/xctool/RunTestsAction.m
@@ -322,7 +322,7 @@ static NSArray *chunkifyArray(NSArray *array, NSUInteger chunkSize) {
   NSString *testableTarget = testable[@"target"];
 
   // Collect build settings for this test target.
-  NSTask *settingsTask = [[[NSTask alloc] init] autorelease];
+  NSTask *settingsTask = [[NSTask alloc] init];
   [settingsTask setLaunchPath:[XcodeDeveloperDirPath() stringByAppendingPathComponent:@"usr/bin/xcodebuild"]];
 
   if (_testSDK) {
@@ -346,6 +346,8 @@ static NSArray *chunkifyArray(NSArray *array, NSUInteger chunkSize) {
                                  }];
 
   NSDictionary *result = LaunchTaskAndCaptureOutput(settingsTask);
+  [settingsTask release];
+  settingsTask = nil;
 
   NSDictionary *allSettings = BuildSettingsFromOutput(result[@"stdout"]);
   NSAssert([allSettings count] == 1,

--- a/xctool/xctool/TaskUtil.m
+++ b/xctool/xctool/TaskUtil.m
@@ -50,13 +50,16 @@ NSDictionary *LaunchTaskAndCaptureOutput(NSTask *task)
                                                                         object:stderrHandle
                                                                          queue:nil
                                                                     usingBlock:completionBlock];
-  [stdoutHandle readToEndOfFileInBackgroundAndNotify];
-  [stderrHandle readToEndOfFileInBackgroundAndNotify];
-  [task setStandardOutput:stdoutPipe];
-  [task setStandardError:stderrPipe];
 
-  [task launch];
-  [task waitUntilExit];
+  CFRunLoopPerformBlock(CFRunLoopGetCurrent(), kCFRunLoopDefaultMode, ^{
+    [stdoutHandle readToEndOfFileInBackgroundAndNotify];
+    [stderrHandle readToEndOfFileInBackgroundAndNotify];
+    [task setStandardOutput:stdoutPipe];
+    [task setStandardError:stderrPipe];
+
+    [task launch];
+    [task waitUntilExit];
+  });
 
   while (standardOutput == nil || standardError == nil) {
     CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, YES);

--- a/xctool/xctool/XCTool.m
+++ b/xctool/xctool/XCTool.m
@@ -160,7 +160,7 @@
   }
 
   if (options.showBuildSettings) {
-    NSTask *task = [[[NSTask alloc] init] autorelease];
+    NSTask *task = [[NSTask alloc] init];
     [task setLaunchPath:[XcodeDeveloperDirPath() stringByAppendingPathComponent:@"usr/bin/xcodebuild"]];
     [task setArguments:[[[options xcodeBuildArgumentsForSubject]
                          arrayByAddingObjectsFromArray:[options commonXcodeBuildArgumentsForSchemeAction:nil xcodeSubjectInfo:nil]]
@@ -170,6 +170,7 @@
     [task launch];
     [task waitUntilExit];
     _exitStatus = [task terminationStatus];
+    [task release];
     return;
   }
 

--- a/xctool/xctool/XCToolUtil.m
+++ b/xctool/xctool/XCToolUtil.m
@@ -113,7 +113,7 @@ NSString *PathToXCToolBinaries(void)
 NSString *XcodeDeveloperDirPath(void)
 {
   NSString *(^getPath)() = ^{
-    NSTask *task = [[[NSTask alloc] init] autorelease];
+    NSTask *task = [[NSTask alloc] init];
     [task setLaunchPath:@"/usr/bin/xcode-select"];
     [task setArguments:@[@"--print-path"]];
     [task setEnvironment:@{}];
@@ -122,6 +122,7 @@ NSString *XcodeDeveloperDirPath(void)
     path = [path stringByTrimmingCharactersInSet:
             [NSCharacterSet newlineCharacterSet]];
 
+    [task release];
     return path;
   };
 
@@ -163,7 +164,7 @@ NSDictionary *GetAvailableSDKsAndAliases()
     //   "iphonesimulator 5.0"
     //
     // xcodebuild is nice enough to return them to us in ascending order.
-    NSTask *task = [[[NSTask alloc] init] autorelease];
+    NSTask *task = [[NSTask alloc] init];
     [task setLaunchPath:@"/bin/bash"];
     [task setArguments:@[
      @"-c",
@@ -188,6 +189,7 @@ NSDictionary *GetAvailableSDKsAndAliases()
       result[sdkName] = sdk;
     }
 
+    [task release];
     return result;
   };
 
@@ -270,7 +272,7 @@ BOOL RunXcodebuildAndFeedEventsToReporters(NSArray *arguments,
                                            NSString *title,
                                            NSArray *reporters)
 {
-  NSTask *task = [[[NSTask alloc] init] autorelease];
+  NSTask *task = [[NSTask alloc] init];
   [task setLaunchPath:[XcodeDeveloperDirPath() stringByAppendingPathComponent:@"usr/bin/xcodebuild"]];
   [task setArguments:arguments];
   NSMutableDictionary *environment =
@@ -323,6 +325,7 @@ BOOL RunXcodebuildAndFeedEventsToReporters(NSArray *arguments,
   [reporters makeObjectsPerformSelector:@selector(handleEvent:)
                              withObject:endEvent];
 
+  [task release];
   return succeeded;
 }
 

--- a/xctool/xctool/XcodeSubjectInfo.m
+++ b/xctool/xctool/XcodeSubjectInfo.m
@@ -748,7 +748,7 @@ containsFilesModifiedSince:(NSDate *)sinceDate
 
 - (NSDictionary *)buildSettingsForFirstBuildable
 {
-  NSTask *task = [[[NSTask alloc] init] autorelease];
+  NSTask *task = [[NSTask alloc] init];
   [task setLaunchPath:
    [XcodeDeveloperDirPath() stringByAppendingPathComponent:
     @"usr/bin/xcodebuild"]];
@@ -762,6 +762,7 @@ containsFilesModifiedSince:(NSDate *)sinceDate
    }];
 
   NSDictionary *result = LaunchTaskAndCaptureOutput(task);
+  [task release];
   return BuildSettingsFromOutput(result[@"stdout"]);
 }
 


### PR DESCRIPTION
NSTask registers some mach ports with the current run loop on launch but
does not remove them until finalize. Sometimes the run loop will try to
read from these ports for reasons beyond my comprehension even after the
task exited, and hang there ad infinitum.

Here I change all NSTask uses to release as soon as possible. This seems
to resolve the issue (1/3 chance to < 1/20 chance in some tests I ran).

Also wrapped `readTillEndOfFileInBackgroundAndNotify` calls to inside
the runloop, per documentation.
