### PR TITLE
Don’t override PATH when calling xcodebuild

### DIFF
--- a/xctool/xctool/XCToolUtil.m
+++ b/xctool/xctool/XCToolUtil.m
@@ -390,7 +390,6 @@ BOOL RunXcodebuildAndFeedEventsToReporters(NSArray *arguments,
   [environment addEntriesFromDictionary:@{
    @"DYLD_INSERT_LIBRARIES" : [XCToolLibPath()
                                stringByAppendingPathComponent:@"xcodebuild-shim.dylib"],
-   @"PATH": @"/usr/bin:/bin:/usr/sbin:/sbin",
    }];
   [task setEnvironment:environment];
 


### PR DESCRIPTION
The builds on my continuous integration server are failing because they rely on the `PATH` to be set appropriately, and `xctool` overrides it.

I tried removing this line, and all the tests pass:

```
./xctool.sh -workspace xctool.xcworkspace -scheme xctool test

[lots of output]

** TEST SUCCEEDED: 191 passed, 0 failed, 0 errored, 191 total ** (43912 ms)
```

If this is not desired, I have another change that would add `/usr/bin`, `/bin`, `/usr/sbin`, and `/sbin` to the `PATH` instead of overriding the `PATH` entirely.
