### PR TITLE
Improved enumeration of folder with crash reports. Safer manipulation with strings.

### DIFF
--- a/xctool/xctool/TestRunState.m
+++ b/xctool/xctool/TestRunState.m
@@ -261,17 +261,15 @@
     return @[];
   }
 
-  NSError *error = nil;
-  NSArray *allContents = [fm contentsOfDirectoryAtPath:diagnosticReportsPath
-                                                 error:&error];
-  NSAssert(error == nil, @"Failed getting contents of directory: %@", error);
-
   NSMutableArray *matchingContents = [NSMutableArray array];
-
-  for (NSString *path in allContents) {
-    if ([[path pathExtension] isEqualToString:@"crash"]) {
-      NSString *fullPath = [[@"~/Library/Logs/DiagnosticReports" stringByAppendingPathComponent:path] stringByStandardizingPath];
-      [matchingContents addObject:fullPath];
+  NSDirectoryEnumerator *enumerator = [fm enumeratorAtURL:[NSURL fileURLWithPath:diagnosticReportsPath]
+                               includingPropertiesForKeys:nil
+                                                  options:NSDirectoryEnumerationSkipsHiddenFiles
+                                             errorHandler:nil];
+  NSURL *fileUrl = nil;
+  while ((fileUrl = [enumerator nextObject])) {
+    if ([[fileUrl pathExtension] isEqualToString:@"crash"]) {
+      [matchingContents addObject:fileUrl];
     }
   }
 
@@ -282,12 +280,15 @@
 {
   NSMutableString *buffer = [NSMutableString string];
 
-  for (NSString *path in reports) {
-    NSString *crashReportText = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:nil];
+  for (NSURL *fileURL in reports) {
+    NSString *crashReportText = [NSString stringWithContentsOfURL:fileURL encoding:NSUTF8StringEncoding error:nil];
     // Throw out everything below "Binary Images" - we mostly just care about the thread backtraces.
-    NSString *minimalCrashReportText = [crashReportText substringToIndex:[crashReportText rangeOfString:@"\nBinary Images:"].location];
-
-    [buffer appendFormat:@"CRASH REPORT: %@\n\n", [path lastPathComponent]];
+    NSRange range = [crashReportText rangeOfString:@"\nBinary Images:"];
+    if (!crashReportText || range.location == NSNotFound) {
+      continue;
+    }
+    NSString *minimalCrashReportText = [crashReportText substringToIndex:range.location];
+    [buffer appendFormat:@"CRASH REPORT: %@\n\n", [fileURL lastPathComponent]];
     [buffer appendString:minimalCrashReportText];
     [buffer appendString:@"\n"];
   }


### PR DESCRIPTION
- Replaced `NSFileManager` `contentsOfDirectoryAtPath:error:` with `enumeratorAtURL:..` which returns ready-to-use `NSURL`s so we avoid manipulation with paths and creating of new objects.
- When composing crash report strings from new crash report files we were ignoring potential errors. Added check if actual string from file was initialized and if it is in correct format.
