### PR TITLE
Quote paths that may contain spaces

### DIFF
--- a/Configurations/iOS-Simulator-Dylib.xcconfig
+++ b/Configurations/iOS-Simulator-Dylib.xcconfig
@@ -58,9 +58,9 @@ _OTHER_CFLAGS = -fobjc-abi-version=2 -D__IPHONE_OS_VERSION_MIN_REQUIRED=$(XT_IOS
 
 // define these so includers that need additional cflags can do
 // OTHER_CFLAGS = $(_IOS_SIMULATOR_CFLAGS) -addtional_flags
-_IOS_SIMULATOR_CFLAGS = -isysroot $(PLATFORM_DIR)/../iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator$(XT_IOS_SDK_VERSION).sdk $(_OTHER_CFLAGS) -F$(PLATFORM_DIR)/../iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator$(XT_IOS_SDK_VERSION).sdk/Developer/Library/Frameworks
+_IOS_SIMULATOR_CFLAGS = -isysroot "$(PLATFORM_DIR)"/../iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator$(XT_IOS_SDK_VERSION).sdk $(_OTHER_CFLAGS) -F"$(PLATFORM_DIR)"/../iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator$(XT_IOS_SDK_VERSION).sdk/Developer/Library/Frameworks
 
-_IOS_SIMULATOR_LDFLAGS = -isysroot $(PLATFORM_DIR)/../iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator$(XT_IOS_SDK_VERSION).sdk -F$(PLATFORM_DIR)/../iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator$(XT_IOS_SDK_VERSION).sdk/Developer/Library/Frameworks -miphoneos-version-min=$(XT_IOS_SDK_VERSION)
+_IOS_SIMULATOR_LDFLAGS = -isysroot "$(PLATFORM_DIR)"/../iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator$(XT_IOS_SDK_VERSION).sdk -F"$(PLATFORM_DIR)"/../iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator$(XT_IOS_SDK_VERSION).sdk/Developer/Library/Frameworks -miphoneos-version-min=$(XT_IOS_SDK_VERSION)
 
 OTHER_CFLAGS = $(_IOS_SIMULATOR_CFLAGS)
 OTHER_LDFLAGS = $(_IOS_SIMULATOR_LDFLAGS)

--- a/mobile-installation-helper/mobile-installation-helper.xcconfig
+++ b/mobile-installation-helper/mobile-installation-helper.xcconfig
@@ -19,7 +19,7 @@
 #include "../Configurations/Install.xcconfig"
 XT_INSTALL_DIR = libexec
 
-OTHER_LDFLAGS = -F$(SDKROOT)/System/Library/PrivateFrameworks -framework MobileInstallation
+OTHER_LDFLAGS = -F"$(SDKROOT)"/System/Library/PrivateFrameworks -framework MobileInstallation
 
 // Make sure the build products go to 'Debug' rather than 'Debug-iphonesimulator'
 EFFECTIVE_PLATFORM_NAME =

--- a/otest-query/otest-query-osx.xcconfig
+++ b/otest-query/otest-query-osx.xcconfig
@@ -22,8 +22,8 @@ XT_INSTALL_DIR = libexec
 MACOSX_DEPLOYMENT_TARGET = 10.7
 
 // Needed so we can #import from SenTestingKit.
-OTHER_CFLAGS = -F$(DEVELOPER_FRAMEWORKS_DIR)
-OTHER_LDFLAGS = -F$(DEVELOPER_FRAMEWORKS_DIR) -weak_framework SenTestingKit
+OTHER_CFLAGS = -F"$(DEVELOPER_FRAMEWORKS_DIR)"
+OTHER_LDFLAGS = -F"$(DEVELOPER_FRAMEWORKS_DIR)" -weak_framework SenTestingKit
 
 // OSX tests or test hosts may use GC, so we have to be GC friendly.
 // By setting the main value to 'unsupported' and then setting the arch-specific setting to

--- a/otest-shim/otest-shim-osx.xcconfig
+++ b/otest-shim/otest-shim-osx.xcconfig
@@ -22,7 +22,7 @@ XT_INSTALL_DIR = lib
 MACOSX_DEPLOYMENT_TARGET = 10.7
 
 // Needed so we can #import from SenTestingKit.
-OTHER_CFLAGS = -F$(DEVELOPER_FRAMEWORKS_DIR)
+OTHER_CFLAGS = -F"$(DEVELOPER_FRAMEWORKS_DIR)"
 
 // OSX tests or test hosts may use GC, so we have to be GC friendly.
 // By setting the main value to 'unsupported' and then setting the arch-specific setting to


### PR DESCRIPTION
If the path to your XCode installation contains spaces, that path
must be quoted or the shell will split it. This change fixes a
few unquoted paths.
