### PR TITLE
Set device name if runner is of type OCUnitIOSAppTestRunner

### DIFF
--- a/xctool/xctool/RunTestsAction.m
+++ b/xctool/xctool/RunTestsAction.m
@@ -520,6 +520,10 @@ typedef BOOL (^TestableBlock)(NSArray *reporters);
                                      reporters:reporters] autorelease];
     [testRunner setCpuType:_cpuType];
 
+    if(_deviceName != nil && [testRunner isKindOfClass:[OCUnitIOSAppTestRunner class]]) {
+      [(OCUnitIOSAppTestRunner *)testRunner setDeviceName:_deviceName];
+    }
+
     PublishEventToReporters(reporters,
                             [[self class] eventForBeginOCUnitFromTestableExecutionInfo:testableExecutionInfo]);
 


### PR DESCRIPTION
The device name setting pulled from -destination wasn't getting carried all the way through to the test runner. This is a partial fix for issue #275 
