### PR TITLE
Updated printed details of run-test action.

### DIFF
--- a/Common/ReporterEvents.h
+++ b/Common/ReporterEvents.h
@@ -49,6 +49,7 @@
 
 #define kReporter_BeginOCUnit_BundleNameKey @"bundleName"
 #define kReporter_BeginOCUnit_SDKNameKey @"sdkName"
+#define kReporter_BeginOCUnit_DeviceNameKey @"deviceName"
 #define kReporter_BeginOCUnit_TestTypeKey @"testType"
 #define kReporter_BeginOCUnit_TargetNameKey @"targetName"
 

--- a/reporters/text/TextReporter.m
+++ b/reporters/text/TextReporter.m
@@ -601,6 +601,10 @@ static NSString *abbreviatePath(NSString *string) {
     [attributes addObject:event[kReporter_BeginOCUnit_SDKNameKey]];
   }
 
+  if (event[kReporter_BeginOCUnit_DeviceNameKey]) {
+    [attributes addObject:event[kReporter_BeginOCUnit_DeviceNameKey]];
+  }
+
   if (event[kReporter_BeginOCUnit_TestTypeKey]) {
     [attributes addObject:event[kReporter_BeginOCUnit_TestTypeKey]];
   }


### PR DESCRIPTION
Before that commit we were printing next run-test details:

```
run-test TestProject-LibraryTests.octest (iphonesimulator8.0, logic-test)
```

Those details could be wrong because actual simulator version is defined by `-destination` flag if so is provided and not by `Xcode_SDK_NAME` in build settings.

This commit respects `-destination` argument and prints actual arguments used to launch simulator:

```
 run-test TestProject-LibraryTests.octest (7.1, iPhone 5s, logic-test)
```
