### PR TITLE
Add source context to exceptions and analyzer warnings

### DIFF
--- a/xctool/xctool-tests/TestData/ContextTest.m
+++ b/xctool/xctool-tests/TestData/ContextTest.m
@@ -1,0 +1,20 @@
+//
+//  ContextTest.m
+//
+//  Created on 7/22/13.
+//
+//
+
+#import "ContextTest.h"
+
+@implementation ContextTest
+
+static int test() {
+  NSObject *blah = [[NSObject alloc] init];
+}
+
+static int test2() {
+  NSObject *blah = [[NSObject alloc] init];        
+}
+
+@end

--- a/xctool/xctool-tests/TextReporterTests.m
+++ b/xctool/xctool-tests/TextReporterTests.m
@@ -99,4 +99,30 @@
                      @"\n"));
 }
 
+- (void) testContextString
+{
+  NSString *testDataPath = TEST_DATA @"ContextTest.m";
+  NSString *context = [TextReporter getContext:testDataPath errorLine:13 colNumber:38];
+  NSString *refString = @"10 @implementation ContextTest\n11 \n12 static int test() {\n13   NSObject *blah = [[NSObject alloc] init];\n     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~\n14 }\n15 ";
+  assertThat(context, equalTo(refString));
+}
+
+- (void) testContextStringUnderlineWithTrailingWhitespace
+{
+  NSString *testDataPath = TEST_DATA @"ContextTest.m";
+  NSString *context = [TextReporter getContext:testDataPath errorLine:17 colNumber:38];
+  NSRange range = [context rangeOfCharacterFromSet:([NSCharacterSet characterSetWithCharactersInString:@"~^"])];
+  range.length = [context rangeOfCharacterFromSet:[NSCharacterSet characterSetWithCharactersInString:@"~^"] options:NSBackwardsSearch].location - range.location + 1;
+  NSString *substr = [context substringWithRange:range];
+  NSString *refSubstr = @"~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~";
+  assertThat(substr, equalTo(refSubstr));
+}
+
+- (void) testContextStringErrorLoadingFileReturnsNil
+{
+  NSString *testDataPath = nil;
+  NSString *context = [TextReporter getContext:testDataPath errorLine:14 colNumber:39];
+  assertThat(context, equalTo(nil));
+}
+
 @end

--- a/xctool/xctool/TextReporter.h
+++ b/xctool/xctool/TextReporter.h
@@ -39,6 +39,16 @@
 @property (nonatomic, retain) NSString *currentBundle;
 @property (nonatomic, retain) NSMutableArray *analyzerWarnings;
 
+/**
+ Returns an NSString that contains lines of context around errorLine with a mark at colNumber.
+ */
++ (NSString *)getContext:(NSString *)filePath errorLine:(int)errorLine colNumber:(int)colNumber;
+
+/**
+ Returns an NSString that contains lines of context around errorLine.
+ */
++ (NSString *)getContext:(NSString *)filePath errorLine:(int)errorLine;
+
 @end
 
 @interface PrettyTextReporter : TextReporter

--- a/xctool/xctool/TextReporter.m
+++ b/xctool/xctool/TextReporter.m
@@ -277,7 +277,7 @@ static NSString *abbreviatePath(NSString *string) {
 
     [self.analyzerWarnings enumerateObjectsUsingBlock:
      ^(NSDictionary *event, NSUInteger idx, BOOL *stop) {
-       [self.reportWriter printLine:@"%lu) %@:%@:%@: %@",
+       [self.reportWriter printLine:@"%lu) %@:%@:%@: %@:",
         (unsigned long)idx,
         abbreviatePath(event[kReporter_AnalyzerResult_FileKey]),
         event[kReporter_AnalyzerResult_LineKey],
@@ -286,6 +286,10 @@ static NSString *abbreviatePath(NSString *string) {
 
        [self printDivider];
        [self.reportWriter disableIndent];
+       [self.reportWriter printLine:@"%@", [TextReporter getContext:event[kReporter_AnalyzerResult_FileKey]
+                                                          errorLine:[event[kReporter_AnalyzerResult_LineKey] intValue]
+                                                          colNumber:[event[kReporter_AnalyzerResult_ColumnKey] intValue]]];
+       [self.reportWriter printNewline];
        for (NSDictionary *piece in event[kReporter_AnalyzerResult_ContextKey]) {
          [self.reportWriter printLine:@"%@:%@:%@: %@",
           abbreviatePath(piece[@"file"]), piece[@"line"], piece[@"col"], piece[@"message"]];
@@ -383,6 +387,8 @@ static NSString *abbreviatePath(NSString *string) {
            [exception[kReporter_EndTest_Exception_LineNumberKey] intValue],
            exception[kReporter_EndTest_Exception_NameKey],
            exception[kReporter_EndTest_Exception_ReasonKey]];
+          [self.reportWriter printLine:@"%@", [TextReporter getContext:exception[kReporter_EndTest_Exception_FilePathInProjectKey]
+                                                             errorLine:[exception[kReporter_EndTest_Exception_LineNumberKey] intValue]]];
           [self.reportWriter enableIndent];
         }
 
@@ -680,11 +686,13 @@ static NSString *abbreviatePath(NSString *string) {
     // Show exception, if any.
     NSDictionary *exception = event[kReporter_EndTest_ExceptionKey];
     if (exception) {
-      [self.reportWriter printLine:@"<faint>%@:%d: %@: %@<reset>",
+      [self.reportWriter printLine:@"<faint>%@:%d: %@: %@:<reset>",
        exception[kReporter_EndTest_Exception_FilePathInProjectKey],
        [exception[kReporter_EndTest_Exception_LineNumberKey] intValue],
        exception[kReporter_EndTest_Exception_NameKey],
        exception[kReporter_EndTest_Exception_ReasonKey]];
+      [self.reportWriter printLine:@"%@", [TextReporter getContext:exception[kReporter_EndTest_Exception_FilePathInProjectKey]
+                                                         errorLine:[exception[kReporter_EndTest_Exception_LineNumberKey] intValue]]];
     }
 
     [self.reportWriter enableIndent];
@@ -714,10 +722,67 @@ static NSString *abbreviatePath(NSString *string) {
   }
 }
 
-
 - (void)analyzerResult:(NSDictionary *)event
 {
   [self.analyzerWarnings addObject:event];
+}
+
++ (NSString *)getContext:(NSString *)filePath errorLine:(int)errorLine colNumber:(int)colNumber
+{
+  BOOL isDirectory = NO;
+  BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:filePath isDirectory:&isDirectory];
+  if (fileExists && !isDirectory) {
+    NSError *error = nil;
+    NSString *fileContents = [NSString stringWithContentsOfFile:filePath
+                                                       encoding:NSUTF8StringEncoding
+                                                          error:&error];
+    if (error) {
+      NSLog(@"Error loading file %@: %@", filePath, [error localizedFailureReason]);
+      return nil;
+    } else {
+      NSMutableString *context = [NSMutableString string];
+      NSArray *lines = [fileContents componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
+      int start = MAX(0, errorLine - 4);
+      int end = MIN((int)[lines count], errorLine + 2);
+      // Give all line numbers the same width even if they roll over to a new power of 10.
+      int lineNoLength = floor(log10(end)) + 1;
+      NSString *formatString = [NSString stringWithFormat:@"%@%d%@", @"%", lineNoLength, @"d %@"];
+      for (int lineNo = start; lineNo < end; lineNo++) {
+        NSString *lineStr = [[lines objectAtIndex:lineNo] description];
+        // Careful: Line numbers start at 1 but array indices start at 0.
+        [context appendFormat:formatString, lineNo + 1, lineStr];
+        if (lineNo + 1 == errorLine) {
+          // Leading whitespace for underline so it's under the text only.
+          int nonWhitespaceLoc = (int)[lineStr rangeOfCharacterFromSet:[[NSCharacterSet whitespaceCharacterSet] invertedSet]].location;
+          NSString *trimmedLineStr = [lineStr stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+          int whitespaceLength = lineNoLength + 1 + nonWhitespaceLoc;
+          NSMutableString *ulineStr = [NSMutableString stringWithString:[[[NSString string]
+                                                                          stringByPaddingToLength:whitespaceLength
+                                                                          withString:@" "
+                                                                          startingAtIndex:0]
+                                                                         stringByPaddingToLength:[trimmedLineStr length] +whitespaceLength
+                                                                         withString:@"~"
+                                                                         startingAtIndex:0]];
+          if (colNumber > 0 && colNumber <= [lineStr length]) {
+            [ulineStr replaceCharactersInRange:NSMakeRange(lineNoLength + colNumber, 1) withString:@"^"];
+          }
+          [context appendFormat:@"\n%@", ulineStr];
+        }
+        if (lineNo + 1 < end) {
+          [context appendString:@"\n"];
+        }
+      }
+      return context;
+    }
+  } else {
+    NSLog(@"ERROR: couldn't load file: %@\n", filePath);
+    return nil;
+  }
+}
+
++ (NSString *)getContext:(NSString *)filePath errorLine:(int)errorLine
+{
+  return [TextReporter getContext:filePath errorLine:errorLine colNumber:0];
 }
 
 @end


### PR DESCRIPTION
Added context for exceptions and analyzer warnings.  A few comments/questions:
- The analyzer already shows a single line of context at build time.  Is that from clang?  Sure would be nice if I could just swipe what it's doing.
- On a similar note, if the code on disk is modified from the code that was built and is being run, then the context will be incorrect.  Do we have access to source code as it was during the build?
- Exceptions appear twice, once during the run and once in a summary at the bottom.  I added context only during the run, but am happy to change that.
- The analyzer warnings have two parts, a summary at the top of each warning, and a (possibly multi-part) set of details that led to the problem.  I added context only for the summary because it was a bit overwhelming if it showed for all of the details.  But, the details are a lot more useful with the context.  So, happy to change this too.

Test Plan:
- Ran TestProject-Library with run-tests and verified output (screenshot attached)
- Modified test so that context crosses 2-digit to 3-digit line number boundary and verified output
- Modified test so that exception line has trailing whitespace and verified output
- Modified test to have a trailing comment and verified output -- the comment gets underlined.  Oh well?
- Added an analyzer warning and verified the output
- Modified test to contain only 2 lines of code and verified output
- Modified test to contain a really long line of code and verified output.  The underline looks weird due to word wrap, but otherwise ok.
- Ran the analyzer on xctool. It claims there's a potential memory leak in TaskUtil.m :)  This also shows what the analyzer looks like with lots and lots of details (screenshot attached)

![run_tests](https://f.cloud.github.com/assets/2028444/828980/6c5f64f0-f0c3-11e2-9fbb-9f5a0785daf1.png)
![analyze_xctool](https://f.cloud.github.com/assets/2028444/828979/66bbceee-f0c3-11e2-9ae4-b9bf4d223a89.png)
