### PR TITLE
otest-query: when we dlopen, use RTLD_LAZY instead of RTLD_NOW.

### DIFF
--- a/otest-query/OtestQuery/OtestQuery.m
+++ b/otest-query/OtestQuery/OtestQuery.m
@@ -93,7 +93,7 @@
 
   // We use dlopen() instead of -[NSBundle loadAndReturnError] because, if
   // something goes wrong, dlerror() gives us a much more helpful error message.
-  if (dlopen([[bundle executablePath] UTF8String], RTLD_NOW) == NULL) {
+  if (dlopen([[bundle executablePath] UTF8String], RTLD_LAZY) == NULL) {
     fprintf(stderr, "%s\n", dlerror());
     exit(kDLOpenError);
   }


### PR DESCRIPTION
Summary:
This fixes an issue I'm seeing... where a framework referenced by my
tests actually references a symbol that does not exist.

Because of this, I'm getting ...

```
Failed to query the list of test cases in the test bundle:
dlopen(/var/folders/v2/b9w9xt6j1n79c8qjxhkvftmc000xbj/T/build-outputYYP4rr/Products/Debug/IntegrationTests.xctest/Contents/MacOS/IntegrationTests, 2): Symbol not found: _SecCertificateGetSHA1Digest
  Referenced from: /Applications/xcode_5.1.app/Contents/Developer/../SharedFrameworks/DVTFoundation.framework/Versions/A/DVTFoundation
  Expected in: /System/Library/Frameworks/Security.framework/Versions/A/Security
 in /Applications/xcode_5.1.app/Contents/Developer/../SharedFrameworks/DVTFoundation.framework/Versions/A/DVTFoundation
```

In the above case, DVTFoundation references `SecCertificateGetSHA1Digest`, and
that symbol is supposed to be in Security.framework, but it's not (at
least on OS X 10.8)

By switching to RTLD_LAZY, dyld won't bother binding every single
function, and we'll never encounter the error.

There shouldn't be any negative consequences by this change - we're just
delaying the binding.  In fact, I wonder if it'll make otest-query a
little faster since we'll skip binding.

From the dyld man page --

```
   RTLD_LAZY   Each external function reference is bound the first time the
               function is called.

   RTLD_NOW    All external function references are bound immediately during
               the call to dlopen().
```

Test Plan:
With this patch, I ran xctool against my project and it now works.
