### PR TITLE
if xctool is interrupted, its child processes should die. 

### DIFF
--- a/xctool/xctool-tests/FakeTask.m
+++ b/xctool/xctool-tests/FakeTask.m
@@ -211,4 +211,9 @@ static void writeAll(int fildes, const void *buf, size_t nbyte) {
   // This is part of NSConcreteTask - we're fine if it's a no-op in tests.
 }
 
+- (void)setStartsNewProcessGroup:(BOOL)startsNewProcessGroup
+{
+  // This is part of NSConcreteTask - we're fine if it's a no-op in tests.
+}
+
 @end

--- a/xctool/xctool/NSConcreteTask.h
+++ b/xctool/xctool/NSConcreteTask.h
@@ -35,4 +35,11 @@
  */
 - (id)preferredArchitectures;
 
+/**
+ * When YES (default), a new progress group is created for the child (via 
+ * POSIX_SPAWN_SETPGROUP to posix_spawnattr_setflags).  If YES, then the child
+ * will continue running even if the parent is killed or interrupted.
+ */
+- (void)setStartsNewProcessGroup:(BOOL)startsNewProcessGroup;
+
 @end

--- a/xctool/xctool/OCUnitOSXAppTestRunner.m
+++ b/xctool/xctool/OCUnitOSXAppTestRunner.m
@@ -49,7 +49,7 @@
                          [XcodeDeveloperDirPath() stringByAppendingPathComponent:@"Library/PrivateFrameworks/IDEBundleInjection.framework/IDEBundleInjection"],
                          ];
 
-  NSTask *task = [[NSTask alloc] init];
+  NSTask *task = CreateTaskInSameProcessGroup();
   [task setLaunchPath:testHostPath];
   [task setArguments:[self otestArguments]];
   [task setEnvironment:[self otestEnvironmentWithOverrides:@{

--- a/xctool/xctool/OTestQuery.m
+++ b/xctool/xctool/OTestQuery.m
@@ -78,7 +78,7 @@ NSArray *OTestQueryTestCasesInIOSBundle(NSString *bundlePath, NSString *sdk, NSS
   NSString *simulatorHome = [NSString stringWithFormat:@"%@/Library/Application Support/iPhone Simulator/%@", NSHomeDirectory(), version];
   NSString *sdkRootPath = SimulatorSDKRootPathWithVersion(version);
 
-  NSTask *task = [[NSTask alloc] init];
+  NSTask *task = CreateTaskInSameProcessGroup();
   [task setLaunchPath:[XCToolLibExecPath() stringByAppendingPathComponent:@"otest-query-ios"]];
   [task setEnvironment:@{@"CFFIXED_USER_HOME" : simulatorHome,
                          @"HOME" : simulatorHome,
@@ -111,7 +111,7 @@ NSArray *OTestQueryTestCasesInIOSBundleWithTestHost(NSString *bundlePath, NSStri
   NSString *simulatorHome = [NSString stringWithFormat:@"%@/Library/Application Support/iPhone Simulator/%@", NSHomeDirectory(), version];
   NSString *sdkRootPath = SimulatorSDKRootPathWithVersion(version);
 
-  NSTask *task = [[NSTask alloc] init];
+  NSTask *task = CreateTaskInSameProcessGroup();
   [task setLaunchPath:testHostExecutablePath];
   [task setEnvironment:@{
    // Inserted this dylib, which will then load whatever is in `OtestQueryBundlePath`.
@@ -139,7 +139,7 @@ NSArray *OTestQueryTestCasesInOSXBundle(NSString *bundlePath, NSString *builtPro
     return nil;
   }
 
-  NSTask *task = [[NSTask alloc] init];
+  NSTask *task = CreateTaskInSameProcessGroup();
   [task setLaunchPath:[XCToolLibExecPath() stringByAppendingPathComponent:@"otest-query-osx"]];
   [task setArguments:@[bundlePath]];
   [task setEnvironment:@{

--- a/xctool/xctool/ReporterTask.m
+++ b/xctool/xctool/ReporterTask.m
@@ -20,6 +20,7 @@
 #import <objc/message.h>
 
 #import "NSFileHandle+Print.h"
+#import "TaskUtil.h"
 #import "XCToolUtil.h"
 
 
@@ -113,7 +114,7 @@
                           @selector(__NSTask_allocWithZone:),
                           NSDefaultMallocZone()) init];
   } else {
-    _task = [[NSTask alloc] init];
+    _task = CreateTaskInSameProcessGroup();
   }
 
   [_task setLaunchPath:_reporterPath];

--- a/xctool/xctool/TaskUtil.h
+++ b/xctool/xctool/TaskUtil.h
@@ -26,3 +26,12 @@ NSDictionary *LaunchTaskAndCaptureOutput(NSTask *task);
  * Launchs a task, waits for exit, and feeds lines from standard out to a block.
  */
 void LaunchTaskAndFeedOuputLinesToBlock(NSTask *task, void (^block)(NSString *));
+
+/**
+ * Returns an NSTask that is configured NOT to start a new process group.  This
+ * way, the child will be killed if the parent is killed (or interrupted).  This
+ * is what we want all the time.
+ *
+ * @return Task with a retain count of 1.
+ */
+NSTask *CreateTaskInSameProcessGroup();

--- a/xctool/xctool/TaskUtil.m
+++ b/xctool/xctool/TaskUtil.m
@@ -18,6 +18,8 @@
 
 #import <poll.h>
 
+#import "NSConcreteTask.h"
+
 static void readOutputs(NSString **outputs, int *fildes, int sz) {
   struct pollfd fds[sz];
   dispatch_data_t data[sz];
@@ -224,4 +226,11 @@ void LaunchTaskAndFeedOuputLinesToBlock(NSTask *task, void (^block)(NSString *))
 
   [task waitUntilExit];
   [buffer release];
+}
+
+NSTask *CreateTaskInSameProcessGroup()
+{
+  NSConcreteTask *task = (NSConcreteTask *)[[NSTask alloc] init];
+  [task setStartsNewProcessGroup:NO];
+  return task;
 }

--- a/xctool/xctool/TestableExecutionInfo.m
+++ b/xctool/xctool/TestableExecutionInfo.m
@@ -72,7 +72,7 @@
                                           testSDK:(NSString *)testSDK
 {
   // Collect build settings for this test target.
-  NSTask *settingsTask = [[NSTask alloc] init];
+  NSTask *settingsTask = CreateTaskInSameProcessGroup();
   [settingsTask setLaunchPath:[XcodeDeveloperDirPath() stringByAppendingPathComponent:@"usr/bin/xcodebuild"]];
 
   if (testSDK) {

--- a/xctool/xctool/XCTool.m
+++ b/xctool/xctool/XCTool.m
@@ -142,7 +142,7 @@
   }
 
   if (options.showBuildSettings) {
-    NSTask *task = [[NSTask alloc] init];
+    NSTask *task = CreateTaskInSameProcessGroup();
     [task setLaunchPath:[XcodeDeveloperDirPath() stringByAppendingPathComponent:@"usr/bin/xcodebuild"]];
     [task setArguments:[[[options xcodeBuildArgumentsForSubject]
                          arrayByAddingObjectsFromArray:[options commonXcodeBuildArgumentsForSchemeAction:nil xcodeSubjectInfo:nil]]

--- a/xctool/xctool/XCToolUtil.m
+++ b/xctool/xctool/XCToolUtil.m
@@ -136,7 +136,7 @@ NSString *XCToolReportersPath(void)
 NSString *XcodeDeveloperDirPath(void)
 {
   NSString *(^getPath)() = ^{
-    NSTask *task = [[NSTask alloc] init];
+    NSTask *task = CreateTaskInSameProcessGroup();
     [task setLaunchPath:@"/usr/bin/xcode-select"];
     [task setArguments:@[@"--print-path"]];
 
@@ -186,7 +186,7 @@ NSDictionary *GetAvailableSDKsAndAliases()
     //   "iphonesimulator 5.0"
     //
     // xcodebuild is nice enough to return them to us in ascending order.
-    NSTask *task = [[NSTask alloc] init];
+    NSTask *task = CreateTaskInSameProcessGroup();
     [task setLaunchPath:@"/bin/bash"];
     [task setArguments:@[
      @"-c",
@@ -301,7 +301,7 @@ BOOL RunXcodebuildAndFeedEventsToReporters(NSArray *arguments,
                                            NSString *title,
                                            NSArray *reporters)
 {
-  NSTask *task = [[NSTask alloc] init];
+  NSTask *task = CreateTaskInSameProcessGroup();
   [task setLaunchPath:[XcodeDeveloperDirPath() stringByAppendingPathComponent:@"usr/bin/xcodebuild"]];
   [task setArguments:arguments];
   NSMutableDictionary *environment =

--- a/xctool/xctool/XcodeSubjectInfo.m
+++ b/xctool/xctool/XcodeSubjectInfo.m
@@ -752,7 +752,7 @@ containsFilesModifiedSince:(NSDate *)sinceDate
 
 - (NSDictionary *)buildSettingsForFirstBuildable
 {
-  NSTask *task = [[NSTask alloc] init];
+  NSTask *task = CreateTaskInSameProcessGroup();
   [task setLaunchPath:
    [XcodeDeveloperDirPath() stringByAppendingPathComponent:
     @"usr/bin/xcodebuild"]];


### PR DESCRIPTION
Let's create all tasks using this `CreateTaskInSameProcessGroup()`
function.  This will give us an NSTask that's configured to NOT start a
new process group for every spawned task.  (The default is to spawn all
children in new process groups.)

This way, if we spawn a long running build (for instance), it won't keep
running if someone does ctrl-c on xctool.
