### PR TITLE
Don't assert if a build generates unexpected output

### DIFF
--- a/Common/Reporter.m
+++ b/Common/Reporter.m
@@ -113,8 +113,9 @@ static void ReadFileDescriptorAndOutputLinesToBlock(int inputFD,
   NSDictionary *dict = [NSJSONSerialization JSONObjectWithData:[line dataUsingEncoding:NSUTF8StringEncoding]
                                                        options:0
                                                          error:&error];
-  NSAssert(dict != nil, @"Failed to decode JSON '%@' with error: %@", line, [error localizedFailureReason]);
-  [self handleEvent:dict];
+  if (dict != nil) {
+    [self handleEvent:dict];
+  }
 }
 
 - (void)handleEvent:(NSDictionary *)eventDict


### PR DESCRIPTION
There are valid reasons for a unit test to write to `stdout` or `stderr` in a format not expected by xctool (which appears to only support `NSLog` output), so unexpected output shouldn't abort the test run.

Most commonly, this would be an indirect consequence of running a script or executing some code that is `NSLog`-unaware.
