### PR TITLE
[TextReporter] Print oc unit errors in the failures section

### DIFF
--- a/reporters/text/TextReporter.h
+++ b/reporters/text/TextReporter.h
@@ -39,6 +39,7 @@
 @property (nonatomic, copy) NSString *currentBundle;
 @property (nonatomic, retain) NSMutableArray *analyzerWarnings;
 @property (nonatomic, retain) NSMutableArray *failedBuildEvents;
+@property (nonatomic, retain) NSMutableArray *failedOcunitEvents;
 
 /**
  Returns an NSString that contains lines of context around errorLine with a mark at colNumber.


### PR DESCRIPTION
When oc unit error occurs (unable to read build settings for target, fails to query the list of test cases in the test bundle, test bundle contained no tests) the error details are printed only in the stream but aren't then repeated in the failures section. That results in the simple messages like `** TEST FAILED: N passed, 0 failed, 0 errored, N total **` without summarizing failures.
This commit fixes such situations.
