### PR TITLE
Fix duplicated test cases by reloading `isEqual:` and `hash` methods of NSInvocation

### DIFF
--- a/Common/NSInvocationInSetFix.h
+++ b/Common/NSInvocationInSetFix.h
@@ -1,0 +1,45 @@
+//
+// Copyright 2014 Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+/**
+ By replacing default implementation of `isEqual` and `hash` we could guarantee
+ that there will be no test duplicates in test suites.
+
+ [Based on SenTesting framework implementation of category
+ NSObject (SenTestRuntimeUtilities) found in NSObject_SenTestRuntimeUtilities.m]
+ Duplicates appear because SenTesting and XCTest frameworks are recursively
+ retrieving methods for a particular test case class starting from class itself
+ and moving to its parent class which could also be a test case with tests. For
+ each method `NSInvocation` object is created with corresponding `selector`.
+ If child class implements test with the name which also exists in parent
+ class then [*TestSuite allTests] returns two test cases with the same name but
+ the same target which is incorrect.
+
+ As it was found in SenTesting framework in NSObject (SenTestRuntimeUtilities)
+ in method `+ (NSArray *) senAllInstanceInvocations` all invocations are stored
+ in `NSSet`. Before adding new object `NSSet` checks if the same object is already
+ added by using `isEqual:` and `hash`. So in this category we are returning `YES`
+ in `isEqual:` if selectors of both invocations are equal and `hash` based on
+ string representation of invocation selector.
+ */
+@interface NSInvocation (Comparison)
+
+- (BOOL)isEqual:(id)object;
+- (NSUInteger)hash;
+
+@end

--- a/Common/NSInvocationInSetFix.m
+++ b/Common/NSInvocationInSetFix.m
@@ -1,0 +1,34 @@
+//
+// Copyright 2014 Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "NSInvocationInSetFix.h"
+
+@implementation NSInvocation (Comparison)
+
+- (BOOL)isEqual:(id)object
+{
+  if ([object isKindOfClass:[NSInvocation class]]) {
+    return [NSStringFromSelector(self.selector) isEqual:NSStringFromSelector(((NSInvocation *)object).selector)];
+  }
+  return NO;
+}
+
+- (NSUInteger)hash
+{
+  return [NSStringFromSelector(self.selector) hash];
+}
+
+@end

--- a/otest-query/OtestQuery/OtestQuery.m
+++ b/otest-query/OtestQuery/OtestQuery.m
@@ -23,6 +23,7 @@
 #import <stdio.h>
 
 #import "DuplicateTestNameFix.h"
+#import "NSInvocationInSetFix.h"
 #import "ParseTestName.h"
 #import "SenIsSuperclassOfClassPerformanceFix.h"
 #import "TestingFramework.h"

--- a/otest-query/otest-query.xcodeproj/project.pbxproj
+++ b/otest-query/otest-query.xcodeproj/project.pbxproj
@@ -39,6 +39,11 @@
 		CC12CC0218E54A7700AA76E9 /* TestingFramework.m in Sources */ = {isa = PBXBuildFile; fileRef = AA318BE517E9AA7400BF159E /* TestingFramework.m */; };
 		CC12CC0318E54A7700AA76E9 /* XcodeRequiredVersion.m in Sources */ = {isa = PBXBuildFile; fileRef = 28EC25F9184EAA680061C3B2 /* XcodeRequiredVersion.m */; };
 		CC12CC0418E54A7E00AA76E9 /* OtestQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = CC12CBF218E54A1400AA76E9 /* OtestQuery.m */; };
+		CC8D774C19660E230035CC60 /* NSInvocationInSetFix.h in Headers */ = {isa = PBXBuildFile; fileRef = CC8D774A19660E230035CC60 /* NSInvocationInSetFix.h */; };
+		CC8D774D19660E230035CC60 /* NSInvocationInSetFix.h in Headers */ = {isa = PBXBuildFile; fileRef = CC8D774A19660E230035CC60 /* NSInvocationInSetFix.h */; };
+		CC8D774E19660E230035CC60 /* NSInvocationInSetFix.m in Sources */ = {isa = PBXBuildFile; fileRef = CC8D774B19660E230035CC60 /* NSInvocationInSetFix.m */; };
+		CC8D774F19660E230035CC60 /* NSInvocationInSetFix.m in Sources */ = {isa = PBXBuildFile; fileRef = CC8D774B19660E230035CC60 /* NSInvocationInSetFix.m */; };
+		CC8D775019660E230035CC60 /* NSInvocationInSetFix.m in Sources */ = {isa = PBXBuildFile; fileRef = CC8D774B19660E230035CC60 /* NSInvocationInSetFix.m */; };
 		CD66612D175D1A890057DF4D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD9049011756C5B1006CF16D /* Foundation.framework */; };
 		CD9049021756C5B1006CF16D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD9049011756C5B1006CF16D /* Foundation.framework */; };
 /* End PBXBuildFile section */
@@ -92,6 +97,8 @@
 		CC12CBF918E54A3700AA76E9 /* otest-query-ios-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "otest-query-ios-Prefix.pch"; sourceTree = "<group>"; };
 		CC12CBFC18E54A4200AA76E9 /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		CC12CBFD18E54A4200AA76E9 /* otest-query-osx-Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "otest-query-osx-Prefix.pch"; sourceTree = "<group>"; };
+		CC8D774A19660E230035CC60 /* NSInvocationInSetFix.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = NSInvocationInSetFix.h; path = ../Common/NSInvocationInSetFix.h; sourceTree = "<group>"; };
+		CC8D774B19660E230035CC60 /* NSInvocationInSetFix.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = NSInvocationInSetFix.m; path = ../Common/NSInvocationInSetFix.m; sourceTree = "<group>"; };
 		CD66612C175D1A890057DF4D /* otest-query-osx */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "otest-query-osx"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD666138175D1B090057DF4D /* otest-query-osx.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "otest-query-osx.xcconfig"; sourceTree = "<group>"; };
 		CD9048FE1756C5B1006CF16D /* otest-query-ios */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "otest-query-ios"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -163,6 +170,8 @@
 				28E44D4C1810FA5300211BD5 /* ParseTestName.m */,
 				90ED5F2118E4FC04001B2B14 /* SenIsSuperclassOfClassPerformanceFix.h */,
 				90ED5F2218E4FC04001B2B14 /* SenIsSuperclassOfClassPerformanceFix.m */,
+				CC8D774A19660E230035CC60 /* NSInvocationInSetFix.h */,
+				CC8D774B19660E230035CC60 /* NSInvocationInSetFix.m */,
 				2887CC33181DDB5F00B0D049 /* Swizzle.h */,
 				2887CC34181DDB5F00B0D049 /* Swizzle.m */,
 				AA318BE317E9A8C000BF159E /* TestingFramework.h */,
@@ -246,6 +255,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CC8D774C19660E230035CC60 /* NSInvocationInSetFix.h in Headers */,
 				AA318BE417E9A8C000BF159E /* TestingFramework.h in Headers */,
 				2887CC35181DDB5F00B0D049 /* Swizzle.h in Headers */,
 				2887CC3B181E0D8600B0D049 /* DuplicateTestNameFix.h in Headers */,
@@ -257,6 +267,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CC8D774D19660E230035CC60 /* NSInvocationInSetFix.h in Headers */,
 				CC12CBF418E54A1400AA76E9 /* OtestQuery.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -437,6 +448,7 @@
 				2887CC3E181E0D8600B0D049 /* DuplicateTestNameFix.m in Sources */,
 				28E44D4F1810FBE500211BD5 /* ParseTestName.m in Sources */,
 				2887CC38181DDB5F00B0D049 /* Swizzle.m in Sources */,
+				CC8D774F19660E230035CC60 /* NSInvocationInSetFix.m in Sources */,
 				90ED5F2518E4FC0C001B2B14 /* SenIsSuperclassOfClassPerformanceFix.m in Sources */,
 				28660742183471FF000ACB87 /* otest-query-lib.m in Sources */,
 				AA318BE817E9AA7400BF159E /* TestingFramework.m in Sources */,
@@ -452,6 +464,7 @@
 				2866076E18347528000ACB87 /* otest-query-lib.m in Sources */,
 				2866076918347520000ACB87 /* DuplicateTestNameFix.m in Sources */,
 				90ED5F2618E4FC0C001B2B14 /* SenIsSuperclassOfClassPerformanceFix.m in Sources */,
+				CC8D775019660E230035CC60 /* NSInvocationInSetFix.m in Sources */,
 				2866076A18347520000ACB87 /* ParseTestName.m in Sources */,
 				2866076B18347520000ACB87 /* Swizzle.m in Sources */,
 				2866076C18347520000ACB87 /* TestingFramework.m in Sources */,
@@ -467,6 +480,7 @@
 				CC12CBFF18E54A7700AA76E9 /* DuplicateTestNameFix.m in Sources */,
 				CC12CC0018E54A7700AA76E9 /* ParseTestName.m in Sources */,
 				90ED5F2418E4FC04001B2B14 /* SenIsSuperclassOfClassPerformanceFix.m in Sources */,
+				CC8D774E19660E230035CC60 /* NSInvocationInSetFix.m in Sources */,
 				CC12CC0118E54A7700AA76E9 /* Swizzle.m in Sources */,
 				CC12CC0218E54A7700AA76E9 /* TestingFramework.m in Sources */,
 				CC12CC0318E54A7700AA76E9 /* XcodeRequiredVersion.m in Sources */,

--- a/otest-shim/otest-shim.xcodeproj/project.pbxproj
+++ b/otest-shim/otest-shim.xcodeproj/project.pbxproj
@@ -49,6 +49,10 @@
 		90F7485718E4FAFF00600D5C /* SenIsSuperclassOfClassPerformanceFix.m in Sources */ = {isa = PBXBuildFile; fileRef = 90F7485318E4FAFF00600D5C /* SenIsSuperclassOfClassPerformanceFix.m */; };
 		AA318BEA17E9B43000BF159E /* XCTest.h in Headers */ = {isa = PBXBuildFile; fileRef = AA318BE917E9B43000BF159E /* XCTest.h */; };
 		AA318BEB17E9B43000BF159E /* XCTest.h in Headers */ = {isa = PBXBuildFile; fileRef = AA318BE917E9B43000BF159E /* XCTest.h */; };
+		CC8D7759196623160035CC60 /* NSInvocationInSetFix.h in Headers */ = {isa = PBXBuildFile; fileRef = CC8D7757196623160035CC60 /* NSInvocationInSetFix.h */; };
+		CC8D775A196623160035CC60 /* NSInvocationInSetFix.h in Headers */ = {isa = PBXBuildFile; fileRef = CC8D7757196623160035CC60 /* NSInvocationInSetFix.h */; };
+		CC8D775B196623160035CC60 /* NSInvocationInSetFix.m in Sources */ = {isa = PBXBuildFile; fileRef = CC8D7758196623160035CC60 /* NSInvocationInSetFix.m */; };
+		CC8D775C196623160035CC60 /* NSInvocationInSetFix.m in Sources */ = {isa = PBXBuildFile; fileRef = CC8D7758196623160035CC60 /* NSInvocationInSetFix.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -85,6 +89,8 @@
 		90F7485218E4FAFF00600D5C /* SenIsSuperclassOfClassPerformanceFix.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SenIsSuperclassOfClassPerformanceFix.h; sourceTree = "<group>"; };
 		90F7485318E4FAFF00600D5C /* SenIsSuperclassOfClassPerformanceFix.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SenIsSuperclassOfClassPerformanceFix.m; sourceTree = "<group>"; };
 		AA318BE917E9B43000BF159E /* XCTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XCTest.h; sourceTree = "<group>"; };
+		CC8D7757196623160035CC60 /* NSInvocationInSetFix.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSInvocationInSetFix.h; sourceTree = "<group>"; };
+		CC8D7758196623160035CC60 /* NSInvocationInSetFix.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSInvocationInSetFix.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -179,6 +185,8 @@
 				2866077318348676000ACB87 /* dyld_priv.h */,
 				3892D7571815ACE200E68652 /* EventGenerator.h */,
 				3892D7581815ACE200E68652 /* EventGenerator.m */,
+				CC8D7757196623160035CC60 /* NSInvocationInSetFix.h */,
+				CC8D7758196623160035CC60 /* NSInvocationInSetFix.m */,
 				28E44D501811024F00211BD5 /* ParseTestName.h */,
 				28E44D511811024F00211BD5 /* ParseTestName.m */,
 				28E28FB317968EC50072376C /* ReporterEvents.h */,
@@ -203,6 +211,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA318BEB17E9B43000BF159E /* XCTest.h in Headers */,
+				CC8D775A196623160035CC60 /* NSInvocationInSetFix.h in Headers */,
 				28E44D531811024F00211BD5 /* ParseTestName.h in Headers */,
 				2887CC48181E145D00B0D049 /* TestingFramework.h in Headers */,
 				2839BE8C1843CCFF000D7BEC /* SenTestCaseInvokeTestFix.h in Headers */,
@@ -220,6 +229,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				28E44D521811024F00211BD5 /* ParseTestName.h in Headers */,
+				CC8D7759196623160035CC60 /* NSInvocationInSetFix.h in Headers */,
 				3892D7591815ACE200E68652 /* EventGenerator.h in Headers */,
 				2887CC47181E145D00B0D049 /* TestingFramework.h in Headers */,
 				2839BE8B1843CCFF000D7BEC /* SenTestCaseInvokeTestFix.h in Headers */,
@@ -340,6 +350,7 @@
 				2839BE63183FEB6F000D7BEC /* SenTestClassEnumeratorFix.m in Sources */,
 				90F7485718E4FAFF00600D5C /* SenIsSuperclassOfClassPerformanceFix.m in Sources */,
 				2839BE8E1843CCFF000D7BEC /* SenTestCaseInvokeTestFix.m in Sources */,
+				CC8D775C196623160035CC60 /* NSInvocationInSetFix.m in Sources */,
 				2887CC4A181E145D00B0D049 /* TestingFramework.m in Sources */,
 				3892D75C1815ACE200E68652 /* EventGenerator.m in Sources */,
 				282BFE2B1716044C0022F9FF /* otest-shim.m in Sources */,
@@ -357,6 +368,7 @@
 				2839BE62183FEB6F000D7BEC /* SenTestClassEnumeratorFix.m in Sources */,
 				90F7485618E4FAFF00600D5C /* SenIsSuperclassOfClassPerformanceFix.m in Sources */,
 				2839BE8D1843CCFF000D7BEC /* SenTestCaseInvokeTestFix.m in Sources */,
+				CC8D775B196623160035CC60 /* NSInvocationInSetFix.m in Sources */,
 				2887CC49181E145D00B0D049 /* TestingFramework.m in Sources */,
 				3892D75B1815ACE200E68652 /* EventGenerator.m in Sources */,
 				283CCA9A16C2EE4C00F2E343 /* otest-shim.m in Sources */,

--- a/otest-shim/otest-shim/otest-shim.m
+++ b/otest-shim/otest-shim/otest-shim.m
@@ -26,6 +26,7 @@
 
 #import "DuplicateTestNameFix.h"
 #import "EventGenerator.h"
+#import "NSInvocationInSetFix.h"
 #import "ParseTestName.h"
 #import "ReporterEvents.h"
 #import "SenIsSuperclassOfClassPerformanceFix.h"


### PR DESCRIPTION
 By replacing default implementation of `isEqual` and `hash` we could guarantee
 that there will be no test duplicates in test suites.

 [Based on SenTesting framework implementation of category 
 NSObject (SenTestRuntimeUtilities) found in NSObject_SenTestRuntimeUtilities.m]
 Duplicates appear because SenTesting and XCTest frameworks are recursively 
 retrieving methods for a particular test case class starting from class itself
 and moving to its parent class which could also be a test case with tests. For
 each method `NSInvocation` object is created with corresponding `selector`.
 If child class implements test with the name which also exists in parent
 class then [*TestSuite allTests] returns two test cases with the same name but
 the same target which is incorrect.

 As it was found in SenTesting framework in NSObject (SenTestRuntimeUtilities)
 in method `+ (NSArray *) senAllInstanceInvocations` all invocations are stored
 in `NSSet`. Before adding new object `NSSet` checks if the same object is already
 added by using `isEqual:` and `hash`. So in this category we are returning `YES`
 in `isEqual:` if selectors of both invocations are equal and `hash` based on
 string representation of invocation selector.
