### PR TITLE
xctool crashes when setting `-reporter` without a next arg

### DIFF
--- a/xctool/xctool/Action.m
+++ b/xctool/xctool/Action.m
@@ -194,7 +194,6 @@
       } else if (matchingNamedOption[kActionOptionMapToSelector]) {
         SEL sel = sel_registerName([matchingNamedOption[kActionOptionMapToSelector] UTF8String]);
         NSString *nextArgument = arguments.count > 1 ? arguments[1] : nil;
-        objc_msgSend(self, sel, nextArgument);
         if(nextArgument) {
           count += 2;
           [arguments removeObjectsInRange:NSMakeRange(0, 2)];
@@ -203,6 +202,7 @@
           [arguments removeAllObjects];
           return 0;
         }
+        objc_msgSend(self, sel, nextArgument);
         continue;
       }
     }


### PR DESCRIPTION
```
2013-10-09 14:45:13.058 xctool[96700:2707] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[__NSArrayM insertObject:atIndex:]: object cannot be nil'
*** First throw call stack:
(
    0   CoreFoundation                      0x00007fff952ee41c __exceptionPreprocess + 172
    1   libobjc.A.dylib                     0x00007fff91dd9e75 objc_exception_throw + 43
    2   CoreFoundation                      0x00007fff951af8b7 -[__NSArrayM insertObject:atIndex:] + 951
    3   xctool                              0x0000000103e9e5de -[Action consumeArguments:errorMessage:] + 719
    4   xctool                              0x0000000103e9f61f -[Options consumeArguments:errorMessage:] + 434
    5   xctool                              0x0000000103e989c8 -[XCTool run] + 491
    6   xctool                              0x0000000103e97f78 main + 507
    7   xctool                              0x0000000103e961f4 start + 52
)
libc++abi.dylib: terminating with uncaught exception of type NSException
```

This is pretty dirty. We should catch this cleanly
