### PR TITLE
Deprecate old option `simulator` in xctool.

### DIFF
--- a/xctool/xctool-tests/OCUnitTestRunnerTests.m
+++ b/xctool/xctool-tests/OCUnitTestRunnerTests.m
@@ -35,7 +35,6 @@ static id TestRunnerWithTestLists(Class cls, NSDictionary *settings, NSArray *fo
                               freshSimulator:NO
                               resetSimulator:NO
                                 freshInstall:NO
-                               simulatorType:nil
                                    reporters:@[eventBuffer]] autorelease];
 }
 

--- a/xctool/xctool-tests/OTestShimTests.m
+++ b/xctool/xctool-tests/OTestShimTests.m
@@ -111,7 +111,6 @@ static NSTask *OtestShimTask(NSString *platformName,
                                                                      freshSimulator:NO
                                                                      resetSimulator:NO
                                                                        freshInstall:NO
-                                                                      simulatorType:nil
                                                                           reporters:@[]];
 
   NSTask *task = [runner otestTaskWithTestBundle: bundlePath];

--- a/xctool/xctool/OCUnitIOSTestRunner.m
+++ b/xctool/xctool/OCUnitIOSTestRunner.m
@@ -29,7 +29,6 @@
   _simulatorInfo.cpuType = _cpuType;
   _simulatorInfo.deviceName = _deviceName;
   _simulatorInfo.OSVersion = _OSVersion;
-  _simulatorInfo.simulatorType = _simulatorType;
   _simulatorInfo.buildSettings = _buildSettings;
 }
 

--- a/xctool/xctool/OCUnitTestRunner.h
+++ b/xctool/xctool/OCUnitTestRunner.h
@@ -31,7 +31,6 @@
   BOOL _freshSimulator;
   BOOL _resetSimulator;
   BOOL _freshInstall;
-  NSString *_simulatorType;
   NSArray *_reporters;
   NSDictionary *_framework;
 }
@@ -59,7 +58,6 @@
              freshSimulator:(BOOL)freshSimulator
              resetSimulator:(BOOL)resetSimulator
                freshInstall:(BOOL)freshInstall
-              simulatorType:(NSString *)simulatorType
                   reporters:(NSArray *)reporters;
 
 - (BOOL)runTests;

--- a/xctool/xctool/OCUnitTestRunner.m
+++ b/xctool/xctool/OCUnitTestRunner.m
@@ -81,7 +81,6 @@
              freshSimulator:(BOOL)freshSimulator
              resetSimulator:(BOOL)resetSimulator
                freshInstall:(BOOL)freshInstall
-              simulatorType:(NSString *)simulatorType
                   reporters:(NSArray *)reporters
 {
   if (self = [super init]) {
@@ -93,7 +92,6 @@
     _freshSimulator = freshSimulator;
     _resetSimulator = resetSimulator;
     _freshInstall = freshInstall;
-    _simulatorType = [simulatorType retain];
     _reporters = [reporters retain];
     _framework = [FrameworkInfoForTestBundleAtPath([self testBundlePath]) retain];
     _cpuType = CPU_TYPE_ANY;
@@ -108,7 +106,6 @@
   [_allTestCases release];
   [_arguments release];
   [_environment release];
-  [_simulatorType release];
   [_reporters release];
   [_framework release];
   [super dealloc];

--- a/xctool/xctool/RunTestsAction.h
+++ b/xctool/xctool/RunTestsAction.h
@@ -62,7 +62,6 @@ typedef enum {
 @property (nonatomic, assign) BOOL failOnEmptyTestBundles;
 @property (nonatomic, assign) BOOL listTestsOnly;
 @property (nonatomic, assign) cpu_type_t cpuType;
-@property (nonatomic, copy) NSString *simulatorType;
 @property (nonatomic, copy) NSString *testSDK;
 @property (nonatomic, retain) NSMutableArray *onlyList;
 @property (nonatomic, copy) NSString *deviceName;

--- a/xctool/xctool/RunTestsAction.m
+++ b/xctool/xctool/RunTestsAction.m
@@ -143,11 +143,6 @@ NSArray *BucketizeTestCasesByTestClass(NSArray *testCases, int bucketSize)
                      description:@"Either 'case' (default) or 'class'."
                        paramName:@"BUCKETBY"
                            mapTo:@selector(setBucketBy:)],
-    [Action actionOptionWithName:@"simulator"
-                         aliases:nil
-                     description:@"Set simulator type (either iphone or ipad)"
-                       paramName:@"SIMULATOR"
-                           mapTo:@selector(setSimulatorType:)],
     [Action actionOptionWithName:@"failOnEmptyTestBundles"
                          aliases:nil
                      description:@"Fail when an empty test bundle was run."
@@ -174,7 +169,6 @@ NSArray *BucketizeTestCasesByTestClass(NSArray *testCases, int bucketSize)
 - (void)dealloc {
   self.onlyList = nil;
   self.testSDK = nil;
-  self.simulatorType = nil;
   [super dealloc];
 }
 
@@ -423,7 +417,6 @@ typedef BOOL (^TestableBlock)(NSArray *reporters);
                                      freshSimulator:self.freshSimulator
                                      resetSimulator:self.resetSimulator
                                      freshInstall:self.freshInstall
-                                     simulatorType:self.simulatorType
                                      reporters:reporters] autorelease];
     [testRunner setCpuType:_cpuType];
 

--- a/xctool/xctool/TestAction.m
+++ b/xctool/xctool/TestAction.m
@@ -90,11 +90,6 @@
                      description:@"Either 'case' (default) or 'class'."
                        paramName:@"BUCKETBY"
                            mapTo:@selector(setBucketBy:)],
-    [Action actionOptionWithName:@"simulator"
-                         aliases:nil
-                     description:@"Set simulator type (either iphone or ipad)"
-                       paramName:@"SIMULATOR"
-                           mapTo:@selector(setSimulatorType:)],
     [Action actionOptionWithName:@"listTestsOnly"
                          aliases:nil
                      description:@"Skip actual test running and list them only."
@@ -160,11 +155,6 @@
 - (void)setBucketBy:(NSString *)str
 {
   [_runTestsAction setBucketBy:str];
-}
-
-- (void)setSimulatorType:(NSString *)simulatorType
-{
-  [_runTestsAction setSimulatorType:simulatorType];
 }
 
 - (void)setSkipDependencies:(BOOL)skipDependencies


### PR DESCRIPTION
In version 5 of xcodebuild it was introduced new option named `-destination`. Generally this option allows to tell which iOS version and device to simulate while building project and running tests. We have already added support for this option but haven’t deprecated old options which are still treated as required.

This PR deprecates and removes the old option `simulator` which previously controlled device type against which xctool ran tests. Now it is replaced with `-destination “”name=<device name>`.
