### PR TITLE
Fix for "Removed "-simulator" option." (5a3b901)

### DIFF
--- a/xctool/xctool/SimulatorWrapper/SimulatorInfo.h
+++ b/xctool/xctool/SimulatorWrapper/SimulatorInfo.h
@@ -24,7 +24,6 @@
 @property (nonatomic, assign) cpu_type_t cpuType;
 @property (nonatomic, copy) NSString *deviceName;
 @property (nonatomic, copy) NSString *OSVersion;
-@property (nonatomic, copy) NSString *simulatorType;
 
 - (NSString *)simulatedArchitecture;
 - (NSNumber *)simulatedDeviceFamily;

--- a/xctool/xctool/SimulatorWrapper/SimulatorInfo.m
+++ b/xctool/xctool/SimulatorWrapper/SimulatorInfo.m
@@ -77,11 +77,7 @@ static const NSInteger KProductTypeIpad = 2;
 
 - (NSNumber *)simulatedDeviceFamily
 {
-  if (_simulatorType) {
-    return [[_simulatorType lowercaseString] isEqualToString:@"ipad"] ? @(KProductTypeIpad) : @(KProductTypeIphone);
-  } else {
-    return @([_buildSettings[Xcode_TARGETED_DEVICE_FAMILY] integerValue]);
-  }
+  return @([_buildSettings[Xcode_TARGETED_DEVICE_FAMILY] integerValue]);
 }
 
 - (NSString *)simulatedDeviceInfoName


### PR DESCRIPTION
This fixes the deprecated property in SimulatorInfo.
