### PR TITLE
build commands are only successful if resultCode == 0 and they have no errors

### DIFF
--- a/Common/ReporterEvents.h
+++ b/Common/ReporterEvents.h
@@ -95,6 +95,9 @@
 #define kReporter_EndBuildCommand_SucceededKey @"succeeded"
 #define kReporter_EndBuildCommand_EmittedOutputTextKey @"emittedOutputText"
 #define kReporter_EndBuildCommand_DurationKey @"duration"
+#define kReporter_EndBuildCommand_ResultCode @"resultCode"
+#define kReporter_EndBuildCommand_TotalNumberOfWarnings @"totalNumberOfWarnings"
+#define kReporter_EndBuildCommand_TotalNumberOfErrors @"totalNumberOfErrors"
 
 #define kReporter_BeginBuildTarget_ProjectKey @"project"
 #define kReporter_BeginBuildTarget_TargetKey @"target"

--- a/reporters/text/TextReporter.m
+++ b/reporters/text/TextReporter.m
@@ -530,7 +530,7 @@ static NSString *abbreviatePath(NSString *string) {
 
   NSString *indicator = nil;
   if (succeeded) {
-    if ([outputText rangeOfString:@"warning:"].location != NSNotFound) {
+    if ([event[kReporter_EndBuildCommand_TotalNumberOfWarnings] unsignedIntegerValue] > 0) {
       indicator = [self warningIndicatorString];
     } else {
       indicator = [self passIndicatorString];


### PR DESCRIPTION
This fixes #262.

Tested by changing a Run Script to emit strings in the form of "error:
blah" and "warning: "blah", and verified that xctool reported failure
and warnings correctly.
