### PR TITLE
Prevent a crash (EXC_BAD_ACCESS)on 10.7 and Xcode 4

### DIFF
--- a/otest-shim/otest-shim/otest-shim.m
+++ b/otest-shim/otest-shim/otest-shim.m
@@ -274,14 +274,14 @@ static ssize_t __write(int fildes, const void *buf, size_t nbyte);
 static ssize_t __write(int fildes, const void *buf, size_t nbyte)
 {
   if (fildes == STDOUT_FILENO || fildes == STDERR_FILENO) {
-    dispatch_sync(EventQueue(), [^{
+    dispatch_sync(EventQueue(), ^{
       if (__testIsRunning && nbyte > 0) {
         NSString *output = [[NSString alloc] initWithBytes:buf length:nbyte encoding:NSUTF8StringEncoding];
         PrintJSON(@{@"event": kReporter_Events_TestOuput, kReporter_TestOutput_OutputKey: StripAnsi(output)});
         [__testOutput appendString:output];
         [output release];
       }
-    } copy]);
+    });
     return nbyte;
   } else {
     return write(fildes, buf, nbyte);


### PR DESCRIPTION
This is the crash I was getting. Removing the copy makes it go away, matching
__write_nocancel above

Process:         otest [46217]
Path:            /Applications/Xcode.app/Contents/Developer/Tools/otest
Identifier:      otest
Version:         ??? (???)
Code Type:       X86-64 (Native)
Parent Process:  xctool [46151]

Date/Time:       2013-09-09 22:17:02.355 -0700
OS Version:      Mac OS X 10.7.5 (11G63)
Report Version:  9

Crashed Thread:  0  Dispatch queue: com.apple.main-thread

Exception Type:  EXC_BAD_ACCESS (SIGSEGV)
Exception Codes: KERN_INVALID_ADDRESS at 0x0000000000000000

VM Regions Near 0:
-->
    __TEXT                 000000010b43a000-000000010b43e000 [   16K] r-x/rwx SM=COW  /Applications/Xcode.app/Contents/Developer/Tools/otest

Application Specific Information:
objc_msgSend() selector name: copy

Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   libobjc.A.dylib                 0x00007fff84ac1e96 objc_msgSend + 22
1   otest-shim-osx.dylib            0x000000010b446208 __write + 116 (otest-shim.m:277)
2   libobjc.A.dylib                 0x00007fff84ace71c _objc_syslog + 60
3   libobjc.A.dylib                 0x00007fff84ace95f _objc_inform + 181
4   libobjc.A.dylib                 0x00007fff84aba974 map_images_nolock + 750
5   libobjc.A.dylib                 0x00007fff84aba622 map_images + 115
6   dyld                            0x00007fff6b03f3dd _ZN4dyldL18notifyBatchPartialE17dyld_image_statesbPFPKcS0_jPK15dyld_image_infoE + 964
7   dyld                            0x00007fff6b03f50b dyld::registerImageStateBatchChangeHandler(dyld_image_states, char const\* (_)(dyld_image_states, unsigned int, dyld_image_info const_)) + 180
8   libdyld.dylib                   0x00007fff8b444acc dyld_register_image_state_change_handler + 81
9   libobjc.A.dylib                 0x00007fff84ab903a _objc_init + 58
10  dyld                            0x00007fff6b049da6 ImageLoaderMachO::doModInitFunctions(ImageLoader::LinkContext const&) + 218
11  dyld                            0x00007fff6b049af2 ImageLoaderMachO::doInitialization(ImageLoader::LinkContext const&) + 46
