### PR TITLE
[WIP] fix build on iOS 7.1+

### DIFF
--- a/xctool/iPhoneSimulatorRemoteClient/iPhoneSimulatorRemoteClient.h
+++ b/xctool/iPhoneSimulatorRemoteClient/iPhoneSimulatorRemoteClient.h
@@ -1,9 +1,9 @@
 #import <Cocoa/Cocoa.h>
 
 /*
- * File: /Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks/iPhoneSimulatorRemoteClient.framework/Versions/A/iPhoneSimulatorRemoteClient
+ * File: /Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks/DVTiPhoneSimulatorRemoteClient.framework/Versions/A/DVTiPhoneSimulatorRemoteClient
  * Arch: Intel 80x86 (i386)
- *       Current version: 12.0.0, Compatibility version: 1.0.0
+ *       Current version: 5.1
  */
 
 @class DTiPhoneSimulatorSession;

--- a/xctool/xctool-tests.xcconfig
+++ b/xctool/xctool-tests.xcconfig
@@ -16,8 +16,8 @@
 
 DEVELOPER_PRIVATE_FRAMEWORK_DIR = "$(DEVELOPER_DIR)"/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks
 
-// xctool-tests will strongly link iPhoneSimulatorRemoteClient - we don't need
+// xctool-tests will strongly link DVTiPhoneSimulatorRemoteClient - we don't need
 // the same dynamic loading magic that the main 'xctool' executable needs.
-OTHER_LDFLAGS = -F$(DEVELOPER_PRIVATE_FRAMEWORK_DIR) -framework iPhoneSimulatorRemoteClient -Wl,-rpath -Wl,$(DEVELOPER_PRIVATE_FRAMEWORK_DIR) -Wl,-rpath -Wl,"$(DEVELOPER_DIR)"/../OtherFrameworks
+OTHER_LDFLAGS = -F$(DEVELOPER_PRIVATE_FRAMEWORK_DIR) -framework DVTiPhoneSimulatorRemoteClient -Wl,-rpath -Wl,$(DEVELOPER_PRIVATE_FRAMEWORK_DIR) -Wl,-rpath -Wl,"$(DEVELOPER_DIR)"/../OtherFrameworks
 
 FRAMEWORK_SEARCH_PATHS = "$(DEVELOPER_LIBRARY_DIR)/Frameworks" "$(SRCROOT)/../Vendor"

--- a/xctool/xctool.xcconfig
+++ b/xctool/xctool.xcconfig
@@ -21,9 +21,9 @@ XT_INSTALL_DIR = bin
 
 DEVELOPER_PRIVATE_FRAMEWORK_DIR = "$(DEVELOPER_DIR)"/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks
 
-// xctool will weak link iPhoneSimulatorRemoteClient, and then configure the necessary
+// xctool will weak link DVTiPhoneSimulatorRemoteClient, and then configure the necessary
 // DYLD paths on startup to make sure the framework can be loaded.
-OTHER_LDFLAGS = -F$(DEVELOPER_PRIVATE_FRAMEWORK_DIR) -weak_framework iPhoneSimulatorRemoteClient
+OTHER_LDFLAGS = -F$(DEVELOPER_PRIVATE_FRAMEWORK_DIR) -weak_framework DVTiPhoneSimulatorRemoteClient
 
 FRAMEWORK_SEARCH_PATHS = "$(DEVELOPER_LIBRARY_DIR)/Frameworks" "$(SRCROOT)/../Vendor"
 

--- a/xctool/xctool/OCUnitIOSAppTestRunner.m
+++ b/xctool/xctool/OCUnitIOSAppTestRunner.m
@@ -188,7 +188,7 @@ static void KillSimulatorJobs()
 }
 
 /**
- * Use the iPhoneSimulatorRemoteClient framework to start the app in the sim,
+ * Use the DVTiPhoneSimulatorRemoteClient framework to start the app in the sim,
  * inject otest-shim into the app as it starts, and feed line-by-line output to
  * the `feedOutputToBlock`.
  *

--- a/xctool/xctool/main.m
+++ b/xctool/xctool/main.m
@@ -22,14 +22,14 @@
 int main(int argc, const char * argv[])
 {
   @autoreleasepool {
-    // xctool depends on iPhoneSimulatorRemoteClient.framework, which is a private
+    // xctool depends on DVTiPhoneSimulatorRemoteClient.framework, which is a private
     // framework for interacting with the simulator that comes bundled with
     // Xcode.
     //
     // Since xctool can work with multiple verstions of Xcode and since each of
     // these Xcode versions might live at different paths, we don't want to strongly
-    // link iPhoneSimulatorRemoteClient.framework.  e.g., if we linked to
-    // `/Applications/Xcode.app/.../.../iPhoneSimulatorRemoteClient.framework`
+    // link DVTiPhoneSimulatorRemoteClient.framework.  e.g., if we linked to
+    // `/Applications/Xcode.app/.../.../DVTiPhoneSimulatorRemoteClient.framework`
     // but Xcode was installed elsewhere, xctool would fail to run.
     //
     // To workaround this, we weak link the framework and at startup, we tweak
@@ -57,9 +57,9 @@ int main(int argc, const char * argv[])
       }
 
       fallbackFrameworkPath = [fallbackFrameworkPath stringByAppendingFormat:@":%@:%@",
-                               // The path to iPhoneSimulatorRemoteClient.framework.
+                               // The path to DVTiPhoneSimulatorRemoteClient.framework.
                                [developerDirPath stringByAppendingPathComponent:@"Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks"],
-                               // The path to other dependencies of iPhoneSimulatorRemoteClient.framework.
+                               // The path to other dependencies of DVTiPhoneSimulatorRemoteClient.framework.
                                [developerDirPath stringByAppendingPathComponent:@"../OtherFrameworks"]
                                ];
       setenv(dyldFallbackFrameworkPathKey, [fallbackFrameworkPath UTF8String], 1);


### PR DESCRIPTION
It seems iPhoneSimulatorRemoteClient.framework was renamed to DVTiPhoneSimulatorRemoteClient on the latest iOS - when trying to install xctool, I got this:

```
=== BUILD TARGET xctool OF PROJECT xctool WITH CONFIGURATION Release ===

Check dependencies

Ld /usr/local/Cellar/xctool/HEAD/libexec/bin/xctool normal x86_64
    cd /Library/Caches/Homebrew/xctool--git/xctool
    export MACOSX_DEPLOYMENT_TARGET=10.7
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++ -arch x86_64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk -L/Library/Caches/Homebrew/xctool--git/build/dc4b35f/Products/Release -F/Library/Caches/Homebrew/xctool--git/build/dc4b35f/Products/Release -F/Applications/Xcode.app/Contents/Developer/Library/Frameworks -F/Library/Caches/Homebrew/xctool--git/xctool/../Vendor -filelist /Library/Caches/Homebrew/xctool--git/build/dc4b35f/Intermediates/xctool.build/Release/xctool.build/Objects-normal/x86_64/xctool.LinkFileList -mmacosx-version-min=10.7 -F/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks -weak_framework iPhoneSimulatorRemoteClient -fobjc-link-runtime -stdlib=libc++ -framework QuartzCore -framework Foundation -Xlinker -dependency_info -Xlinker /Library/Caches/Homebrew/xctool--git/build/dc4b35f/Intermediates/xctool.build/Release/xctool.build/Objects-normal/x86_64/xctool_dependency_info.dat -o /usr/local/Cellar/xctool/HEAD/libexec/bin/xctool
ld: framework not found iPhoneSimulatorRemoteClient
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Fixing the framework name fixes that and it builds fine.
