### PR TITLE
Count ocunit failures as errors in overall test results

### DIFF
--- a/reporters/text/TextReporter.m
+++ b/reporters/text/TextReporter.m
@@ -636,6 +636,9 @@ static NSString *abbreviatePath(NSString *string) {
 
     if (![event[kReporter_EndOCUnit_SucceededKey] boolValue]) {
       [self.failedOcunitEvents addObject:event];
+      [_resultCounter suiteBegin];
+      [_resultCounter testErrored];
+      [_resultCounter suiteEnd];
     }
 
     [self.reportWriter enableIndent];


### PR DESCRIPTION
We are printing ocunit failures in Failures section but are not counting them as errors in overall test results which could lead to such kind of messages:

```
** RUN-TESTS FAILED: 466 passed, 0 failed, 0 errored, 466 total **
```

To improve the message we are now counting ocunit failures as errors:

```
** RUN-TESTS FAILED: 466 passed, 0 failed, 30 errored, 496 total **
```
