### PR TITLE
fix the `was compiled for iOS Simulator, but linking for MacOSX` warning

### DIFF
--- a/Configurations/iOS-Simulator-Dylib.xcconfig
+++ b/Configurations/iOS-Simulator-Dylib.xcconfig
@@ -28,6 +28,13 @@ XT_NEWEST_IOS_SDK_EXPANDED_0500 = 70000
 XT_IOS_SDK_VERSION = $(XT_NEWEST_IOS_SDK_$(XCODE_VERSION_MINOR))
 XT_IOS_SDK_VERSION_EXPANDED = $(XT_NEWEST_IOS_SDK_EXPANDED_$(XCODE_VERSION_MINOR))
 
+// Xcode 4 and Xcode 5 use a different option name to specify the min OS version.
+//
+// In Xcode 4, it's like ... `-miphoneos-version-min=5.0`
+// In Xcode 5, it's like ... `-mios-simulator-version-min=5.0`
+XT_IOS_SIMULATOR_VERSION_MIN_0460 = iphoneos-version-min
+XT_IOS_SIMULATOR_VERSION_MIN_0500 = ios-simulator-version-min
+
 // Must be set to 'macosx' or you'll get an error:
 //    target specifies product type 'com.apple.product-type.library.dynamic', but there's no
 //    such product type for the 'iphonesimulator' platform
@@ -59,9 +66,9 @@ _OTHER_CFLAGS = -fobjc-abi-version=2 -D__IPHONE_OS_VERSION_MIN_REQUIRED=$(XT_IOS
 
 // define these so includers that need additional cflags can do
 // OTHER_CFLAGS = $(_IOS_SIMULATOR_CFLAGS) -addtional_flags
-_IOS_SIMULATOR_CFLAGS = -isysroot "$(PLATFORM_DIR)"/../iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator$(XT_IOS_SDK_VERSION).sdk $(_OTHER_CFLAGS) -F"$(PLATFORM_DIR)"/../iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator$(XT_IOS_SDK_VERSION).sdk/Developer/Library/Frameworks -miphoneos-version-min=$(XT_IOS_SDK_VERSION)
+_IOS_SIMULATOR_CFLAGS = -isysroot "$(PLATFORM_DIR)"/../iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator$(XT_IOS_SDK_VERSION).sdk $(_OTHER_CFLAGS) -F"$(PLATFORM_DIR)"/../iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator$(XT_IOS_SDK_VERSION).sdk/Developer/Library/Frameworks -m$(XT_IOS_SIMULATOR_VERSION_MIN_$(XCODE_VERSION_MINOR))=$(XT_IOS_SDK_VERSION)
 
-_IOS_SIMULATOR_LDFLAGS = -isysroot "$(PLATFORM_DIR)"/../iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator$(XT_IOS_SDK_VERSION).sdk -F"$(PLATFORM_DIR)"/../iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator$(XT_IOS_SDK_VERSION).sdk/Developer/Library/Frameworks -miphoneos-version-min=$(XT_IOS_SDK_VERSION)
+_IOS_SIMULATOR_LDFLAGS = -isysroot "$(PLATFORM_DIR)"/../iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator$(XT_IOS_SDK_VERSION).sdk -F"$(PLATFORM_DIR)"/../iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator$(XT_IOS_SDK_VERSION).sdk/Developer/Library/Frameworks -m$(XT_IOS_SIMULATOR_VERSION_MIN_$(XCODE_VERSION_MINOR))=$(XT_IOS_SDK_VERSION)
 
 OTHER_CFLAGS = $(_IOS_SIMULATOR_CFLAGS)
 OTHER_LDFLAGS = $(_IOS_SIMULATOR_LDFLAGS)


### PR DESCRIPTION
We're seeing ...

```
ld: warning: ObjC object file
(/Users/fpotter/Library/Developer/Xcode/DerivedData/xctool-coaqfpnavanndzgumiqgxmfwpkjd/Build/Intermediates/otest-query.build/Debug/otest-query-ios.build/Objects-normal/i386/main.o)
was compiled for iOS Simulator, but linking for MacOSX
```

Where we used to pass `-miphoneos-version-min=7.0` in Xcode 4, we now
need to pass `-mios-simulator-version-min=7.0`.
