### PR TITLE
When analyzing, warn when build-state.dat is not in the expected location

### DIFF
--- a/xctool/xctool/AnalyzeAction.m
+++ b/xctool/xctool/AnalyzeAction.m
@@ -155,6 +155,13 @@
                     objroot:xcodeSubjectInfo.objRoot];
   NSString *buildStatePath = [path stringByAppendingPathComponent:@"build-state.dat"];
 
+  if (![[NSFileManager defaultManager] fileExistsAtPath:buildStatePath]) {
+    NSLog(@"No build-state.dat for project/target: %@/%@, skipping...\n"
+          "  it may be overriding CONFIGURATION_TEMP_DIR and emitting intermediate \n"
+          "  files in a non-standard location", projectName, targetName);
+    return;
+  }
+
   BOOL haveFoundWarnings = NO;
 
   BuildStateParser *buildState = [[[BuildStateParser alloc] initWithPath:buildStatePath] autorelease];


### PR DESCRIPTION
Targets overriding the CONFIGURATION_TEMP_DIR build setting will emit intermediate files in a non-standard location. Since xctool does not parse the full build settings for sake of performance, it can't know where the actual intermediates will be emitted to.

Previously, when collecting analyzer output, xctool blindly assumes the location and existence of the file, and would block forever trying to read it. Now it gives an insightful log message and ignores the target.
