### PR TITLE
Improve iPhone simulator system root sdk selection. Code cleaning.

### DIFF
--- a/reporters/json-compilation-database/JSONCompilationDatabaseReporter.m
+++ b/reporters/json-compilation-database/JSONCompilationDatabaseReporter.m
@@ -113,7 +113,7 @@
   NSArray *eventBuildcommands = [eventBuildCommand componentsSeparatedByString:@"\n"];
   NSString *rawWorkingDirectory = [eventBuildcommands[1] strip];
   NSString *rawCompilerCommand = nil;
-  
+
   // We know the first line is event tile, the second one is to change to the working directory
   // so we start with the third line, discard lines of setting env variables, then it's compiler command
   for (int i = 2; i < [eventBuildcommands count]; i++) {

--- a/sim-shim/sim-shim/sim_shim.m
+++ b/sim-shim/sim-shim/sim_shim.m
@@ -101,7 +101,7 @@ DYLD_INTERPOSE(__launch_msg, launch_msg);
 // In iOS 6, `sim` doesn't have to call GetJobs to look up the bootstrap name
 // since it's always constant.  Let's prevent it from over reaching that mach
 // service.
-kern_return_t	__bootstrap_look_up(mach_port_t bp, const name_t service_name, mach_port_t *sp) {
+kern_return_t __bootstrap_look_up(mach_port_t bp, const name_t service_name, mach_port_t *sp) {
   if (strcmp(service_name, "com.apple.iphonesimulator.bootstrap_subset") == 0) {
     return BOOTSTRAP_UNKNOWN_SERVICE;
   } else {

--- a/xctool/SimulatorHost/ISHDeviceInfo.h
+++ b/xctool/SimulatorHost/ISHDeviceInfo.h
@@ -4,10 +4,6 @@
 //     class-dump is Copyright (C) 1997-1998, 2000-2001, 2004-2013 by Steve Nygard.
 //
 
-#import <objc/NSObject.h>
-
-@class NSArray, NSDictionary, NSImage, NSSet, NSString;
-
 @interface ISHDeviceInfo : NSObject
 {
     BOOL _canTether;

--- a/xctool/SimulatorHost/ISHDeviceVersions.h
+++ b/xctool/SimulatorHost/ISHDeviceVersions.h
@@ -4,10 +4,6 @@
 //     class-dump is Copyright (C) 1997-1998, 2000-2001, 2004-2013 by Steve Nygard.
 //
 
-#import <objc/NSObject.h>
-
-@class NSMutableDictionary, NSString;
-
 @interface ISHDeviceVersions : NSObject
 {
     BOOL _allowOther;

--- a/xctool/SimulatorHost/ISHSDKInfo.h
+++ b/xctool/SimulatorHost/ISHSDKInfo.h
@@ -4,10 +4,6 @@
 //     class-dump is Copyright (C) 1997-1998, 2000-2001, 2004-2013 by Steve Nygard.
 //
 
-#import <objc/NSObject.h>
-
-@class NSDictionary, NSString;
-
 @interface ISHSDKInfo : NSObject
 {
     BOOL _usesLegacyPathInfoStruct;

--- a/xctool/xctool-tests/OCUnitTestRunnerTests.m
+++ b/xctool/xctool-tests/OCUnitTestRunnerTests.m
@@ -1,9 +1,8 @@
 
 #import <SenTestingKit/SenTestingKit.h>
 
-#import "DTiPhoneSimulatorRemoteClient.h"
-
 #import "ContainsArray.h"
+#import "DTiPhoneSimulatorRemoteClient.h"
 #import "EventBuffer.h"
 #import "FakeTask.h"
 #import "FakeTaskManager.h"

--- a/xctool/xctool/Options.m
+++ b/xctool/xctool/Options.m
@@ -539,7 +539,7 @@
         if (sdksAndAliases[possibleSdk]) {
           self.sdk = possibleSdk;
         }
-      }    
+      }
     }
   }
 


### PR DESCRIPTION
If sdk version is, for example, `7.0.3` and available system root sdk is `7.0` then `[DTiPhoneSimulatorSystemRoot rootWithSDKVersion:sdkVersion];` returns `nil`. To fix that we are now additionally looping through all sdks in `[[ISHDeviceVersions sharedInstance] allSDKs]` and comparing `shortVersionString` with sdk version.

Also removed useless imports and class definitions in `ISH*` headers and fixed import order and spaces usage in some other files.
