### PR TITLE
Update PATH instead of overriding it

### DIFF
--- a/xctool/xctool/XCToolUtil.m
+++ b/xctool/xctool/XCToolUtil.m
@@ -390,7 +390,6 @@ BOOL RunXcodebuildAndFeedEventsToReporters(NSArray *arguments,
   [environment addEntriesFromDictionary:@{
    @"DYLD_INSERT_LIBRARIES" : [XCToolLibPath()
                                stringByAppendingPathComponent:@"xcodebuild-shim.dylib"],
-   @"PATH": @"/usr/bin:/bin:/usr/sbin:/sbin",
    }];
   [task setEnvironment:environment];
 


### PR DESCRIPTION
The builds on my continuous integration server are failing because they rely on the `PATH` being set appropriately, and `xctool` overrides it.

I changed the code to instead append the `/usr/bin`, `/bin`, `/usr/sbin`, and `/sbin` to the `PATH` instead of overriding it entirely, and now everything works.
