### PR TITLE
[analyzer] Extract the type and category of bug reports

### DIFF
--- a/Common/ReporterEvents.h
+++ b/Common/ReporterEvents.h
@@ -128,6 +128,7 @@
 #define kReporter_AnalyzerResult_ColumnKey @"col"
 #define kReporter_AnalyzerResult_DescriptionKey @"description"
 #define kReporter_AnalyzerResult_ContextKey @"context"
+#define kReporter_AnalyzerResult_CategoryKey @"category"
+#define kReporter_AnalyzerResult_TypeKey @"type"
 
 #define kReporter_OutputBeforeTestBundleStarts_OutputKey @"output"
-

--- a/xctool/xctool/AnalyzeAction.m
+++ b/xctool/xctool/AnalyzeAction.m
@@ -184,6 +184,8 @@
       NSNumber *line = diag[@"location"][@"line"];
       NSNumber *col = diag[@"location"][@"col"];
       NSString *desc = diag[@"description"];
+      NSString *category = diag[@"category"];
+      NSString *type = diag[@"type"];
       NSArray *context = [self.class contextFromDiagPath:diag[@"path"]
                                                  fileMap:diags[@"files"]];
 
@@ -196,6 +198,8 @@
           kReporter_AnalyzerResult_ColumnKey: col,
           kReporter_AnalyzerResult_DescriptionKey: desc,
           kReporter_AnalyzerResult_ContextKey: context,
+          kReporter_AnalyzerResult_CategoryKey: category,
+          kReporter_AnalyzerResult_TypeKey: type,
           }));
     }
   }


### PR DESCRIPTION
Extract the type and category of bug reports as well from the analyzer plist files

This is based on my observation of such an entry in the plist files:

```
{
  "clang_version" => "..."
  "files" => [
    0 => "..."
  ]
  "diagnostics" => [
    0 => {
      "category" => "..."
      "location" => {
        "col" => 17
        "file" => 0
        "line" => 53
      }
      "path" => [
        0 => {
          "location" => {
            "col" => 17
            "file" => 0
            "line" => 53
          }
          "depth" => 0
          "extended_message" => "xxx'"
          "message" => "xxx'"
          "kind" => "event"
        }
      ]
      "description" => "xxx"
      "type" => "yyy"
    }
  ]
}
```
