### PR TITLE
XCTool strip ANSI escape codes from test output.

### DIFF
--- a/otest-shim/otest-shim/otest-shim.m
+++ b/otest-shim/otest-shim/otest-shim.m
@@ -74,7 +74,7 @@ static dispatch_queue_t EventQueue()
 static NSString *StripAnsi(NSString *inputString)
 {
   NSRegularExpression *regex =
-    [NSRegularExpression regularExpressionWithPattern:@"\\e.(\\d{1,1};)??(\\d{1,2}[mHfABCDJhI])"
+    [NSRegularExpression regularExpressionWithPattern:@"\\e\\[(\\d;)??(\\d{1,2}[mHfABCDJhI])"
                                         options:0
                                           error:nil];
   NSString *outputString = [regex stringByReplacingMatchesInString:inputString


### PR DESCRIPTION
Added a function to strip ANSI escape codes from strings generated by test harnesses in order to ensure that JSON and XML formatted output does not cause problems for parsers.

The StripAnsi() function was added to otest-shim.m and has the ability to strip all ANSI
escape codes from output strings except for keyboard change codes, which are not relevant
to this scenario.

This change can be verified by performing the following test:
1.  Edit TestProject-Library-OSX.xcodeproj by modifying the file TestProject_Library_OSXTests.m to add the following line to the testWillPass function:
   printf("x1b[31mThis is red text.x1b[0m/n");
   1.  From the xctools base directory, run xctools with the following command line:
      ./xctool.sh -project xctool/xctool-tests/TestData/TestProject-Library-OSX/TestProject-Library-OSX.xcodeproj -scheme TestProject-Library-OSX test
   2.  In the test output you should see a line that reads "This is red text." but the StripAnsi() function should have removed the ANSI escape sequences.
