### PR TITLE
Fix running tests for OS X framework targets

### DIFF
--- a/xctool/xctool/RunTestsAction.m
+++ b/xctool/xctool/RunTestsAction.m
@@ -412,7 +412,8 @@ NSArray *BucketizeTestCasesByTestClass(NSArray *testCases, int bucketSize)
 - (NSArray *)testConfigurationsForBuildSettings:(NSDictionary *)testableBuildSettings
 {
   NSString *sdkName = testableBuildSettings[@"SDK_NAME"];
-  BOOL isApplicationTest = testableBuildSettings[@"TEST_HOST"] != nil;
+  NSString *testHost = testableBuildSettings[@"TEST_HOST"];
+  BOOL isApplicationTest = testHost != nil;
 
   // array of [class, (bool) GC Enabled]
   NSMutableArray *testConfigurations = [NSMutableArray array];
@@ -425,7 +426,7 @@ NSArray *BucketizeTestCasesByTestClass(NSArray *testCases, int bucketSize)
     }
   } else if ([sdkName hasPrefix:@"macosx"]) {
     Class testClass = {0};
-    if (isApplicationTest) {
+    if (isApplicationTest && IsMachOExecutable(testHost)) {
       testClass = [OCUnitOSXAppTestRunner class];
     } else {
       testClass = [OCUnitOSXLogicTestRunner class];

--- a/xctool/xctool/TestableExecutionInfo.m
+++ b/xctool/xctool/TestableExecutionInfo.m
@@ -157,7 +157,8 @@
                                        error:(NSString **)error
 {
   NSString *sdkName = testableBuildSettings[@"SDK_NAME"];
-  BOOL hasTestHost = (testableBuildSettings[@"TEST_HOST"] != nil);
+  NSString *testHost = testableBuildSettings[@"TEST_HOST"];
+  BOOL hasTestHost = (testHost != nil);
   Class runnerClass = {0};
   if ([sdkName hasPrefix:@"iphonesimulator"]) {
     if (hasTestHost) {
@@ -166,7 +167,7 @@
       runnerClass = [OCUnitIOSLogicTestQueryRunner class];
     }
   } else if ([sdkName hasPrefix:@"macosx"]) {
-    if (hasTestHost) {
+    if (hasTestHost && IsMachOExecutable(testHost)) {
       runnerClass = [OCUnitOSXAppTestQueryRunner class];
     } else {
       runnerClass = [OCUnitOSXLogicTestQueryRunner class];

--- a/xctool/xctool/XCToolUtil.h
+++ b/xctool/xctool/XCToolUtil.h
@@ -143,3 +143,7 @@ NSString *SystemPaths();
  */
 NSString *MakeTemporaryDirectory(NSString *nameTemplate);
 
+/**
+ * Returns YES if the path leads to an executable.
+ */
+BOOL IsMachOExecutable(NSString *path);

--- a/xctool/xctool/XCToolUtil.m
+++ b/xctool/xctool/XCToolUtil.m
@@ -595,3 +595,16 @@ NSString *MakeTemporaryDirectory(NSString *nameTemplate)
 
   return [NSString stringWithUTF8String:template.bytes];
 }
+
+// Forward declaration for private CFBundle API.
+// https://www.opensource.apple.com/source/CF/CF-855.11/CFBundle.c
+CFStringRef _CFBundleCopyFileTypeForFileURL(CFURLRef url);
+
+BOOL IsMachOExecutable(NSString *path)
+{
+  NSURL *fileURL = [NSURL fileURLWithPath:path];
+  CFStringRef fileType = _CFBundleCopyFileTypeForFileURL((CFURLRef)fileURL);
+  CFComparisonResult result = CFStringCompare(fileType, CFSTR("tool"), 0);
+  CFRelease(fileType);
+  return result == kCFCompareEqualTo;
+}


### PR DESCRIPTION
The OS X logic test query and runner do exactly what we need to do for a framework target, so I figure just detect the odd case of a framework as `TEST_HOST` and call that a logic test.

I'm not particularly happy about `TestHostIsFrameworkExecutable` loading the framework bundle to carry out its tests; I'm worried about categories inadvertently overriding methods or other possible weirdness. But relying on the path alone is naive, as frameworks can include executables (perhaps as resources) that are legitimate test hosts. Suggestions welcome.

Fixes #251.
