### PR TITLE
Add new option `-resetSimulator`. Reset simulator if (un)installation fails.

### DIFF
--- a/xctool/xctool-tests/OCUnitTestRunnerTests.m
+++ b/xctool/xctool-tests/OCUnitTestRunnerTests.m
@@ -33,6 +33,7 @@ static id TestRunnerWithTestLists(Class cls, NSDictionary *settings, NSArray *fo
                                    arguments:arguments
                                  environment:environment
                               freshSimulator:NO
+                              resetSimulator:NO
                                 freshInstall:NO
                                simulatorType:nil
                                    reporters:@[eventBuffer]] autorelease];

--- a/xctool/xctool-tests/OTestShimTests.m
+++ b/xctool/xctool-tests/OTestShimTests.m
@@ -109,6 +109,7 @@ static NSTask *OtestShimTask(NSString *platformName,
                                                                           arguments:@[]
                                                                         environment:@{}
                                                                      freshSimulator:NO
+                                                                     resetSimulator:NO
                                                                        freshInstall:NO
                                                                       simulatorType:nil
                                                                           reporters:@[]];

--- a/xctool/xctool/OCUnitTestRunner.h
+++ b/xctool/xctool/OCUnitTestRunner.h
@@ -28,6 +28,7 @@
   NSDictionary *_environment;
   BOOL _garbageCollection;
   BOOL _freshSimulator;
+  BOOL _resetSimulator;
   BOOL _freshInstall;
   NSString *_simulatorType;
   NSArray *_reporters;
@@ -55,6 +56,7 @@
                   arguments:(NSArray *)arguments
                 environment:(NSDictionary *)environment
              freshSimulator:(BOOL)freshSimulator
+             resetSimulator:(BOOL)resetSimulator
                freshInstall:(BOOL)freshInstall
               simulatorType:(NSString *)simulatorType
                   reporters:(NSArray *)reporters;

--- a/xctool/xctool/OCUnitTestRunner.m
+++ b/xctool/xctool/OCUnitTestRunner.m
@@ -79,6 +79,7 @@
                   arguments:(NSArray *)arguments
                 environment:(NSDictionary *)environment
              freshSimulator:(BOOL)freshSimulator
+             resetSimulator:(BOOL)resetSimulator
                freshInstall:(BOOL)freshInstall
               simulatorType:(NSString *)simulatorType
                   reporters:(NSArray *)reporters
@@ -90,6 +91,7 @@
     _arguments = [arguments retain];
     _environment = [environment retain];
     _freshSimulator = freshSimulator;
+    _resetSimulator = resetSimulator;
     _freshInstall = freshInstall;
     _simulatorType = [simulatorType retain];
     _reporters = [reporters retain];

--- a/xctool/xctool/RunTestsAction.h
+++ b/xctool/xctool/RunTestsAction.h
@@ -56,6 +56,7 @@ typedef enum {
 }
 
 @property (nonatomic, assign) BOOL freshSimulator;
+@property (nonatomic, assign) BOOL resetSimulator;
 @property (nonatomic, assign) BOOL freshInstall;
 @property (nonatomic, assign) BOOL parallelize;
 @property (nonatomic, assign) BOOL failOnEmptyTestBundles;

--- a/xctool/xctool/RunTestsAction.m
+++ b/xctool/xctool/RunTestsAction.m
@@ -119,6 +119,11 @@ NSArray *BucketizeTestCasesByTestClass(NSArray *testCases, int bucketSize)
                      description:
      @"Start fresh simulator for each application test target"
                          setFlag:@selector(setFreshSimulator:)],
+    [Action actionOptionWithName:@"resetSimulator"
+                         aliases:nil
+                     description:
+     @"Reset simulator content and settings and restart it before running every app test run."
+                         setFlag:@selector(setResetSimulator:)],
     [Action actionOptionWithName:@"freshInstall"
                          aliases:nil
                      description:
@@ -422,6 +427,7 @@ typedef BOOL (^TestableBlock)(NSArray *reporters);
                                      arguments:arguments
                                      environment:environment
                                      freshSimulator:self.freshSimulator
+                                     resetSimulator:self.resetSimulator
                                      freshInstall:self.freshInstall
                                      simulatorType:self.simulatorType
                                      reporters:reporters] autorelease];

--- a/xctool/xctool/TestAction.m
+++ b/xctool/xctool/TestAction.m
@@ -57,6 +57,11 @@
                      description:
      @"Start fresh simulator for each application test target"
                          setFlag:@selector(setFreshSimulator:)],
+    [Action actionOptionWithName:@"resetSimulator"
+                         aliases:nil
+                     description:
+     @"Reset simulator content and settings and restart it before running every app test run."
+                         setFlag:@selector(setResetSimulator:)],
     [Action actionOptionWithName:@"freshInstall"
                          aliases:nil
                      description:
@@ -121,6 +126,11 @@
 - (void)setFreshSimulator:(BOOL)freshSimulator
 {
   [_runTestsAction setFreshSimulator:freshSimulator];
+}
+
+- (void)setResetSimulator:(BOOL)resetSimulator
+{
+  [_runTestsAction setResetSimulator:resetSimulator];
 }
 
 - (void)setFreshInstall:(BOOL)freshInstall


### PR DESCRIPTION
New option tells xctool to reset iOS simulator content and settings and restart it before running every app test run.

Sometimes iOS simulator fails to install or uninstall test host app. If that happens we were retrying 3 times before failing, now we are additionally resetting simulator content and settings folder after each attempt.
