### PR TITLE
Synchronize standard user defaults after clearing filter testcases key.

### DIFF
--- a/otest-query/otest-query/OtestQuery.m
+++ b/otest-query/otest-query/OtestQuery.m
@@ -88,6 +88,7 @@
   // By clearing the preference, we can prevent tests from running.
   [[NSUserDefaults standardUserDefaults] removeObjectForKey:
    [framework objectForKey:kTestingFrameworkFilterTestArgsKey]];
+  [[NSUserDefaults standardUserDefaults] synchronize];
 
   // We use dlopen() instead of -[NSBundle loadAndReturnError] because, if
   // something goes wrong, dlerror() gives us a much more helpful error message.


### PR DESCRIPTION
After removing object from standard user defaults it is safer to synchronize user defaults immediately as we couldn't be sure that defaults are updated before `dlopen()` is executed.
