### PR TITLE
Refactor OCTestSuiteEventState. Move publishing of events to reporters from OCUnitTestRunner to OCTestSuiteEventState and TestRunState.

### DIFF
--- a/xctool/xctool/OCTestSuiteEventState.h
+++ b/xctool/xctool/OCTestSuiteEventState.h
@@ -28,8 +28,8 @@
 - (instancetype)initWithName:(NSString *)name
                    reporters:(NSArray *)reporters;
 
-- (void)beginTestSuite;
-- (void)endTestSuite;
+- (void)beginTestSuite:(NSDictionary *)event;
+- (void)endTestSuite:(NSDictionary *)event;
 - (void)insertTest:(OCTestEventState *)test atIndex:(NSUInteger)index;
 - (void)addTest:(OCTestEventState *)test;
 - (void)addTestsFromArray:(NSArray *)tests;

--- a/xctool/xctool/OCTestSuiteEventState.m
+++ b/xctool/xctool/OCTestSuiteEventState.m
@@ -19,6 +19,15 @@
 #import "EventGenerator.h"
 #import "ReporterEvents.h"
 
+@interface OCTestSuiteEventState ()
+{
+  double _totalDuration;
+}
+
+@property (nonatomic, retain) NSDictionary *beginTestSuiteInfo;
+
+@end
+
 @implementation OCTestSuiteEventState
 
 - (instancetype)initWithName:(NSString *)name
@@ -41,35 +50,48 @@
 {
   [_testName release];
   [_tests release];
+  [_beginTestSuiteInfo release];
   [super dealloc];
 }
 
-- (void)beginTestSuite
+- (void)beginTestSuite:(NSDictionary *)event
 {
   NSAssert(!_isStarted, @"Test should not have started yet.");
   _isStarted = true;
+  self.beginTestSuiteInfo = event;
+
+  [self publishWithEvent:event];
 }
 
-- (void)endTestSuite
+- (void)endTestSuite:(NSDictionary *)event
 {
   NSAssert(_isStarted, @"Test must have already started.");
   _isFinished = true;
+
+  _totalDuration = [event[kReporter_TimestampKey] doubleValue] - [_beginTestSuiteInfo[kReporter_TimestampKey] doubleValue];
+
+  NSMutableDictionary *finalEvent = [[event mutableCopy] autorelease];
+  finalEvent[kReporter_EndTestSuite_TestCaseCountKey] = @([self testCount]);
+  finalEvent[kReporter_EndTestSuite_TotalFailureCountKey] = @([self totalFailures]);
+  finalEvent[kReporter_EndTestSuite_UnexpectedExceptionCountKey] = @([self totalErrors]);
+  finalEvent[kReporter_EndTestSuite_TestDurationKey] = @([self testDuration]);
+  finalEvent[kReporter_EndTestSuite_TotalDurationKey] = @([self totalDuration]);
+  [self publishWithEvent:finalEvent];
 }
 
 - (void)publishEvents
 {
   if (!_isStarted) {
-    [self publishWithEvent:
+    NSDictionary *event =
       EventDictionaryWithNameAndContent(kReporter_Events_BeginTestSuite,
-        @{kReporter_BeginTestSuite_SuiteKey:self.testName})
-    ];
-    [self beginTestSuite];
+        @{kReporter_BeginTestSuite_SuiteKey:self.testName});
+    [self beginTestSuite:event];
   }
 
   [_tests makeObjectsPerformSelector:@selector(publishEvents)];
 
   if (!_isFinished) {
-    [self publishWithEvent:
+    NSDictionary *event =
       EventDictionaryWithNameAndContent(kReporter_Events_EndTestSuite, @{
         kReporter_EndTestSuite_SuiteKey:self.testName,
         kReporter_EndTestSuite_TestCaseCountKey:@([self testCount]),
@@ -77,8 +99,8 @@
         kReporter_EndTestSuite_UnexpectedExceptionCountKey:@([self totalErrors]),
         kReporter_EndTestSuite_TotalDurationKey:@([self totalDuration]),
         kReporter_EndTestSuite_TestDurationKey:@([self testDuration]),
-    })];
-    [self endTestSuite];
+    });
+    [self endTestSuite:event];
   }
 }
 
@@ -179,7 +201,7 @@
 
 - (double)totalDuration
 {
-  return [self testDuration];
+  return _totalDuration;
 }
 
 - (unsigned int)testCount

--- a/xctool/xctool/OCUnitTestRunner.m
+++ b/xctool/xctool/OCUnitTestRunner.m
@@ -123,10 +123,7 @@
   TestRunState *testRunState = [[[TestRunState alloc] initWithTests:_focusedTestCases reporters:_reporters] autorelease];
 
   void (^feedOutputToBlock)(NSString *) = ^(NSString *line) {
-    NSData *lineData = [line dataUsingEncoding:NSUTF8StringEncoding];
-
     [testRunState parseAndHandleEvent:line];
-    [_reporters makeObjectsPerformSelector:@selector(publishDataForEvent:) withObject:lineData];
   };
 
   NSString *runTestsError = nil;

--- a/xctool/xctool/TestRunState.m
+++ b/xctool/xctool/TestRunState.m
@@ -72,6 +72,11 @@
   _crashReportsAtStart = [[NSSet setWithArray:[self collectCrashReportPaths]] retain];
 }
 
+- (void)publishEventToReporters:(NSDictionary *)event
+{
+  PublishEventToReporters(_testSuiteState.reporters, event);
+}
+
 - (void)outputBeforeTestBundleStarts:(NSDictionary *)event
 {
   [_outputBeforeTestsStart appendString:event[kReporter_OutputBeforeTestBundleStarts_OutputKey]];
@@ -84,7 +89,7 @@
            @"Expected to begin test suite `%@', got `%@'",
            kReporter_TestSuite_TopLevelSuiteName, event[kReporter_BeginTestSuite_SuiteKey]);
 
-  [_testSuiteState beginTestSuite];
+  [_testSuiteState beginTestSuite:event];
 }
 
 - (void)beginTest:(NSDictionary *)event
@@ -94,6 +99,8 @@
   OCTestEventState *state = [_testSuiteState getTestWithTestName:testName];
   NSAssert(state, @"Can't find test state for '%@', check senTestList", testName);
   [state stateBeginTest];
+
+  [self publishEventToReporters:event];
 }
 
 - (void)endTest:(NSDictionary *)event
@@ -111,11 +118,13 @@
     _previousTestState = nil;
   }
   _previousTestState = [state retain];
+
+  [self publishEventToReporters:event];
 }
 
 - (void)endTestSuite:(NSDictionary *)event
 {
-  [_testSuiteState endTestSuite];
+  [_testSuiteState endTestSuite:event];
 }
 
 - (void)testOutput:(NSDictionary *)event


### PR DESCRIPTION
Refactor test suite event state to support errored tests and publish full statistics to reporters. This will fix `JUnit` reporter - it will print correct error and failure count info for test suite.
Publish suite events to reporters in `OCTestSuiteEventState` and test events in `TestRunState` rather then in `OCUnitTestRunner`.
