### PR TITLE
change `-[SenTestCase invokeTest]` to create an inner autorelease pool.

### DIFF
--- a/otest-shim/otest-shim.xcodeproj/project.pbxproj
+++ b/otest-shim/otest-shim.xcodeproj/project.pbxproj
@@ -13,6 +13,10 @@
 		2839BE61183FEB6F000D7BEC /* SenTestClassEnumeratorFix.h in Headers */ = {isa = PBXBuildFile; fileRef = 2839BE5E183FEB6F000D7BEC /* SenTestClassEnumeratorFix.h */; };
 		2839BE62183FEB6F000D7BEC /* SenTestClassEnumeratorFix.m in Sources */ = {isa = PBXBuildFile; fileRef = 2839BE5F183FEB6F000D7BEC /* SenTestClassEnumeratorFix.m */; };
 		2839BE63183FEB6F000D7BEC /* SenTestClassEnumeratorFix.m in Sources */ = {isa = PBXBuildFile; fileRef = 2839BE5F183FEB6F000D7BEC /* SenTestClassEnumeratorFix.m */; };
+		2839BE8B1843CCFF000D7BEC /* SenTestCaseInvokeTestFix.h in Headers */ = {isa = PBXBuildFile; fileRef = 2839BE891843CCFF000D7BEC /* SenTestCaseInvokeTestFix.h */; };
+		2839BE8C1843CCFF000D7BEC /* SenTestCaseInvokeTestFix.h in Headers */ = {isa = PBXBuildFile; fileRef = 2839BE891843CCFF000D7BEC /* SenTestCaseInvokeTestFix.h */; };
+		2839BE8D1843CCFF000D7BEC /* SenTestCaseInvokeTestFix.m in Sources */ = {isa = PBXBuildFile; fileRef = 2839BE8A1843CCFF000D7BEC /* SenTestCaseInvokeTestFix.m */; };
+		2839BE8E1843CCFF000D7BEC /* SenTestCaseInvokeTestFix.m in Sources */ = {isa = PBXBuildFile; fileRef = 2839BE8A1843CCFF000D7BEC /* SenTestCaseInvokeTestFix.m */; };
 		283CCA9A16C2EE4C00F2E343 /* otest-shim.m in Sources */ = {isa = PBXBuildFile; fileRef = 283CCA9916C2EE4C00F2E343 /* otest-shim.m */; };
 		2887CC41181E0D9200B0D049 /* DuplicateTestNameFix.h in Headers */ = {isa = PBXBuildFile; fileRef = 2887CC3F181E0D9200B0D049 /* DuplicateTestNameFix.h */; };
 		2887CC42181E0D9200B0D049 /* DuplicateTestNameFix.h in Headers */ = {isa = PBXBuildFile; fileRef = 2887CC3F181E0D9200B0D049 /* DuplicateTestNameFix.h */; };
@@ -51,6 +55,8 @@
 		282BFE2C1716049F0022F9FF /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
 		2839BE5E183FEB6F000D7BEC /* SenTestClassEnumeratorFix.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SenTestClassEnumeratorFix.h; sourceTree = "<group>"; };
 		2839BE5F183FEB6F000D7BEC /* SenTestClassEnumeratorFix.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SenTestClassEnumeratorFix.m; sourceTree = "<group>"; };
+		2839BE891843CCFF000D7BEC /* SenTestCaseInvokeTestFix.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SenTestCaseInvokeTestFix.h; sourceTree = "<group>"; };
+		2839BE8A1843CCFF000D7BEC /* SenTestCaseInvokeTestFix.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SenTestCaseInvokeTestFix.m; sourceTree = "<group>"; };
 		283CCA8C16C2EE4C00F2E343 /* otest-shim-ios.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = "otest-shim-ios.dylib"; sourceTree = BUILT_PRODUCTS_DIR; };
 		283CCA9416C2EE4C00F2E343 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		283CCA9716C2EE4C00F2E343 /* otest-shim-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "otest-shim-Prefix.pch"; sourceTree = "<group>"; };
@@ -138,6 +144,8 @@
 			isa = PBXGroup;
 			children = (
 				283CCA9916C2EE4C00F2E343 /* otest-shim.m */,
+				2839BE891843CCFF000D7BEC /* SenTestCaseInvokeTestFix.h */,
+				2839BE8A1843CCFF000D7BEC /* SenTestCaseInvokeTestFix.m */,
 				2839BE5E183FEB6F000D7BEC /* SenTestClassEnumeratorFix.h */,
 				2839BE5F183FEB6F000D7BEC /* SenTestClassEnumeratorFix.m */,
 				283CCA9616C2EE4C00F2E343 /* Supporting Files */,
@@ -185,6 +193,7 @@
 				AA318BEB17E9B43000BF159E /* XCTest.h in Headers */,
 				28E44D531811024F00211BD5 /* ParseTestName.h in Headers */,
 				2887CC48181E145D00B0D049 /* TestingFramework.h in Headers */,
+				2839BE8C1843CCFF000D7BEC /* SenTestCaseInvokeTestFix.h in Headers */,
 				3892D75A1815ACE200E68652 /* EventGenerator.h in Headers */,
 				28897FCA173E50F9004BA024 /* Swizzle.h in Headers */,
 				28E28FB517968EC50072376C /* ReporterEvents.h in Headers */,
@@ -200,6 +209,7 @@
 				28E44D521811024F00211BD5 /* ParseTestName.h in Headers */,
 				3892D7591815ACE200E68652 /* EventGenerator.h in Headers */,
 				2887CC47181E145D00B0D049 /* TestingFramework.h in Headers */,
+				2839BE8B1843CCFF000D7BEC /* SenTestCaseInvokeTestFix.h in Headers */,
 				28897FC9173E50F9004BA024 /* Swizzle.h in Headers */,
 				28E28FB417968EC50072376C /* ReporterEvents.h in Headers */,
 				AA318BEA17E9B43000BF159E /* XCTest.h in Headers */,
@@ -279,6 +289,7 @@
 			files = (
 				2887CC44181E0D9200B0D049 /* DuplicateTestNameFix.m in Sources */,
 				2839BE63183FEB6F000D7BEC /* SenTestClassEnumeratorFix.m in Sources */,
+				2839BE8E1843CCFF000D7BEC /* SenTestCaseInvokeTestFix.m in Sources */,
 				2887CC4A181E145D00B0D049 /* TestingFramework.m in Sources */,
 				3892D75C1815ACE200E68652 /* EventGenerator.m in Sources */,
 				282BFE2B1716044C0022F9FF /* otest-shim.m in Sources */,
@@ -293,6 +304,7 @@
 			files = (
 				2887CC43181E0D9200B0D049 /* DuplicateTestNameFix.m in Sources */,
 				2839BE62183FEB6F000D7BEC /* SenTestClassEnumeratorFix.m in Sources */,
+				2839BE8D1843CCFF000D7BEC /* SenTestCaseInvokeTestFix.m in Sources */,
 				2887CC49181E145D00B0D049 /* TestingFramework.m in Sources */,
 				3892D75B1815ACE200E68652 /* EventGenerator.m in Sources */,
 				283CCA9A16C2EE4C00F2E343 /* otest-shim.m in Sources */,

--- a/otest-shim/otest-shim/SenTestCaseInvokeTestFix.h
+++ b/otest-shim/otest-shim/SenTestCaseInvokeTestFix.h
@@ -1,0 +1,73 @@
+//
+// Copyright 2013 Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+/**
+ This replaces the implementation of `-[SenTestCase invokeTest]` with our
+ own implementation that creates a new autorelease pool around the invocation
+ of setUp, <test method>, tearDown.
+
+ SenTestingKit *does* wrap test executions in autorelease pools, but it does it
+ like this...
+
+   1a. pool = [[NSAutoreleasePool alloc] init]
+   2a. Announce test case started with: "Test Case '...' started."
+   3a. Call setUp
+   4a. Call the [test method]
+   5a. Call tearDown
+   6a. Announce test case ended with: "Test Case '...' failed (0.000 seconds)."
+   7a. [pool drain]
+
+ We're modifying it to be ...
+
+   1b. pool = [[NSAutoreleasePool alloc] init]
+   2b. Announce test case started with: "Test Case '...' started."
+>  3b. innerPool = [[NSAutoreleasePool alloc] init]
+   4b. Call setUp
+   5b. Call the [test method]
+   6b. Call tearDown
+>  7b. [innerPool drain]
+   8b. Announce test case ended with: "Test Case '...' failed (0.000 seconds)."
+   9b. [pool drain]
+
+ This gives us two benefits...
+
+ 1. When an over-release bug occurs (i.e. when the autorelease pool drains and
+    tries to free an already released object), the crash will appear to happen
+    DURING the test rather than AFTER the test.  This is because we'll drain
+    the pool before emitting the "Test Case '...' failed (0.000 seconds)."
+    message.
+
+ 2. It insulates otest-shim from brokenness by letting the test run completely
+    in a different autorelease pool.  The whole situation that prompted this was
+    a test that mock'ed `[NSDate date]` via `[OCMockObject niceMockForClass:[NSDate class]]`.
+    OCMock works by swizzling, and it will automatically undo its swizzle when
+    the mock object is released.
+
+    The problem was that otest-shim's code was getting called in step [6a] above
+    (inside of our swizzle of `+[SenTestLog testCaseDidStop:]`), and our swizzle
+    needed to call `[NSDate date]`.  But, since we were running in the same
+    autorelease pool as the test, the OCMockObject for NSDate hadn't yet been
+    released and so the swizzle was still live.
+
+    otest-shim's code was trying to call the real NSDate, but getting the
+    swizzled version instead.
+
+    By creating an inner pool for the test code, we can make sure the mock
+    object + swizzle get released.
+ */
+void XTApplySenTestCaseInvokeTestFix();

--- a/otest-shim/otest-shim/SenTestCaseInvokeTestFix.m
+++ b/otest-shim/otest-shim/SenTestCaseInvokeTestFix.m
@@ -1,0 +1,82 @@
+//
+// Copyright 2013 Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "SenTestClassEnumeratorFix.h"
+
+#import "dyld-interposing.h"
+#import "Swizzle.h"
+
+/**
+ A struct with the same layout as SenTestCase.
+ 
+ We use this instead of copying the class-dump of SenTestCase into
+ this file.  If we did that, the linker would need to link directly into
+ SenTestingKit, which we specifically do not want to do (because the initializer
+ in SenTestingKit will immediately start running tests, prematurely for what
+ we're doing).
+ */
+struct XTSenTestCase
+{
+  Class isa;
+
+  NSInvocation *invocation;
+  id *run;
+  SEL failureAction;
+};
+
+@interface XTSenTestCase
+- (NSUInteger)numberOfTestIterationsForTestWithSelector:(SEL)arg1;
+- (void)afterTestIteration:(unsigned long long)arg1 selector:(SEL)arg2;
+- (void)beforeTestIteration:(unsigned long long)arg1 selector:(SEL)arg2;
+- (void)tearDownTestWithSelector:(SEL)arg1;
+- (void)setUpTestWithSelector:(SEL)arg1;
+- (void)setUp;
+- (void)tearDown;
+@end
+
+static void SenTestCase_invokeTest(XTSenTestCase *self, SEL cmd)
+{
+  struct XTSenTestCase *testCaseStruct = (struct XTSenTestCase *)self;
+  NSInvocation *invocation = testCaseStruct->invocation;
+
+  SEL selector = [invocation selector];
+
+  // Make a new pool around our invocation of setUp, <test method>, tearDown.
+  // This is the whole reason we re-implement this method.
+  NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+
+  [self setUpTestWithSelector:selector];
+  [self setUp];
+
+  NSUInteger numberOfIterations = [self numberOfTestIterationsForTestWithSelector:selector];
+  for (NSUInteger i = 0; i < numberOfIterations; i++) {
+    [self beforeTestIteration:i selector:selector];
+    [invocation invoke];
+    [self afterTestIteration:i selector:selector];
+  }
+
+  [self tearDown];
+  [self tearDownTestWithSelector:selector];
+
+  [pool drain];
+}
+
+void XTApplySenTestCaseInvokeTestFix()
+{
+  XTSwizzleSelectorForFunction(NSClassFromString(@"SenTestCase"),
+                               @selector(invokeTest),
+                               (IMP)SenTestCase_invokeTest);
+}

--- a/otest-shim/otest-shim/otest-shim.m
+++ b/otest-shim/otest-shim/otest-shim.m
@@ -29,6 +29,7 @@
 #import "EventGenerator.h"
 #import "ParseTestName.h"
 #import "ReporterEvents.h"
+#import "SenTestCaseInvokeTestFix.h"
 #import "SenTestClassEnumeratorFix.h"
 #import "Swizzle.h"
 #import "TestingFramework.h"
@@ -551,6 +552,7 @@ static const char *DyldImageStateChangeHandler(enum dyld_image_states state,
       NSDictionary *frameworkInfo = FrameworkInfoForExtension(@"octest");
       ApplyDuplicateTestNameFix([frameworkInfo objectForKey:kTestingFrameworkTestProbeClassName]);
       XTApplySenTestClassEnumeratorFix();
+      XTApplySenTestCaseInvokeTestFix();
     }
     else if (strstr(info[i].imageFilePath, "XCTest.framework") != NULL) {
       // Since the 'XCTestLog' class now exists, we can swizzle it!


### PR DESCRIPTION
This replaces the implementation of `-[SenTestCase invokeTest]` with our own implementation that creates a new autorelease pool around the invocation of setUp, <test method>, tearDown.

SenTestingKit _does_ wrap test executions in autorelease pools, but it does it like this...

```
   1a. pool = [[NSAutoreleasePool alloc] init]
   2a. Announce test case started with: "Test Case '...' started."
   3a. Call setUp
   4a. Call the [test method]
   5a. Call tearDown
   6a. Announce test case ended with: "Test Case '...' failed (0.000 seconds)."
   7a. [pool drain]
```

We're modifying it to be ...

```
   1b. pool = [[NSAutoreleasePool alloc] init]
   2b. Announce test case started with: "Test Case '...' started."
>  3b. innerPool = [[NSAutoreleasePool alloc] init]
   4b. Call setUp
   5b. Call the [test method]
   6b. Call tearDown
>  7b. [innerPool drain]
   8b. Announce test case ended with: "Test Case '...' failed (0.000 seconds)."
   9b. [pool drain]
```

This gives us two benefits...
1. When an over-release bug occurs (i.e. when the autorelease pool drains and tries to free an already released object), the crash will appear to happen DURING the test rather than AFTER the test.  This is because we'll drain the pool before emitting the "Test Case '...' failed (0.000 seconds)." message.
2. It insulates otest-shim from brokenness by letting the test run completely in a different autorelease pool.  The whole situation that prompted this was a test that mock'ed `[NSDate date]` via `[OCMockObject niceMockForClass:[NSDate class]]`. OCMock works by swizzling, and it will automatically undo its swizzle when the mock object is released.
   
   The problem was that otest-shim's code was getting called in step [6a] above (inside of our swizzle of `+[SenTestLog testCaseDidStop:]`), and our swizzle needed to call `[NSDate date]`.  But, since we were running in the same autorelease pool as the test, the OCMockObject for NSDate hadn't yet been released and so the swizzle was still live.
   
   otest-shim's code was trying to call the real NSDate, but getting the swizzled version instead.
   
   By creating an inner pool for the test code, we can make sure the mock object + swizzle get released.
