### PR TITLE
Fix crash with appendDataToBuffer appending a nil NSString

### DIFF
--- a/xctool/xctool/LineReader.m
+++ b/xctool/xctool/LineReader.m
@@ -57,7 +57,10 @@
 
 - (void)appendDataToBuffer:(NSData *)data
 {
-  [_buffer appendString:[[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] autorelease]];
+    NSString *dataToAppend = [[[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] autorelease];
+    if (dataToAppend) {
+        [_buffer appendString:dataToAppend];
+    }
 }
 
 - (void)dataAvailableNotification:(NSNotification *)notification


### PR DESCRIPTION
We are seeing a crash with dataAvailableNotification, just adding a check for nil before appending. 

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[__NSCFString appendString:]: nil argument'
*** First throw call stack:
(
    0   CoreFoundation                      0x00007fff9041825c __exceptionPreprocess + 172
    1   libobjc.A.dylib                     0x00007fff8b62ee75 objc_exception_throw + 43
    2   CoreFoundation                      0x00007fff9041810c +[NSException raise:format:] + 204
    3   CoreFoundation                      0x00007fff903e7def mutateError + 159
    4   xctool                              0x00000001084ae257 -[LineReader dataAvailableNotification:] + 79
    5   CoreFoundation                      0x00007fff903e6e0c __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ + 12
    6   CoreFoundation                      0x00007fff902da8dd _CFXNotificationPost + 2893
    7   Foundation                          0x00007fff87f877ba -[NSNotificationCenter postNotificationName:object:userInfo:] + 68
    8   Foundation                          0x00007fff88080450 _performFileHandleSource + 1548
    9   CoreFoundation                      0x00007fff90349661 __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 17
    10  CoreFoundation                      0x00007fff9033ad12 __CFRunLoopDoSources0 + 242
    11  CoreFoundation                      0x00007fff9033a49f __CFRunLoopRun + 831
    12  CoreFoundation                      0x00007fff90339f25 CFRunLoopRunSpecific + 309
    13  CoreFoundation                      0x00007fff903ef811 CFRunLoopRun + 97
    14  xctool                              0x00000001084ae931 -[SimulatorLauncher launchAndWaitForExit] + 117
    15  xctool                              0x00000001084ab9a8 -[OCUnitIOSAppTestRunner runTestsInSimulator:feedOutputToBlock:infraSucceeded:error:] + 286
    16  xctool                              0x00000001084ac0ce -[OCUnitIOSAppTestRunner runTestsAndFeedOutputTo:startupError:] + 1122
    17  xctool                              0x00000001084ad719 -[OCUnitTestRunner runTests] + 229
    18  xctool                              0x00000001084b5956 __158-[RunTestsAction blockForTestable:focusedTestCases:allTestCases:testableExecutionInfo:testableTarget:isApplicationTest:arguments:environment:testRunnerClass:]_block_invoke + 518
    19  xctool                              0x00000001084b6bc5 __56-[RunTestsAction runTestables:options:xcodeSubjectInfo:]_block_invoke340 + 210
    20  xctool                              0x00000001084b67d0 -[RunTestsAction runTestables:options:xcodeSubjectInfo:] + 3359
    21  xctool                              0x00000001084b517a -[RunTestsAction performActionWithOptions:xcodeSubjectInfo:] + 851
    22  xctool                              0x00000001084c015f -[TestAction performActionWithOptions:xcodeSubjectInfo:] + 77
    23  xctool                              0x00000001084a802e -[XCTool run] + 2024
    24  xctool                              0x00000001084a6f85 main + 542
    25  xctool                              0x00000001084a4da4 start + 52
)
```
