### PR TITLE
Add user notifications reporter which sends notifications to NSUserNotificationCenter after an action succeeded or failed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,8 @@ Started](http://about.travis-ci.org/docs/user/getting-started/) page.
 ## Reporters
 
 xctool has reporters that output build and test results in different
-formats.  By default, _xctool_ always uses the `pretty` reporter.
+formats.  By default, _xctool_ always uses the `pretty` and 
+`user-notifications` reporters.
 
 You can change or add reporters with the `-reporter` option:
 
@@ -347,6 +348,7 @@ results.
 one per line [(example
 output)](https://gist.github.com/fpotter/82ffcc3d9a49d10ee41b).
 * __json-compilation-database__: outputs a [JSON Compilation Database](http://clang.llvm.org/docs/JSONCompilationDatabase.html) of build events which can be used by [Clang Tooling](http://clang.llvm.org/docs/LibTooling.html) based tools, e.g. [OCLint](http://oclint.org).
+* __user-notifications__: sends notification to Notification Center when action is completed [(example notifications)](https://cloud.githubusercontent.com/assets/1044236/2771974/a2715306-ca74-11e3-9889-fa50607cc412.png).
 
 ### Implementing Your Own Reporters
 

--- a/reporters/reporters.xcodeproj/project.pbxproj
+++ b/reporters/reporters.xcodeproj/project.pbxproj
@@ -53,6 +53,12 @@
 		3892D7541815A13400E68652 /* EventGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 3892D74F1815A13400E68652 /* EventGenerator.m */; };
 		3892D7551815A13400E68652 /* EventGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 3892D74F1815A13400E68652 /* EventGenerator.m */; };
 		3892D7561815A13400E68652 /* EventGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 3892D74F1815A13400E68652 /* EventGenerator.m */; };
+		CC8AA20618F368EE00D9F322 /* user-notifications-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = CC8AA20518F368EE00D9F322 /* user-notifications-Info.plist */; };
+		CCC0AAF418EC8A92004FD861 /* UserNotificationsReporter.m in Sources */ = {isa = PBXBuildFile; fileRef = CCC0AAF318EC8A92004FD861 /* UserNotificationsReporter.m */; };
+		CCC0AAF818EC8AC4004FD861 /* Reporter.m in Sources */ = {isa = PBXBuildFile; fileRef = EE61734617E284DD00F02C91 /* Reporter.m */; };
+		CCC0AAFB18EC8AC4004FD861 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2893A96A17960D2000EFBD28 /* Foundation.framework */; };
+		CCC0AB0218EC8C6A004FD861 /* UserNotificationsReporter.m in Sources */ = {isa = PBXBuildFile; fileRef = CCC0AAF318EC8A92004FD861 /* UserNotificationsReporter.m */; };
+		CCC0AB0518EC931C004FD861 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = CCC0AAED18EC8A1F004FD861 /* main.m */; };
 		EE61734717E284DD00F02C91 /* Reporter.m in Sources */ = {isa = PBXBuildFile; fileRef = EE61734617E284DD00F02C91 /* Reporter.m */; };
 		EE61734817E284DD00F02C91 /* Reporter.m in Sources */ = {isa = PBXBuildFile; fileRef = EE61734617E284DD00F02C91 /* Reporter.m */; };
 		EE61734917E284DD00F02C91 /* Reporter.m in Sources */ = {isa = PBXBuildFile; fileRef = EE61734617E284DD00F02C91 /* Reporter.m */; };
@@ -131,6 +137,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 		};
+		CCC0AAFC18EC8AC4004FD861 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 8;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
@@ -179,6 +194,12 @@
 		28F48A56179750A600068E00 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		3892D74E1815A13400E68652 /* EventGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = EventGenerator.h; path = ../Common/EventGenerator.h; sourceTree = "<group>"; };
 		3892D74F1815A13400E68652 /* EventGenerator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = EventGenerator.m; path = ../Common/EventGenerator.m; sourceTree = "<group>"; };
+		CC8AA20518F368EE00D9F322 /* user-notifications-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "user-notifications-Info.plist"; path = "user-notifications/user-notifications-Info.plist"; sourceTree = "<group>"; };
+		CCC0AAED18EC8A1F004FD861 /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = "user-notifications/main.m"; sourceTree = "<group>"; };
+		CCC0AAF218EC8A92004FD861 /* UserNotificationsReporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UserNotificationsReporter.h; path = "user-notifications/UserNotificationsReporter.h"; sourceTree = "<group>"; };
+		CCC0AAF318EC8A92004FD861 /* UserNotificationsReporter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = UserNotificationsReporter.m; path = "user-notifications/UserNotificationsReporter.m"; sourceTree = "<group>"; };
+		CCC0AB0018EC8AC4004FD861 /* user-notifications */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "user-notifications"; sourceTree = BUILT_PRODUCTS_DIR; };
+		CCC0AB0318EC9115004FD861 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
 		EE61734517E2785F00F02C91 /* Reporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Reporter.h; path = ../Common/Reporter.h; sourceTree = "<group>"; };
 		EE61734617E284DD00F02C91 /* Reporter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Reporter.m; path = ../Common/Reporter.m; sourceTree = "<group>"; };
 		EE9E73E117A7323B008A5ED2 /* TestResultCounter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestResultCounter.h; sourceTree = "<group>"; };
@@ -245,6 +266,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		CCC0AAFA18EC8AC4004FD861 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CCC0AAFB18EC8AC4004FD861 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -260,6 +289,7 @@
 				28F48A2417974D4100068E00 /* junit */,
 				28F48A3D17974EF600068E00 /* json-compilation-database */,
 				28F48A55179750A600068E00 /* json-stream */,
+				CCC0AAEC18EC89AE004FD861 /* user-notifications */,
 				2893A94E17960CD400EFBD28 /* Frameworks */,
 				2893A94D17960CD400EFBD28 /* Products */,
 			);
@@ -275,6 +305,7 @@
 				28F48A2217974D4100068E00 /* junit */,
 				28F48A3B17974EF600068E00 /* json-compilation-database */,
 				28F48A53179750A600068E00 /* json-stream */,
+				CCC0AB0018EC8AC4004FD861 /* user-notifications */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -397,6 +428,17 @@
 				28F48A56179750A600068E00 /* main.m */,
 			);
 			path = "json-stream";
+			sourceTree = "<group>";
+		};
+		CCC0AAEC18EC89AE004FD861 /* user-notifications */ = {
+			isa = PBXGroup;
+			children = (
+				CCC0AAED18EC8A1F004FD861 /* main.m */,
+				CCC0AAF218EC8A92004FD861 /* UserNotificationsReporter.h */,
+				CCC0AAF318EC8A92004FD861 /* UserNotificationsReporter.m */,
+				CC8AA20518F368EE00D9F322 /* user-notifications-Info.plist */,
+			);
+			name = "user-notifications";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -522,6 +564,23 @@
 			productReference = 28F48A53179750A600068E00 /* json-stream */;
 			productType = "com.apple.product-type.tool";
 		};
+		CCC0AAF518EC8AC4004FD861 /* user-notifications */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CCC0AAFD18EC8AC4004FD861 /* Build configuration list for PBXNativeTarget "user-notifications" */;
+			buildPhases = (
+				CCC0AAF618EC8AC4004FD861 /* Sources */,
+				CCC0AAFA18EC8AC4004FD861 /* Frameworks */,
+				CCC0AAFC18EC8AC4004FD861 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "user-notifications";
+			productName = "user-notifications";
+			productReference = CCC0AB0018EC8AC4004FD861 /* user-notifications */;
+			productType = "com.apple.product-type.tool";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -549,6 +608,7 @@
 				28F48A2117974D4100068E00 /* junit */,
 				28F48A3A17974EF600068E00 /* json-compilation-database */,
 				28F48A52179750A500068E00 /* json-stream */,
+				CCC0AAF518EC8AC4004FD861 /* user-notifications */,
 			);
 		};
 /* End PBXProject section */
@@ -558,6 +618,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CC8AA20618F368EE00D9F322 /* user-notifications-Info.plist in Resources */,
 				2893A95C17960CD400EFBD28 /* InfoPlist.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -584,6 +645,7 @@
 				28F48A4A17974F3F00068E00 /* JSONCompilationDatabaseReporter.m in Sources */,
 				28F48A4D17974FEB00068E00 /* JSONCompilationDatabaseReporterTests.m in Sources */,
 				EE9E73E317A7323B008A5ED2 /* TestResultCounter.m in Sources */,
+				CCC0AAF418EC8A92004FD861 /* UserNotificationsReporter.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -654,6 +716,16 @@
 				3892D7561815A13400E68652 /* EventGenerator.m in Sources */,
 				EE61734D17E284DD00F02C91 /* Reporter.m in Sources */,
 				28F48A57179750A600068E00 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CCC0AAF618EC8AC4004FD861 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CCC0AB0518EC931C004FD861 /* main.m in Sources */,
+				CCC0AB0218EC8C6A004FD861 /* UserNotificationsReporter.m in Sources */,
+				CCC0AAF818EC8AC4004FD861 /* Reporter.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1102,6 +1174,77 @@
 			};
 			name = Release;
 		};
+		CCC0AAFE18EC8AC4004FD861 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "user-notifications/user-notifications-Info.plist";
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = (
+					"-sectcreate",
+					__TEXT,
+					__info_plist,
+					"$(INFOPLIST_FILE)",
+				);
+				PRODUCT_NAME = "user-notifications";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		CCC0AAFF18EC8AC4004FD861 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_64_BIT)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = "user-notifications/user-notifications-Info.plist";
+				OTHER_LDFLAGS = (
+					"-sectcreate",
+					__TEXT,
+					__info_plist,
+					"$(INFOPLIST_FILE)",
+				);
+				PRODUCT_NAME = "user-notifications";
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1173,6 +1316,15 @@
 			buildConfigurations = (
 				28F48A5D179750A600068E00 /* Debug */,
 				28F48A5E179750A600068E00 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CCC0AAFD18EC8AC4004FD861 /* Build configuration list for PBXNativeTarget "user-notifications" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CCC0AAFE18EC8AC4004FD861 /* Debug */,
+				CCC0AAFF18EC8AC4004FD861 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/reporters/user-notifications/UserNotificationsReporter.h
+++ b/reporters/user-notifications/UserNotificationsReporter.h
@@ -1,0 +1,23 @@
+//
+// Copyright 2013 Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "Reporter.h"
+
+@interface UserNotificationsReporter : Reporter
+
+@end

--- a/reporters/user-notifications/UserNotificationsReporter.m
+++ b/reporters/user-notifications/UserNotificationsReporter.m
@@ -1,0 +1,110 @@
+//
+// Copyright 2013 Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "UserNotificationsReporter.h"
+
+#import "ReporterEvents.h"
+
+@interface UserNotificationsReporter ()
+@property (nonatomic, copy) NSString *mainProjectName;
+@property (nonatomic, copy) NSString *mainProjectPath;
+@property (nonatomic, copy) NSString *mainWorkspaceName;
+@property (nonatomic, copy) NSString *mainWorkspacePath;
+@end
+
+@implementation UserNotificationsReporter
+
+- (void)dealloc
+{
+  [_mainProjectName release];
+  [_mainProjectPath release];
+  [_mainWorkspaceName release];
+  [_mainWorkspacePath release];
+  
+  [super dealloc];
+}
+
+- (void)beginAction:(NSDictionary *)event
+{
+  if (_mainProjectPath || _mainWorkspacePath) {
+    return;
+  }
+
+  self.mainProjectPath = event[kReporter_BeginAction_ProjectKey];
+  if ([_mainProjectPath isKindOfClass:[NSString class]]) {
+    self.mainProjectName = [[_mainProjectPath lastPathComponent] stringByDeletingPathExtension];
+  } else {
+    self.mainProjectPath = nil;
+    self.mainProjectName = nil;
+  }
+
+  self.mainWorkspacePath = event[kReporter_BeginAction_WorkspaceKey];
+  if ([_mainWorkspacePath isKindOfClass:[NSString class]]) {
+    self.mainWorkspaceName = [[_mainWorkspacePath lastPathComponent] stringByDeletingPathExtension];
+  } else {
+    self.mainWorkspacePath = nil;
+    self.mainWorkspaceName = nil;
+  }
+}
+
+- (void)endAction:(NSDictionary *)event
+{
+  if (_mainWorkspacePath) {
+    if (![event[kReporter_EndAction_WorkspaceKey] isEqual:_mainWorkspacePath]) {
+      return;
+    }
+  }
+
+  if (_mainProjectPath) {
+    if (![event[kReporter_EndAction_ProjectKey] isEqual:_mainProjectPath]) {
+      return;
+    }
+  }
+
+  NSString *name = event[kReporter_EndAction_NameKey];
+  NSString *schemeName = event[kReporter_EndAction_SchemeKey] ?: @"";
+  BOOL succeeded = [event[kReporter_EndAction_SucceededKey] boolValue];
+  NSString *status = succeeded ? @"Succeeded" : @"Failed";
+
+  [self deliverNotificationWithTitle:[NSString stringWithFormat:@"%@ %@", [name capitalizedString], status]
+                            subtitle:[NSString stringWithFormat:@"%@ | %@ Scheme", _mainProjectName ?: _mainWorkspaceName, schemeName]
+                             message:nil
+                             options:@{}
+                               sound:NSUserNotificationDefaultSoundName];
+}
+
+#pragma mark -
+#pragma mark Private methods
+
+- (void)deliverNotificationWithTitle:(NSString *)title
+                            subtitle:(NSString *)subtitle
+                             message:(NSString *)message
+                             options:(NSDictionary *)options
+                               sound:(NSString *)sound;
+{
+  NSUserNotification *userNotification = [[NSUserNotification alloc] init];
+  userNotification.title = title;
+  userNotification.subtitle = subtitle;
+  userNotification.informativeText = message;
+  userNotification.userInfo = options;
+  userNotification.soundName = sound;
+
+  NSUserNotificationCenter *center = [NSUserNotificationCenter defaultUserNotificationCenter];
+  [center scheduleNotification:userNotification];
+  [userNotification release];
+}
+
+@end

--- a/reporters/user-notifications/main.m
+++ b/reporters/user-notifications/main.m
@@ -1,0 +1,28 @@
+//
+// Copyright 2013 Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "UserNotificationsReporter.h"
+
+int main(int argc, const char * argv[])
+{
+  @autoreleasepool {
+    [UserNotificationsReporter readFromInput:[NSFileHandle fileHandleWithStandardInput]
+                                 andOutputTo:[NSFileHandle fileHandleWithStandardOutput]];
+  }
+  return 0;
+}

--- a/reporters/user-notifications/user-notifications-Info.plist
+++ b/reporters/user-notifications/user-notifications-Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleIdentifier</key>
+	<string>com.facebook.xctool</string>
+</dict>
+</plist>

--- a/xctool/xctool-tests/ArchiveActionTests.m
+++ b/xctool/xctool-tests/ArchiveActionTests.m
@@ -27,6 +27,7 @@
     tool.arguments = @[@"-project", TEST_DATA @"TestProject-Library/TestProject-Library.xcodeproj",
                        @"-scheme", @"TestProject-Library",
                        @"archive",
+                       @"-reporter", @"plain",
                        ];
 
     [TestUtil runWithFakeStreams:tool];
@@ -68,6 +69,7 @@
     tool.arguments = @[@"-project", TEST_DATA @"TestProject-App-OSX/TestProject-App-OSX.xcodeproj",
                        @"-scheme", @"TestProject-App-OSX",
                        @"archive",
+                       @"-reporter", @"plain",
                        ];
 
     NSDictionary *output = [TestUtil runWithFakeStreams:tool];
@@ -103,6 +105,7 @@
     tool.arguments = @[@"-project", TEST_DATA @"TestProject-App-OSX/TestProject-App-OSX.xcodeproj",
                        @"-scheme", @"TestProject-App-OSX",
                        @"archive",
+                       @"-reporter", @"plain",
                        ];
 
     NSDictionary *output = [TestUtil runWithFakeStreams:tool];
@@ -127,6 +130,7 @@
     tool.arguments = @[@"-project", TEST_DATA @"TestProject-Library-WithDifferentConfigurations/TestProject-Library.xcodeproj",
                        @"-scheme", @"TestProject-Library",
                        @"archive",
+                       @"-reporter", @"plain",
                        ];
 
     [TestUtil runWithFakeStreams:tool];

--- a/xctool/xctool-tests/BuildActionTests.m
+++ b/xctool/xctool-tests/BuildActionTests.m
@@ -56,6 +56,7 @@ void _CFAutoreleasePoolPrintPools();
                        @"-scheme", @"TestProject-Library",
                        @"-sdk", @"iphonesimulator6.0",
                        @"build",
+                       @"-reporter", @"plain",
                        ];
 
     [TestUtil runWithFakeStreams:tool];
@@ -87,6 +88,7 @@ void _CFAutoreleasePoolPrintPools();
     tool.arguments = @[@"-project", TEST_DATA @"TestProject-Library/TestProject-Library.xcodeproj",
                        @"-scheme", @"TestProject-Library",
                        @"build",
+                       @"-reporter", @"plain",
                        ];
 
     [TestUtil runWithFakeStreams:tool];
@@ -116,6 +118,7 @@ void _CFAutoreleasePoolPrintPools();
     tool.arguments = @[@"-workspace", TEST_DATA @"TestWorkspace-Library/TestWorkspace-Library.xcworkspace",
                        @"-scheme", @"TestProject-Library",
                        @"build",
+                       @"-reporter", @"plain",
                        ];
 
     [TestUtil runWithFakeStreams:tool];
@@ -146,6 +149,7 @@ void _CFAutoreleasePoolPrintPools();
                        @"-scheme", @"TestProject-Library",
                        @"-configuration", @"SOME_CONFIGURATION",
                        @"build",
+                       @"-reporter", @"plain",
                        ];
 
     [TestUtil runWithFakeStreams:tool];
@@ -183,6 +187,7 @@ void _CFAutoreleasePoolPrintPools();
       tool.arguments = @[@"-project", TEST_DATA @"TestProject-Library/TestProject-Library.xcodeproj",
                          @"-scheme", @"TestProject-Library",
                          @"build",
+                         @"-reporter", @"plain",
                          ];
 
       [TestUtil runWithFakeStreams:tool];
@@ -213,6 +218,7 @@ void _CFAutoreleasePoolPrintPools();
     tool.arguments = @[@"-project", TEST_DATA @"TestProject-Library-WithDifferentConfigurations/TestProject-Library.xcodeproj",
                        @"-scheme", @"TestProject-Library",
                        @"build",
+                       @"-reporter", @"plain",
                        ];
 
     [TestUtil runWithFakeStreams:tool];
@@ -242,6 +248,7 @@ void _CFAutoreleasePoolPrintPools();
     tool.arguments = @[@"-workspace", TEST_DATA @"ProjectsWithDifferentSDKs/ProjectsWithDifferentSDKs.xcworkspace",
                        @"-scheme", @"ProjectsWithDifferentSDKs",
                        @"build",
+                       @"-reporter", @"plain",
                        ];
 
     [TestUtil runWithFakeStreams:tool];

--- a/xctool/xctool-tests/BuildTestsActionTests.m
+++ b/xctool/xctool-tests/BuildTestsActionTests.m
@@ -115,7 +115,8 @@ static NSString *kTestWorkspaceTestProjectOtherLibTargetID      = @"28ADB45F16E4
                        @"-scheme", @"TestProject-Library",
                        @"-configuration", @"Debug",
                        @"-sdk", @"iphonesimulator6.0",
-                       @"build-tests"
+                       @"build-tests",
+                       @"-reporter", @"plain",
                        ];
 
     [Swizzler whileSwizzlingSelector:@selector(schemeGenerator)
@@ -175,7 +176,8 @@ static NSString *kTestWorkspaceTestProjectOtherLibTargetID      = @"28ADB45F16E4
                        @"-scheme", @"TestProject-Library",
                        @"-configuration", @"Debug",
                        @"-sdk", @"iphonesimulator6.0",
-                       @"build-tests"
+                       @"build-tests",
+                       @"-reporter", @"plain",
                        ];
 
     [Swizzler whileSwizzlingSelector:@selector(schemeGenerator)
@@ -243,7 +245,8 @@ static NSString *kTestWorkspaceTestProjectOtherLibTargetID      = @"28ADB45F16E4
                        @"-scheme", @"TestProject-Library",
                        @"-configuration", @"Debug",
                        @"-sdk", @"iphonesimulator6.0",
-                       @"build-tests", @"-only", @"TestProject-LibraryTests"
+                       @"build-tests", @"-only", @"TestProject-LibraryTests",
+                       @"-reporter", @"plain",
                        ];
 
     [Swizzler whileSwizzlingSelector:@selector(schemeGenerator)
@@ -308,7 +311,8 @@ static NSString *kTestWorkspaceTestProjectOtherLibTargetID      = @"28ADB45F16E4
                        @"-sdk", @"iphonesimulator6.0",
                        @"build-tests",
                        @"-only", @"TestProject-LibraryTests",
-                       @"-skip-deps"
+                       @"-skip-deps",
+                       @"-reporter", @"plain",
                        ];
 
     [Swizzler whileSwizzlingSelector:@selector(schemeGenerator)
@@ -359,6 +363,7 @@ static NSString *kTestWorkspaceTestProjectOtherLibTargetID      = @"28ADB45F16E4
     tool.arguments = @[@"-project", TEST_DATA @"TestProject-Library-WithDifferentConfigurations/TestProject-Library.xcodeproj",
                        @"-scheme", @"TestProject-Library",
                        @"build-tests",
+                       @"-reporter", @"plain",
                        ];
 
     [TestUtil runWithFakeStreams:tool];

--- a/xctool/xctool-tests/CleanActionTests.m
+++ b/xctool/xctool-tests/CleanActionTests.m
@@ -60,6 +60,7 @@
     tool.arguments = @[@"-project", TEST_DATA @"TestProject-Library/TestProject-Library.xcodeproj",
                        @"-scheme", @"TestProject-Library",
                        @"clean",
+                       @"-reporter", @"plain",
                        ];
 
     [Swizzler whileSwizzlingSelector:@selector(schemeGenerator)
@@ -105,6 +106,7 @@
     tool.arguments = @[@"-project", TEST_DATA @"TestProject-Library-WithDifferentConfigurations/TestProject-Library.xcodeproj",
                        @"-scheme", @"TestProject-Library",
                        @"clean",
+                       @"-reporter", @"plain",
                        ];
 
     [TestUtil runWithFakeStreams:tool];

--- a/xctool/xctool-tests/RunTestsActionTests.m
+++ b/xctool/xctool-tests/RunTestsActionTests.m
@@ -107,7 +107,8 @@
                        @"-project", TEST_DATA @"TestProjectWithSchemeThatReferencesNonExistentTestTarget/TestProject-Library.xcodeproj",
                        @"-scheme", @"TestProject-Library",
                        @"-sdk", @"iphonesimulator",
-                       @"test"
+                       @"test",
+                       @"-reporter", @"plain",
                        ];
 
     NSDictionary *output = [TestUtil runWithFakeStreams:tool];
@@ -153,7 +154,8 @@
     tool.arguments = @[@"-project", TEST_DATA @"TestProject-Library/TestProject-Library.xcodeproj",
                        @"-scheme", @"TestProject-Library",
                        @"-configuration", @"Debug",
-                       @"run-tests"
+                       @"run-tests",
+                       @"-reporter", @"plain",
                        ];
 
     NSDictionary *output = [TestUtil runWithFakeStreams:tool];
@@ -190,7 +192,8 @@
     tool.arguments = @[@"-project", TEST_DATA @"TestProject-Library-XCTest-iOS/TestProject-Library-XCTest-iOS.xcodeproj",
                        @"-scheme", @"TestProject-Library-XCTest-iOS",
                        @"-configuration", @"Debug",
-                       @"run-tests"
+                       @"run-tests",
+                       @"-reporter", @"plain",
                        ];
 
     NSDictionary *output = [TestUtil runWithFakeStreams:tool];
@@ -241,7 +244,8 @@
                        @"-scheme", @"TestProject-Library",
                        @"-configuration", @"Debug",
                        @"-sdk", @"iphonesimulator6.0",
-                       @"run-tests"
+                       @"run-tests",
+                       @"-reporter", @"plain",
                        ];
 
     [TestUtil runWithFakeStreams:tool];
@@ -316,6 +320,7 @@
                        @"-configuration", @"Debug",
                        @"-sdk", @"iphonesimulator6.0",
                        @"run-tests", @"-test-sdk", @"iphonesimulator5.0",
+                       @"-reporter", @"plain",
                        ];
 
     [TestUtil runWithFakeStreams:tool];
@@ -389,6 +394,7 @@
                          @"-configuration", @"Debug",
                          @"-sdk", @"iphonesimulator6.0",
                          @"run-tests", @"-only", onlyArgument,
+                         @"-reporter", @"plain",
                          ];
 
       [TestUtil runWithFakeStreams:tool];
@@ -454,6 +460,7 @@
     tool.arguments = @[@"-project", TEST_DATA @"TestsWithArgAndEnvSettingsInRunAction/TestsWithArgAndEnvSettings.xcodeproj",
                        @"-scheme", @"TestsWithArgAndEnvSettings",
                        @"run-tests",
+                       @"-reporter", @"plain",
                        ];
 
     __block OCUnitTestRunner *runner = nil;
@@ -507,6 +514,7 @@
     tool.arguments = @[@"-project", TEST_DATA @"TestsWithArgAndEnvSettingsInTestAction/TestsWithArgAndEnvSettings.xcodeproj",
                        @"-scheme", @"TestsWithArgAndEnvSettings",
                        @"run-tests",
+                       @"-reporter", @"plain",
                        ];
 
     __block OCUnitTestRunner *runner = nil;
@@ -560,6 +568,7 @@
     tool.arguments = @[@"-project", TEST_DATA @"TestsWithArgAndEnvSettingsWithMacroExpansion/TestsWithArgAndEnvSettings.xcodeproj",
                        @"-scheme", @"TestsWithArgAndEnvSettings",
                        @"run-tests",
+                       @"-reporter", @"plain",
                        ];
 
     __block OCUnitTestRunner *runner = nil;
@@ -626,6 +635,7 @@
                        @"-sdk", @"iphonesimulator",
                        @"-arch", @"i386",
                        @"run-tests",
+                       @"-reporter", @"plain",
                        ];
 
     [TestUtil runWithFakeStreams:tool];

--- a/xctool/xctool.xcodeproj/xcshareddata/xcschemes/xctool.xcscheme
+++ b/xctool/xctool.xcodeproj/xcshareddata/xcschemes/xctool.xcscheme
@@ -252,6 +252,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CCC0AAF518EC8AC4004FD861"
+               BuildableName = "user-notifications"
+               BlueprintName = "user-notifications"
+               ReferencedContainer = "container:../reporters/reporters.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "2893A94B17960CD400EFBD28"
                BuildableName = "reporters-tests.octest"
                BlueprintName = "reporters-tests"

--- a/xctool/xctool/Options.m
+++ b/xctool/xctool/Options.m
@@ -289,6 +289,13 @@
     [[[ReporterTask alloc] initWithReporterPath:[XCToolReportersPath() stringByAppendingPathComponent:@"pretty"]
                                      outputPath:@"-"] autorelease];
     [self.reporters addObject:reporterTask];
+
+    if (![[[NSProcessInfo processInfo] environment][@"TRAVIS"] isEqualToString:@"true"]) {
+      ReporterTask *userNotificationsReporterTask =
+      [[[ReporterTask alloc] initWithReporterPath:[XCToolReportersPath() stringByAppendingPathComponent:@"user-notifications"]
+                                       outputPath:@"-"] autorelease];
+      [self.reporters addObject:userNotificationsReporterTask];
+    }
   }
 
   return YES;


### PR DESCRIPTION
When building or running tests in Xcode developer is able to see results of these actions even if Xcode is collapsed. When running xctool in terminal developer has to follow the progress and manually check from time to time if building/testing/etc is completed.

This changes bring to xctool support of Mac OS X User Notifications, which are available in Mac OS X 10.8 and higher. Whenever the action is completed appropriate user notification is sent.

Examples of notifications:
![xctool_notification](https://cloud.githubusercontent.com/assets/1044236/2771973/a26f356c-ca74-11e3-92d0-71809dcaa3df.png)
![xctool_notifiction_center](https://cloud.githubusercontent.com/assets/1044236/2771974/a2715306-ca74-11e3-9889-fa50607cc412.png)
