### PR TITLE
Test project doesn't have a shared scheme

### DIFF
--- a/xctool/xctool-tests/TestData/TestProject-Library-XCTest-iOS/TestProject-Library-XCTest-iOS.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/xctool/xctool-tests/TestData/TestProject-Library-XCTest-iOS/TestProject-Library-XCTest-iOS.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEWorkspaceSharedSettings_AutocreateContextsIfNeeded</key>
+	<false/>
+</dict>
+</plist>

--- a/xctool/xctool-tests/TestData/TestProject-Library-XCTest-iOS/TestProject-Library-XCTest-iOS.xcodeproj/xcshareddata/xcschemes/TestProject-Library-XCTest-iOS.xcscheme
+++ b/xctool/xctool-tests/TestData/TestProject-Library-XCTest-iOS/TestProject-Library-XCTest-iOS.xcodeproj/xcshareddata/xcschemes/TestProject-Library-XCTest-iOS.xcscheme
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0500"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AA318BAD17E98F2F00BF159E"
+               BuildableName = "libTestProject-Library-XCTest-iOS.a"
+               BlueprintName = "TestProject-Library-XCTest-iOS"
+               ReferencedContainer = "container:TestProject-Library-XCTest-iOS.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AA318BBD17E98F2F00BF159E"
+               BuildableName = "TestProject-Library-XCTest-iOSTests.xctest"
+               BlueprintName = "TestProject-Library-XCTest-iOSTests"
+               ReferencedContainer = "container:TestProject-Library-XCTest-iOS.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
`TestProject-Library-XCTest-iOS` didn't have a shared scheme. This made a test fail. It went unnoticed on Travis, since the Travis machines aren't on OS X 10.9 yet. 

This fixes the one test failure being noticed on #179.
