### PR TITLE
Added support for -resultBundlePath argument to xcodebuild.

### DIFF
--- a/xctool/xctool-tests/OptionsTests.m
+++ b/xctool/xctool-tests/OptionsTests.m
@@ -192,6 +192,36 @@
    TEST_DATA @"TestWorkspace-Library-TestProject-Library-showBuildSettings.txt"];
 }
 
+- (void)testResultBundlePathMustBeADirectory
+{
+  NSString *validFilePath = TEST_DATA @"TestWorkspace-Library-TestProject-Library-showBuildSettings.txt";
+  [[Options optionsFrom:@[
+                          @"-scheme", @"TestProject-Library",
+                          @"-workspace", TEST_DATA @"TestWorkspace-Library/TestWorkspace-Library.xcworkspace",
+                          @"-resultBundlePath", validFilePath,
+                          ]]
+   assertOptionsFailToValidateWithError:
+   [NSString stringWithFormat:@"Specified result bundle path must be a directory: %@", validFilePath]];
+}
+
+- (void)testResultBundlePathMustExist
+{
+  NSString *invalidResultBundlePath = @"SOME_BAD_PATH";
+  [[Options optionsFrom:@[
+                          @"-scheme", @"TestProject-Library",
+                          @"-workspace", TEST_DATA @"TestWorkspace-Library/TestWorkspace-Library.xcworkspace",
+                          @"-resultBundlePath", invalidResultBundlePath,
+                          ]]
+   assertOptionsFailToValidateWithError:
+   [NSString stringWithFormat:@"Specified result bundle path doesn't exist: %@", invalidResultBundlePath]];
+}
+
+- (void)testResultBundlePathWorks
+{
+  Options *options = [Options optionsFrom:@[@"-resultBundlePath", @"foo"]];
+  assertThat(options.resultBundlePath, equalTo(@"foo"));
+}
+
 - (void)testFindTargetWorks
 {
   Options *options = [Options optionsFrom:@[@"-find-target", @"foo"]];

--- a/xctool/xctool/Options.h
+++ b/xctool/xctool/Options.h
@@ -44,6 +44,7 @@
 @property (nonatomic, copy) NSString *findTarget;
 @property (nonatomic, copy) NSString *findTargetPath;
 @property (nonatomic, copy) NSString *findProjectPath;
+@property (nonatomic, copy) NSString *resultBundlePath;
 @property (nonatomic, copy) NSArray *findTargetExcludePaths;
 
 @property (nonatomic, assign) BOOL showBuildSettings;

--- a/xctool/xctool/Options.m
+++ b/xctool/xctool/Options.m
@@ -71,6 +71,11 @@
                      description:@"scheme to use for building or testing"
                        paramName:@"NAME"
                            mapTo:@selector(setScheme:)],
+    [Action actionOptionWithName:@"resultBundlePath"
+                         aliases:nil
+                     description:@"path to bundle to write results from performing a build action"
+                       paramName:@"PATH"
+                           mapTo:@selector(setResultBundlePath:)],
     [Action actionOptionWithName:@"find-target"
                          aliases:nil
                      description:@"Search for the workspace/project/scheme to build the target"
@@ -409,6 +414,16 @@
     *errorMessage = [NSString stringWithFormat:@"Project must end in .xcodeproj: %@", self.project];
     return NO;
   }
+  
+  if (self.resultBundlePath != nil) {
+    BOOL isDirectory = NO;
+    BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:self.resultBundlePath isDirectory:&isDirectory];
+    if (!isDirectory) {
+      NSString *errorReason = fileExists ? @"must be a directory" : @"doesn't exist";
+      *errorMessage = [NSString stringWithFormat:@"Specified result bundle path %@: %@", errorReason, self.resultBundlePath];
+      return NO;
+    }
+  }
 
   NSArray *schemePaths = nil;
   if (self.workspace != nil) {
@@ -631,6 +646,10 @@
     [arguments addObjectsFromArray:@[@"-jobs", self.jobs]];
   }
 
+  if (self.resultBundlePath != nil) {
+    [arguments addObjectsFromArray:@[@"-resultBundlePath", self.resultBundlePath]];
+  }
+    
   [_buildSettings enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop){
     [arguments addObject:[NSString stringWithFormat:@"%@=%@", key, obj]];
   }];


### PR DESCRIPTION
`-resultBundlePath` is an argument to `xcodebuild` which specifies the path where the results of a build should be written. `xctool` doesn't currently proxy this argument to `xcodebuild`, hence this pull request.
