### PR TITLE
Updated CC path in .xcconfig

### DIFF
--- a/Configurations/dont_clang_as_osx.py
+++ b/Configurations/dont_clang_as_osx.py
@@ -8,6 +8,7 @@
 import os
 import sys
 
+print os.environ
 assert ('DEVELOPER_DIR' in os.environ), 'DEVELOPER_DIR should be set.'
 clang_path = '%s/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang' % (
     os.environ['DEVELOPER_DIR'])

--- a/Configurations/iOS-Simulator-Dylib.xcconfig
+++ b/Configurations/iOS-Simulator-Dylib.xcconfig
@@ -37,7 +37,7 @@ SDKROOT = macosx
 // build an iOS dylib.  Let's use a wrapper around 'ld' and 'cc' to make it strip
 // out the OSX specific flags.
 LD = ../Configurations/dont_clang_as_osx.py
-CC = $(SRCROOT)/../../xctool/Configurations/dont_clang_as_osx.py
+CC = $(SRCROOT)/../Configurations/dont_clang_as_osx.py
 
 ARCHS = i386
 VALID_ARCHS = i386


### PR DESCRIPTION
The .xcconfig assumed the repository to be checked out as `xctool`.
This has been fixed. This fixes errors with building in homebrew.

Part of fix for issue #190
