### PR TITLE
Record stderr of sim during testing and print it contents in log if it fails.

### DIFF
--- a/xctool/xctool-tests/FakeOCUnitTestRunner.m
+++ b/xctool/xctool-tests/FakeOCUnitTestRunner.m
@@ -40,6 +40,7 @@
 
 - (void)runTestsAndFeedOutputTo:(void (^)(NSString *))outputLineBlock
                    startupError:(NSString **)startupError
+                    otherErrors:(NSString **)otherErrors
 {
   for (lastLineIndex++; lastLineIndex < [_outputLines count]; lastLineIndex++) {
     if ([_outputLines[lastLineIndex] isEqualToString:@"__break__"]) {

--- a/xctool/xctool-tests/TestRunStateTests.m
+++ b/xctool/xctool-tests/TestRunStateTests.m
@@ -95,7 +95,7 @@ static TestRunState *TestRunStateForFakeRun(id<EventSink> sink)
   [state prepareToRun];
   [self sendEventsFromFile:TEST_DATA @"JSONStreamReporter-runtests.txt"
                 toReporter:state];
-  [state didFinishRunWithStartupError:nil];
+  [state didFinishRunWithStartupError:nil otherErrors:nil];
 
   assertThat(eventBuffer.events, hasCountOf(7*2 + 2));
   assertThat(SelectEventFields(eventBuffer.events, kReporter_Events_BeginTest, @"event"), hasCountOf(7));
@@ -111,7 +111,7 @@ static TestRunState *TestRunStateForFakeRun(id<EventSink> sink)
 
     [state prepareToRun];
     [self sendEvents:events toReporter:state];
-    [state didFinishRunWithStartupError:nil];
+    [state didFinishRunWithStartupError:nil otherErrors:nil];
 
     assertThat(SelectEventFields(eventBuffer.events, nil, @"event"),
                equalTo(expectedEvents));
@@ -171,7 +171,7 @@ static TestRunState *TestRunStateForFakeRun(id<EventSink> sink)
   [state prepareToRun];
   [self sendEvents:[EventsForFakeRun() subarrayWithRange:NSMakeRange(0, 2)]
           toReporter:state];
-  [state didFinishRunWithStartupError:nil];
+  [state didFinishRunWithStartupError:nil otherErrors:nil];
 
   assertThat(SelectEventFields(eventBuffer.events, nil, @"event"),
              equalTo(@[kReporter_Events_BeginTestSuite,
@@ -194,7 +194,7 @@ static TestRunState *TestRunStateForFakeRun(id<EventSink> sink)
   [state prepareToRun];
   [self sendEvents:[EventsForFakeRun() subarrayWithRange:NSMakeRange(0, 4)]
         toReporter:state];
-  [state didFinishRunWithStartupError:nil];
+  [state didFinishRunWithStartupError:nil otherErrors:nil];
 
   assertThat(SelectEventFields(eventBuffer.events, nil, @"event"),
              equalTo(@[kReporter_Events_BeginTestSuite,
@@ -227,7 +227,7 @@ static TestRunState *TestRunStateForFakeRun(id<EventSink> sink)
   [state prepareToRun];
   [self sendEvents:@[]
         toReporter:state];
-  [state didFinishRunWithStartupError:@"cupcakes candy donuts cookies"];
+  [state didFinishRunWithStartupError:@"cupcakes candy donuts cookies" otherErrors:nil];
 
   assertThat(SelectEventFields(eventBuffer.events, nil, @"event"),
              equalTo(@[kReporter_Events_BeginTestSuite,
@@ -263,7 +263,7 @@ static TestRunState *TestRunStateForFakeRun(id<EventSink> sink)
   [state prepareToRun];
   [self sendEvents:[EventsForFakeRun() subarrayWithRange:NSMakeRange(0, 6)]
         toReporter:state];
-  [state didFinishRunWithStartupError:nil];
+  [state didFinishRunWithStartupError:nil otherErrors:nil];
 
   // In this case there are no tests left with which to report the error, so we
   // create a fake one just so we have a place to advertise the error.
@@ -298,7 +298,7 @@ static TestRunState *TestRunStateForFakeRun(id<EventSink> sink)
   [state prepareToRun];
   [self sendEvents:EventsForFakeRun()
         toReporter:state];
-  [state didFinishRunWithStartupError:nil];
+  [state didFinishRunWithStartupError:nil otherErrors:nil];
 
   // Not much we can do here, make sure no events are shipped out
   assertThatInteger(eventBuffer.events.count, equalToInteger(6));

--- a/xctool/xctool/OCUnitIOSAppTestRunner.m
+++ b/xctool/xctool/OCUnitIOSAppTestRunner.m
@@ -441,6 +441,7 @@ static BOOL RemoveSimulatorContentAndSettings(NSString *simulatorVersion, cpu_ty
 
 - (void)runTestsAndFeedOutputTo:(void (^)(NSString *))outputLineBlock
                    startupError:(NSString **)startupError
+                    otherErrors:(NSString **)otherErrors
 {
   NSString *sdkName = _buildSettings[Xcode_SDK_NAME];
   NSAssert([sdkName hasPrefix:@"iphonesimulator"], @"Unexpected SDK: %@", sdkName);

--- a/xctool/xctool/OCUnitIOSDeviceTestRunner.m
+++ b/xctool/xctool/OCUnitIOSDeviceTestRunner.m
@@ -21,6 +21,7 @@
 
 - (void)runTestsAndFeedOutputTo:(void (^)(NSString *))outputLineBlock
                    startupError:(NSString **)startupError
+                    otherErrors:(NSString **)otherErrors
 {
   // Just a place holder.  The plumbing for 'run-tests' expects each SDK to have
   // an associated test runner.

--- a/xctool/xctool/OCUnitIOSLogicTestRunner.m
+++ b/xctool/xctool/OCUnitIOSLogicTestRunner.m
@@ -58,6 +58,7 @@
 
 - (void)runTestsAndFeedOutputTo:(void (^)(NSString *))outputLineBlock
                    startupError:(NSString **)startupError
+                    otherErrors:(NSString **)otherErrors
 {
   NSString *sdkName = _buildSettings[Xcode_SDK_NAME];
   NSAssert([sdkName hasPrefix:@"iphonesimulator"], @"Unexpected SDK name: %@", sdkName);
@@ -71,18 +72,21 @@
   }
 
   if (bundleExists) {
+    NSPipe *outputPipe = [NSPipe pipe];
     @autoreleasepool {
       NSTask *task = [self otestTaskWithTestBundle:testBundlePath];
 
       // Don't let STDERR pass through.  This silences the warning message that
       // comes from the 'sim' launcher when the iOS Simulator isn't running:
       // "Simulator does not seem to be running, or may be running an old SDK."
-      [task setStandardError:[NSFileHandle fileHandleWithNullDevice]];
+      [task setStandardError:outputPipe];
 
       LaunchTaskAndFeedOuputLinesToBlock(task,
                                          @"running otest/xctest on test bundle",
                                          outputLineBlock);
     }
+    NSData *outputData = [[outputPipe fileHandleForReading] readDataToEndOfFile];
+    *otherErrors = [[[NSString alloc] initWithData:outputData encoding:NSUTF8StringEncoding] autorelease];
   } else {
     *startupError = [NSString stringWithFormat:@"Test bundle not found at: %@", testBundlePath];
   }

--- a/xctool/xctool/OCUnitOSXAppTestRunner.m
+++ b/xctool/xctool/OCUnitOSXAppTestRunner.m
@@ -28,6 +28,7 @@
 
 - (void)runTestsAndFeedOutputTo:(void (^)(NSString *))outputLineBlock
                    startupError:(NSString **)startupError
+                    otherErrors:(NSString **)otherErrors
 {
   NSString *sdkName = _buildSettings[Xcode_SDK_NAME];
   NSAssert([sdkName hasPrefix:@"macosx"], @"Unexpected SDK: %@", sdkName);

--- a/xctool/xctool/OCUnitOSXLogicTestRunner.m
+++ b/xctool/xctool/OCUnitOSXLogicTestRunner.m
@@ -48,6 +48,7 @@
 
 - (void)runTestsAndFeedOutputTo:(void (^)(NSString *))outputLineBlock
                    startupError:(NSString **)startupError
+                    otherErrors:(NSString **)otherErrors
 {
   NSAssert([_buildSettings[Xcode_SDK_NAME] hasPrefix:@"macosx"], @"Should be a macosx SDK.");
 

--- a/xctool/xctool/OCUnitTestRunner.m
+++ b/xctool/xctool/OCUnitTestRunner.m
@@ -116,6 +116,7 @@
 
 - (void)runTestsAndFeedOutputTo:(void (^)(NSString *))outputLineBlock
                    startupError:(NSString **)startupError
+                    otherErrors:(NSString **)otherErrors
 {
   // Subclasses will override this method.
 }
@@ -139,13 +140,15 @@
     };
 
     NSString *runTestsError = nil;
+    NSString *otherErrors = nil;
 
     [testRunState prepareToRun];
 
     [self runTestsAndFeedOutputTo:feedOutputToBlock
-                     startupError:&runTestsError];
+                     startupError:&runTestsError
+                      otherErrors:&otherErrors];
 
-    [testRunState didFinishRunWithStartupError:runTestsError];
+    [testRunState didFinishRunWithStartupError:runTestsError otherErrors:otherErrors];
 
     allTestsPassed &= [testRunState allTestsPassed];
 

--- a/xctool/xctool/OCUnitTestRunnerInternal.h
+++ b/xctool/xctool/OCUnitTestRunnerInternal.h
@@ -8,6 +8,7 @@
  run the tests.
  */
 - (void)runTestsAndFeedOutputTo:(void (^)(NSString *))outputLineBlock
-                   startupError:(NSString **)startupError;
+                   startupError:(NSString **)startupError
+                    otherErrors:(NSString **)otherErrors;
 
 @end

--- a/xctool/xctool/TestRunState.h
+++ b/xctool/xctool/TestRunState.h
@@ -36,6 +36,6 @@
 
 - (BOOL)allTestsPassed;
 - (void)prepareToRun;
-- (void)didFinishRunWithStartupError:(NSString *)startupError;
+- (void)didFinishRunWithStartupError:(NSString *)startupError otherErrors:(NSString *)otherErrors;
 
 @end


### PR DESCRIPTION
Summary:
When `sim` process fail to run xctool commands xctool silently ignores all errors printed to stderr and is not logging them at all. There could be issues in future that would be hard to find without that logs.

In this commit we are saving stderr to string and print it in case when `sim` process and testing fails.

Test plan:
1) Simulated bad input argument of `sim` process.
2) Ensured that stderr contents were printed.
