### PR TITLE
force i386 when running `otest` for iOS logic tests.

### DIFF
--- a/xctool/xctool-tests/FakeTask.m
+++ b/xctool/xctool-tests/FakeTask.m
@@ -206,4 +206,9 @@ static void writeAll(int fildes, const void *buf, size_t nbyte) {
           [self arguments]];
 }
 
+- (void)setPreferredArchitectures:(NSArray *)architectures
+{
+  // This is part of NSConcreteTask - we're fine if it's a no-op in tests.
+}
+
 @end

--- a/xctool/xctool.xcodeproj/project.pbxproj
+++ b/xctool/xctool.xcodeproj/project.pbxproj
@@ -243,6 +243,7 @@
 		28E9B9D516C3275200A52E4D /* OCUnitTestRunner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OCUnitTestRunner.h; sourceTree = "<group>"; };
 		28E9B9D616C3275200A52E4D /* OCUnitTestRunner.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCUnitTestRunner.m; sourceTree = "<group>"; };
 		28E9B9DE16C3278D00A52E4D /* iPhoneSimulatorRemoteClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = iPhoneSimulatorRemoteClient.h; sourceTree = "<group>"; };
+		28EAB46017E29647005EB9CF /* NSConcreteTask.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSConcreteTask.h; sourceTree = "<group>"; };
 		28F489F117973B6100068E00 /* FakeFileHandle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FakeFileHandle.h; sourceTree = "<group>"; };
 		28F489F217973B6100068E00 /* FakeFileHandle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FakeFileHandle.m; sourceTree = "<group>"; };
 		28F489FA17973BF900068E00 /* NSFileHandle+Print.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSFileHandle+Print.h"; sourceTree = "<group>"; };
@@ -414,6 +415,7 @@
 				28BB043C17C7FF43004F6C13 /* Buildable.m */,
 				2869F3C317C82FB80078F078 /* TestableExecutionInfo.h */,
 				2869F3C417C82FB80078F078 /* TestableExecutionInfo.m */,
+				28EAB46017E29647005EB9CF /* NSConcreteTask.h */,
 			);
 			path = xctool;
 			sourceTree = "<group>";

--- a/xctool/xctool/NSConcreteTask.h
+++ b/xctool/xctool/NSConcreteTask.h
@@ -1,0 +1,38 @@
+//
+// Copyright 2013 Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/**
+ * NSConcreteTask is the true implementation behind NSTask.
+ */
+@interface NSConcreteTask : NSTask
+
+/**
+ * Internal dictionary of settings.  Passed to `launchWithDictionary:`.
+ */
+- (NSMutableDictionary *)taskDictionary;
+
+/**
+ * Set to `@[@(CPU_TYPE_X86_64)]` to prefer x86_64, or to `@[@(CPU_TYPE_I386)]`
+ * to prefer i386.
+ */
+- (void)setPreferredArchitectures:(NSArray *)architectures;
+
+/**
+ * Returns preferred architectures.
+ */
+- (id)preferredArchitectures;
+
+@end

--- a/xctool/xctool/OCUnitIOSLogicTestRunner.m
+++ b/xctool/xctool/OCUnitIOSLogicTestRunner.m
@@ -16,6 +16,7 @@
 
 #import "OCUnitIOSLogicTestRunner.h"
 
+#import "NSConcreteTask.h"
 #import "OTestQuery.h"
 #import "TaskUtil.h"
 #import "XCToolUtil.h"
@@ -41,7 +42,21 @@
 
 - (NSTask *)otestTaskWithTestBundle:(NSString *)testBundlePath
 {
-  NSTask *task = [[[NSTask alloc] init] autorelease];
+  NSConcreteTask *task = (NSConcreteTask *)[[[NSTask alloc] init] autorelease];
+
+  // As of the Xcode 5 GM, the iPhoneSimulator version of 'otest' is now a
+  // universal binary.  By default, the x86_64 version will be run. That's a
+  // problem because 1) Xcode doesn't build iPhoneSimulator tests as x86_64 by
+  // default (yet), and 2) otest-shim + otest-query are still i386 only.
+  //
+  // Let's force otest to start as i386 for now.
+  //
+  // At some point Apple may introduce universal binaries for iOS simulator
+  // apps.  When that happens, we'll need to make otest-shim-ios a fat binary
+  // and run tests twice - once against i386 and x86_64 - which is how Xcode
+  // handles testing for universal OS X binaries.
+  [task setPreferredArchitectures:@[@(CPU_TYPE_I386)]];
+
   [task setLaunchPath:[NSString stringWithFormat:@"%@/Developer/usr/bin/otest", _buildSettings[@"SDKROOT"]]];
   [task setArguments:[[self otestArguments] arrayByAddingObject:testBundlePath]];
   NSMutableDictionary *env = [[self.environmentOverrides mutableCopy] autorelease];


### PR DESCRIPTION
As of the Xcode 5 GM, `otest` for the iPhoneSimulator SDK became
a universal binary.

The problem with that is that 1) Xcode doesn't yet build iPhoneSimulator
binaries as x86_64 - they're all still i386; and 2) otest-shim + friends
are still i386 only.

For now, we can just force i386 and things will keep working.  At
somepoint Apple is going to start building simulator binaries as x86_64
and we'll have to make otest-shim + otest-query universal.

We'll probably also have to do what Xcode does when testing universal
binaries - i.e. runs tests twice, once as i386 and once as x86_64.
