### PR TITLE
fix typo in xctool.xcconfig

### DIFF
--- a/xctool/xctool.xcconfig
+++ b/xctool/xctool.xcconfig
@@ -27,7 +27,7 @@ XCTOOL_VENDOR_DIR = $(SRCROOT)/../Vendor
 // xctool will weak link iPhoneSimulatorRemoteClient, and then configure the necessary
 // DYLD paths on startup to make sure the framework can be loaded.
 OTHER_LDFLAGS_0500 = -weak_framework DVTFoundation -weak_framework DVTiPhoneSimulatorRemoteClient -weak_framework SimulatorHost
-OTHER_LDFLAGS_0600 = -weak_framework DVTFoundation -weak_framework DVTiPhoneSimulatorRemoteClient -weak_framework CoreSimulator -Wl,-rpath -Wl,$(PRIVATE_FRAMEWORKS_DIR) -Wl,-rpath -Wl,$(SHARED_FRAMEWORKS_DIR
+OTHER_LDFLAGS_0600 = -weak_framework DVTFoundation -weak_framework DVTiPhoneSimulatorRemoteClient -weak_framework CoreSimulator -Wl,-rpath -Wl,$(PRIVATE_FRAMEWORKS_DIR) -Wl,-rpath -Wl,$(SHARED_FRAMEWORKS_DIR)
 
 OTHER_LDFLAGS = $(OTHER_LDFLAGS_$(XCODE_VERSION_MAJOR))
 


### PR DESCRIPTION
The paren was lacking, I don't know if it is actually supposed to be there, but the open paren seemed a little lonely.
