### PR TITLE
Memory improvements when reading stderr of octest/xctest. Attaching read stderr only to place holder test rather then to all tests in the bundle.

### DIFF
--- a/xctool/xctool/OCUnitIOSLogicTestRunner.m
+++ b/xctool/xctool/OCUnitIOSLogicTestRunner.m
@@ -64,8 +64,10 @@
   }
 
   if (bundleExists) {
-    NSPipe *outputPipe = [NSPipe pipe];
+    NSString *output = nil;
     @autoreleasepool {
+      NSPipe *outputPipe = [NSPipe pipe];
+
       NSTask *task = [self otestTaskWithTestBundle:testBundlePath];
 
       // Don't let STDERR pass through.  This silences the warning message that
@@ -76,9 +78,11 @@
       LaunchTaskAndFeedOuputLinesToBlock(task,
                                          @"running otest/xctest on test bundle",
                                          outputLineBlock);
+
+      NSData *outputData = [[outputPipe fileHandleForReading] readDataToEndOfFile];
+      output = [[NSString alloc] initWithData:outputData encoding:NSUTF8StringEncoding];
     }
-    NSData *outputData = [[outputPipe fileHandleForReading] readDataToEndOfFile];
-    *otherErrors = [[[NSString alloc] initWithData:outputData encoding:NSUTF8StringEncoding] autorelease];
+    *otherErrors = [output autorelease];
   } else {
     *startupError = [NSString stringWithFormat:@"Test bundle not found at: %@", testBundlePath];
   }

--- a/xctool/xctool/TestRunState.m
+++ b/xctool/xctool/TestRunState.m
@@ -176,15 +176,13 @@
 
   // All tests should include this message.
   NSString *output = @"Test did not run: the test bundle stopped running or crashed before the test suite started.";
-  if (otherErrors) {
-    output = [output stringByAppendingFormat:@" Stderr output: %@", otherErrors];
-  }
   [_testSuiteState.tests makeObjectsPerformSelector:@selector(appendOutput:)
                                          withObject:output];
 
   // And, our "place holder" test should have a more detailed message about
   // what we think went wrong.
-  NSString *fakeTestOutput = [NSString stringWithFormat:@"%@\n%@",
+  NSString *fakeTestOutput = [NSString stringWithFormat:@"%@\n%@\n%@",
+                              otherErrors ?: @"",
                               _outputBeforeTestsStart,
                               [self collectCrashReports:_crashReportsAtStart]];
   fakeTestOutput = [fakeTestOutput stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];


### PR DESCRIPTION
Moved `NSPipe` and `NSData` under `@autoreleasepool`.
In case of crash attaching stderr of octest/xctest only to "place holder" test rather then to all tests in the test bundle.
