### PR TITLE
Use NSXMLDocument in JUnitReporter to fix issues with unencoded chars

### DIFF
--- a/reporters/junit/JUnitReporter.m
+++ b/reporters/junit/JUnitReporter.m
@@ -17,10 +17,6 @@
 @property (nonatomic) int totalErrors;
 @property (nonatomic) float totalTime;
 
-- (void)write:(NSString *)string;
-- (void)writeWithFormat:(NSString *)format, ... NS_FORMAT_FUNCTION(1,2);
-- (NSString *)xmlEscape:(NSString *)string;
-
 @end
 
 #pragma mark Implementation
@@ -77,73 +73,69 @@
 
 - (void)didFinishReporting
 {
-  [self write:@"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"];
-  [self writeWithFormat:
-   @"<testsuites name=\"AllTestUnits\" tests=\"%d\" failures=\"%d\" errors=\"%d\" time=\"%f\">\n",
-   self.totalTests, self.totalFailures, self.totalErrors, self.totalTime];
+  NSXMLElement *testsuites = [[NSXMLElement alloc] initWithName:@"testsuites"];
+  [testsuites setAttributes:@[[NSXMLNode attributeWithName:@"name" stringValue:@"AllTestUnits"],
+                              [NSXMLNode attributeWithName:@"tests" stringValue:[NSString stringWithFormat:@"%d", self.totalTests]],
+                              [NSXMLNode attributeWithName:@"failures" stringValue:[NSString stringWithFormat:@"%d", self.totalFailures]],
+                              [NSXMLNode attributeWithName:@"errors" stringValue:[NSString stringWithFormat:@"%d", self.totalErrors]],
+                              [NSXMLNode attributeWithName:@"time" stringValue:[NSString stringWithFormat:@"%f", self.totalTime]]]];
 
   for (NSDictionary *testSuite in self.testSuites) {
     NSDictionary *suiteEvent = testSuite[kJUnitReporter_Suite_Event];
     NSArray *suiteResults = testSuite[kJUnitReporter_Suite_Results];
-    [self writeWithFormat:
-     @"\t<testsuite name=\"%@\" tests=\"%d\" failures=\"%d\" errors=\"%d\" "
-     @"time=\"%f\" timestamp=\"%@\">\n",
-     [self xmlEscape:suiteEvent[kReporter_EndTestSuite_SuiteKey]],
-     [suiteEvent[kReporter_EndTestSuite_TestCaseCountKey] intValue],
-     [suiteEvent[kReporter_EndTestSuite_TotalFailureCountKey] intValue],
-     [suiteEvent[kReporter_EndTestSuite_UnexpectedExceptionCountKey] intValue],
-     [suiteEvent[kReporter_EndTestSuite_TotalDurationKey] floatValue],
-     [self.formatter stringFromDate:[NSDate date]]];
+    NSXMLElement *testsuite = [[NSXMLElement alloc] initWithName:@"testsuite"];
+    NSArray *attributes = @[[NSXMLNode attributeWithName:@"tests" stringValue:[NSString stringWithFormat:@"%d", [suiteEvent[kReporter_EndTestSuite_TestCaseCountKey] intValue]]],
+                            [NSXMLNode attributeWithName:@"failures" stringValue:[NSString stringWithFormat:@"%d",[suiteEvent[kReporter_EndTestSuite_TotalFailureCountKey] intValue]]],
+                            [NSXMLNode attributeWithName:@"errors" stringValue:[NSString stringWithFormat:@"%d", [suiteEvent[kReporter_EndTestSuite_UnexpectedExceptionCountKey] intValue]]],
+                            [NSXMLNode attributeWithName:@"time" stringValue:[NSString stringWithFormat:@"%f", [suiteEvent[kReporter_EndTestSuite_TotalDurationKey] floatValue]]],
+                            [NSXMLNode attributeWithName:@"timestamp" stringValue:[self.formatter stringFromDate:[NSDate date]]],
+                            [NSXMLNode attributeWithName:@"name" stringValue:suiteEvent[kReporter_EndTestSuite_SuiteKey]]];
+    [testsuite setAttributes:attributes];
+    
     for (NSDictionary *testResult in suiteResults) {
-      [self writeWithFormat:
-       @"\t\t<testcase classname=\"%@\" name=\"%@\" time=\"%f\">\n",
-       [self xmlEscape:testResult[kReporter_EndTest_ClassNameKey]],
-       [self xmlEscape:testResult[kReporter_EndTest_MethodNameKey]],
-       [testResult[kReporter_EndTest_TotalDurationKey] floatValue]];
+      NSXMLElement *testcase = [[NSXMLElement alloc] initWithName:@"testcase"];
+      NSMutableDictionary *attributes = [[NSMutableDictionary alloc] initWithCapacity:3];
+      [testcase setAttributes:@[[NSXMLNode attributeWithName:@"classname" stringValue:testResult[kReporter_EndTest_ClassNameKey]],
+                                [NSXMLNode attributeWithName:@"name" stringValue:testResult[kReporter_EndTest_MethodNameKey]],
+                                [NSXMLNode attributeWithName:@"time" stringValue:[NSString stringWithFormat:@"%f", [testResult[kReporter_EndTest_TotalDurationKey] floatValue]]]]];
+      [attributes release];
 
       if (![testResult[kReporter_EndTest_SucceededKey] boolValue]) {
         NSDictionary *exception = testResult[kReporter_EndTest_ExceptionKey];
-        [self writeWithFormat:
-         @"\t\t\t<failure message=\"%@\" type=\"Failure\">%@:%d</failure>\n",
-         [self xmlEscape:exception[kReporter_EndTest_Exception_ReasonKey]],
-         [self xmlEscape:exception[kReporter_EndTest_Exception_FilePathInProjectKey]],
-         [exception[kReporter_EndTest_Exception_LineNumberKey] intValue]];
+        NSString *failureValue = [[NSString alloc] initWithFormat:@"%@:%d", exception[kReporter_EndTest_Exception_FilePathInProjectKey],
+                                  [exception[kReporter_EndTest_Exception_LineNumberKey] intValue]];
+        NSXMLElement *failure = [[NSXMLElement alloc] initWithName:@"failure" stringValue:failureValue];
+        [failure setAttributes:@[[NSXMLNode attributeWithName:@"type" stringValue:@"Failure"],
+                                 [NSXMLNode attributeWithName:@"message" stringValue:exception[kReporter_EndTest_Exception_ReasonKey]]]];
+        [testcase addChild:failure];
+        [failureValue release];
+        [failure release];
       }
+      
 
       NSString *output = testResult[kReporter_EndTest_OutputKey];
       if (output && output.length > 0) {
-        [self writeWithFormat:@"\t\t\t<system-out>%@</system-out>\n", [self xmlEscape:output]];
+        NSXMLElement *systemOutput = [[NSXMLElement alloc] initWithName:@"system-out" stringValue:output];
+        [testcase addChild:systemOutput];
+        [systemOutput release];
       }
-      [self write:@"\t\t</testcase>\n"];
+      [testsuite addChild:testcase];
+      
+      [testcase release];
     }
-    [self write:@"\t</testsuite>\n"];
+    [testsuites addChild:testsuite];
+    [testsuite release];
   }
-  [self write:@"</testsuites>\n"];
+  NSXMLDocument *doc = [[NSXMLDocument alloc] initWithRootElement:testsuites];
+  doc.version = @"1.0";
+  [doc setStandalone:YES];
+  doc.characterEncoding = @"UTF-8";
+  [_outputHandle writeData:[doc XMLDataWithOptions:NSXMLNodePrettyPrint]];
+  
+  [testsuites release];
+  [doc release];
+  
   self.testSuites = nil;
-}
-
-#pragma mark Private Methods
-- (void)write:(NSString *)string
-{
-  [_outputHandle writeData:[string dataUsingEncoding:NSUTF8StringEncoding]];
-}
-
-- (void)writeWithFormat:(NSString *)format, ...
-{
-  va_list args;
-  va_start(args, format);
-  NSString *msg = [[NSString alloc] initWithFormat:format arguments:args];
-  [self write:msg];
-  [msg release];
-  msg = nil;
-  va_end(args);
-}
-
-- (NSString *)xmlEscape:(NSString *)string
-{
-  NSAssert(string != nil, @"Should have non-nil string.");
-  NSString *xmlStr = (NSString *)CFXMLCreateStringByEscapingEntities(kCFAllocatorDefault, (CFStringRef)string, NULL);
-  return [xmlStr autorelease];
 }
 
 @end

--- a/reporters/reporters-tests/JUnitReporterTests.m
+++ b/reporters/reporters-tests/JUnitReporterTests.m
@@ -23,7 +23,7 @@
                               range:NSMakeRange(0, [xmlStr length])
                        withTemplate:@"time=\"\""];
   [timeRegex release];
-  timeRegex = [[NSRegularExpression alloc] initWithPattern:@"timestamp=\\\"[GMT:\\-0-9\\.]*\\\""
+  timeRegex = [[NSRegularExpression alloc] initWithPattern:@"timestamp=\\\"[GMT:\\-0-9\\.\\+]*\\\""
                                                                         options:0
                                                                           error:nil];
   [timeRegex replaceMatchesInString:xmlStr
@@ -33,15 +33,14 @@
   [timeRegex release];
   timeRegex = nil;
     STAssertEqualObjects(@"\
-<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n\
 <testsuites name=\"AllTestUnits\" tests=\"7\" failures=\"1\" errors=\"0\" time=\"\">\n\
-\t<testsuite name=\"OtherTests\" tests=\"1\" failures=\"0\" errors=\"0\" time=\"\" timestamp=\"\">\n\
-\t\t<testcase classname=\"OtherTests\" name=\"testSomething\" time=\"\">\n\
-\t\t</testcase>\n\
-\t</testsuite>\n\
-\t<testsuite name=\"SomeTests\" tests=\"6\" failures=\"1\" errors=\"0\" time=\"\" timestamp=\"\">\n\
-\t\t<testcase classname=\"SomeTests\" name=\"testBacktraceOutputIsCaptured\" time=\"\">\n\
-\t\t\t<system-out>0   TestProject-LibraryTests            0x016c9827 -[SomeTests testBacktraceOutputIsCaptured] + 103\n\
+    <testsuite tests=\"1\" failures=\"0\" errors=\"0\" time=\"\" timestamp=\"\" name=\"OtherTests\">\n\
+        <testcase classname=\"OtherTests\" name=\"testSomething\" time=\"\"></testcase>\n\
+    </testsuite>\n\
+    <testsuite tests=\"6\" failures=\"1\" errors=\"0\" time=\"\" timestamp=\"\" name=\"SomeTests\">\n\
+        <testcase classname=\"SomeTests\" name=\"testBacktraceOutputIsCaptured\" time=\"\">\n\
+            <system-out>0   TestProject-LibraryTests            0x016c9827 -[SomeTests testBacktraceOutputIsCaptured] + 103\n\
 1   CoreFoundation                      0x00a011bd __invoking___ + 29\n\
 2   CoreFoundation                      0x00a010d6 -[NSInvocation invoke] + 342\n\
 3   SenTestingKit                       0x20103ed1 -[SenTestCase invokeTest] + 219\n\
@@ -61,33 +60,32 @@
 17  otest                               0x00002001 otest + 4097\n\
 18  otest                               0x00001f71 otest + 3953\n\
 </system-out>\n\
-\t\t</testcase>\n\
-\t\t<testcase classname=\"SomeTests\" name=\"testOutputMerging\" time=\"\">\n\
-\t\t\t<system-out>stdout-line1\n\
+        </testcase>\n\
+        <testcase classname=\"SomeTests\" name=\"testOutputMerging\" time=\"\">\n\
+            <system-out>stdout-line1\n\
 stderr-line1\n\
 stdout-line2\n\
 stdout-line3\n\
 stderr-line2\n\
 stderr-line3\n\
 </system-out>\n\
-\t\t</testcase>\n\
-\t\t<testcase classname=\"SomeTests\" name=\"testPrintSDK\" time=\"\">\n\
-\t\t\t<system-out>2013-05-08 20:51:11.809 otest[88423:707] SDK: 6.1\n\
+        </testcase>\n\
+        <testcase classname=\"SomeTests\" name=\"testPrintSDK\" time=\"\">\n\
+            <system-out>2013-05-08 20:51:11.809 otest[88423:707] SDK: 6.1\n\
 </system-out>\n\
-\t\t</testcase>\n\
-\t\t<testcase classname=\"SomeTests\" name=\"testStream\" time=\"\">\n\
-\t\t\t<system-out>2013-05-08 20:51:11.809 otest[88423:707] &gt;&gt;&gt;&gt; i = 0\n\
-2013-05-08 20:51:12.060 otest[88423:707] &gt;&gt;&gt;&gt; i = 1\n\
-2013-05-08 20:51:12.312 otest[88423:707] &gt;&gt;&gt;&gt; i = 2\n\
+        </testcase>\n\
+        <testcase classname=\"SomeTests\" name=\"testStream\" time=\"\">\n\
+            <system-out>2013-05-08 20:51:11.809 otest[88423:707] >>>> i = 0\n\
+2013-05-08 20:51:12.060 otest[88423:707] >>>> i = 1\n\
+2013-05-08 20:51:12.312 otest[88423:707] >>>> i = 2\n\
 </system-out>\n\
-\t\t</testcase>\n\
-\t\t<testcase classname=\"SomeTests\" name=\"testWillFail\" time=\"\">\n\
-\t\t\t<failure message=\"&apos;a&apos; should be equal to &apos;b&apos; Strings aren&apos;t equal\" type=\"Failure\">/Users/fpotter/xctool/xctool/xctool-tests/TestData/TestProject-Library/TestProject-LibraryTests/SomeTests.m:40</failure>\n\
-\t\t</testcase>\n\
-\t\t<testcase classname=\"SomeTests\" name=\"testWillPass\" time=\"\">\n\
-\t\t</testcase>\n\
-\t</testsuite>\n\
-</testsuites>\n\
+        </testcase>\n\
+        <testcase classname=\"SomeTests\" name=\"testWillFail\" time=\"\">\n\
+            <failure type=\"Failure\" message=\"'a' should be equal to 'b' Strings aren't equal\">/Users/fpotter/xctool/xctool/xctool-tests/TestData/TestProject-Library/TestProject-LibraryTests/SomeTests.m:40</failure>\n\
+        </testcase>\n\
+        <testcase classname=\"SomeTests\" name=\"testWillPass\" time=\"\"></testcase>\n\
+    </testsuite>\n\
+</testsuites>\
 ", xmlStr, @"JUnit XML should match");
 }
 


### PR DESCRIPTION
We've had problems with the JUnitReporter which didn't encode some control characters within the system-out node and produced invalid xml. Using NSXMLDocument instead of plain strings should fix the issue.
