### PR TITLE
Print output of tests during testing.

### DIFF
--- a/xctool/xctool-tests/OCUnitTestRunnerTests.m
+++ b/xctool/xctool-tests/OCUnitTestRunnerTests.m
@@ -392,7 +392,7 @@ static int NumberOfEntries(NSArray *array, NSObject *target)
   NSArray *events = [eventBuffer events];
 
   // check number of events
-  assertThatInteger([events count], equalToInteger(19));
+  assertThatInteger([events count], equalToInteger(20));
 
   // check last event statistics
   assertThat([events lastObject][@"event"], equalTo(kReporter_Events_EndTestSuite));
@@ -413,9 +413,10 @@ static int NumberOfEntries(NSArray *array, NSObject *target)
   assertThatInteger(NumberOfEntries([events valueForKeyPath:kReporter_EndTest_ResultKey], @"error"), equalToInteger(1));
 
   // check test output of crash
-  assertThatInteger(NumberOfEntries([events valueForKeyPath:@"event"], kReporter_Events_TestOuput), equalToInteger(1));
-  assertThat(events[8][kReporter_EndTest_OutputKey], equalTo(@"Test crashed while running."));
-  assertThat(events[9][kReporter_EndTest_OutputKey], equalTo(@"Hello!\nTest crashed while running."));
+  assertThatInteger(NumberOfEntries([events valueForKeyPath:@"event"], kReporter_Events_TestOuput), equalToInteger(2));
+  assertThat(events[8][kReporter_EndTest_OutputKey], equalTo(@"Hello!\n"));
+  assertThat(events[9][kReporter_EndTest_OutputKey], equalTo(@"Test crashed while running."));
+  assertThat(events[10][kReporter_EndTest_OutputKey], equalTo(@"Hello!\nTest crashed while running."));
 }
 
 #pragma mark misc.

--- a/xctool/xctool-tests/TestRunStateTests.m
+++ b/xctool/xctool-tests/TestRunStateTests.m
@@ -97,7 +97,7 @@ static TestRunState *TestRunStateForFakeRun(id<EventSink> sink)
                 toReporter:state];
   [state didFinishRunWithStartupError:nil otherErrors:nil];
 
-  assertThat(eventBuffer.events, hasCountOf(7*2 + 2));
+  assertThat(eventBuffer.events, hasCountOf(43));
   assertThat(SelectEventFields(eventBuffer.events, kReporter_Events_BeginTest, @"event"), hasCountOf(7));
   assertThat(SelectEventFields(eventBuffer.events, kReporter_Events_EndTest, @"event"), hasCountOf(7));
 }
@@ -199,6 +199,7 @@ static TestRunState *TestRunStateForFakeRun(id<EventSink> sink)
   assertThat(SelectEventFields(eventBuffer.events, nil, @"event"),
              equalTo(@[kReporter_Events_BeginTestSuite,
                        kReporter_Events_BeginTest,
+                       kReporter_Events_TestOuput,
                        kReporter_Events_EndTest,
                        kReporter_Events_BeginTest,
                        kReporter_Events_TestOuput,
@@ -215,6 +216,8 @@ static TestRunState *TestRunStateForFakeRun(id<EventSink> sink)
 
   NSArray *output = SelectEventFields(eventBuffer.events, kReporter_Events_TestOuput, kReporter_TestOutput_OutputKey);
   assertThat(output[0],
+             equalTo(@"puppies!\n"));
+  assertThat(output[1],
              equalTo(@"The test bundle stopped running or crashed immediately after running '-[OtherTests testSomething]'.  "
                      @"Even though that test finished, it's likely responsible for the crash."));
 }
@@ -270,6 +273,7 @@ static TestRunState *TestRunStateForFakeRun(id<EventSink> sink)
   assertThat(SelectEventFields(eventBuffer.events, nil, @"event"),
              equalTo(@[kReporter_Events_BeginTestSuite,
                        kReporter_Events_BeginTest,
+                       kReporter_Events_TestOuput,
                        kReporter_Events_EndTest,
                        kReporter_Events_BeginTest,
                        kReporter_Events_EndTest,
@@ -286,6 +290,8 @@ static TestRunState *TestRunStateForFakeRun(id<EventSink> sink)
 
   NSArray *output = SelectEventFields(eventBuffer.events, kReporter_Events_TestOuput, kReporter_TestOutput_OutputKey);
   assertThat(output[0],
+             equalTo(@"puppies!\n"));
+  assertThat(output[1],
              equalTo(@"The test bundle stopped running or crashed immediately after running '-[OtherTests testAnother]'.  "
                      @"Even though that test finished, it's likely responsible for the crash."));
 }
@@ -301,7 +307,7 @@ static TestRunState *TestRunStateForFakeRun(id<EventSink> sink)
   [state didFinishRunWithStartupError:nil otherErrors:nil];
 
   // Not much we can do here, make sure no events are shipped out
-  assertThatInteger(eventBuffer.events.count, equalToInteger(6));
+  assertThatInteger(eventBuffer.events.count, equalToInteger(7));
   assertThat(SelectEventFields(eventBuffer.events, kReporter_Events_BeginTest, @"event"), hasCountOf(2));
   assertThat(SelectEventFields(eventBuffer.events, kReporter_Events_EndTest, @"event"), hasCountOf(2));
 }

--- a/xctool/xctool/TestRunState.m
+++ b/xctool/xctool/TestRunState.m
@@ -145,6 +145,8 @@
   OCTestEventState *test = [_testSuiteState runningTest];
   NSAssert(test, @"Got output with no test running");
   [test stateTestOutput:event[kReporter_TestOutput_OutputKey]];
+  
+  [self publishEventToReporters:event];
 }
 
 - (void)handleStartupError:(NSString *)startupError


### PR DESCRIPTION
In the commit https://github.com/facebook/xctool/commit/b2c7fc9b2cfc1afe5327827102fc397a8a41b3e3 I have broken printing output of tests during testing. We were still printing it in summary if test fails but if test passes then it wasn't possible to see its output.
