### PR TITLE
Add "error" attribute to testcase element in JUnit reporter

### DIFF
--- a/reporters/junit/JUnitReporter.m
+++ b/reporters/junit/JUnitReporter.m
@@ -173,6 +173,14 @@
                                                            stringValue:exception[kReporter_EndTest_Exception_ReasonKey]]]];
           [testcaseElement addChild:failureElement];
         }
+
+        if ([testResult[kReporter_EndTest_ResultKey] isEqualToString:@"error"]) {
+          NSXMLElement *errorElement = [NSXMLElement elementWithName:@"error"
+                                                           stringValue:nil];
+          [errorElement setAttributes:@[[NSXMLNode attributeWithName:@"type"
+                                                           stringValue:@"Error"]]];
+          [testcaseElement addChild:errorElement];
+        }
       }
 
       NSString *output = testResult[kReporter_EndTest_OutputKey];


### PR DESCRIPTION
If test result is `"error"` we are now adding new xml element to testcase element in JUnit reporter. Name of the element is `"error"` and `type` attribute is `"Error"`.
