### PR TITLE
Suggest creating schemes if we detect none are present

### DIFF
--- a/xctool/xctool-tests/OptionsTests.m
+++ b/xctool/xctool-tests/OptionsTests.m
@@ -189,12 +189,7 @@
    assertOptionsFailToValidateWithError:
    @"Can't find scheme 'TestProject-Library-Bogus'.\n\n"
    @"Possible schemes include:\n"
-   @"  TestProject-Library\n\n"
-   @"TIP: This might happen if you're relying on Xcode to autocreate your schemes\n"
-   @"and your scheme files don't yet exist.  xctool, like xcodebuild, isn't able to\n"
-   @"automatically create schemes.  We recommend disabling \"Autocreate schemes\"\n"
-   @"in your workspace/project, making sure your existing schemes are marked as\n"
-   @"\"Shared\", and making sure they're checked into source control."
+   @"  TestProject-Library"
    withBuildSettingsFromFile:
    TEST_DATA @"TestWorkspace-Library-TestProject-Library-showBuildSettings.txt"];
 }

--- a/xctool/xctool/Options.m
+++ b/xctool/xctool/Options.m
@@ -393,8 +393,8 @@
   BOOL automaticSchemeCreationDisabled = NO;
   
   {
-    NSString *basePath = self.project != nil ? self.project : self.workspace;
-    NSString *settingsPath = [basePath stringByAppendingPathComponent:@"/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings"];
+    NSString *basePath = self.project != nil ? [self.project stringByAppendingPathComponent:@"project.xcworkspace"] : self.workspace;
+    NSString *settingsPath = [basePath stringByAppendingPathComponent:@"xcshareddata/WorkspaceSettings.xcsettings"];
     NSDictionary *settings = [NSDictionary dictionaryWithContentsOfFile:settingsPath];
     NSNumber *automaticSchemeCreationSetting = [settings objectForKey:@"IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded"];
     


### PR DESCRIPTION
If no user or shared schemes are present, show a helpful error message pointing to our documentation instead of showing an empty schemes list.
