### PR TITLE
Allow Swift modules in class name passed to ParseClassAndMethodFromTestName

### DIFF
--- a/Common/ParseTestName.m
+++ b/Common/ParseTestName.m
@@ -8,7 +8,7 @@ void ParseClassAndMethodFromTestName(NSString **className, NSString **methodName
   NSCAssert(testName, @"testName should be non-nil");
 
   NSRegularExpression *testNameRegex =
-  [NSRegularExpression regularExpressionWithPattern:@"^-\\[(\\w+) (\\w+)\\]$"
+  [NSRegularExpression regularExpressionWithPattern:@"^-\\[([\\w.]+) (\\w+)\\]$"
                                             options:0
                                               error:nil];
   NSTextCheckingResult *match =


### PR DESCRIPTION
I'm not sure if this is the correct way to fix this issue, but as of Xcode 6 Beta 5, xctool will crash when trying to run tests for the default Xcode Swift iOS project template. An assertion fails resulting in this error:

```
2014-08-08 16:52:50.307 XCToolTestApp[96581:13240590] *** Assertion failure in void ParseClassAndMethodFromTestName(NSString **, NSString **, NSString *)(), /Users/alex/code/xctool/Common/ParseTestName.m:19
2014-08-08 16:52:50.341 XCToolTestApp[96581:13240590] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Test name seems to be malformed: -[XCToolTestAppTests.SomeTests testExample]'
```

I changed `ParseClassAndMethodFromTestName` to allow the `.` in the `ModuleName`.`ClassName` syntax passed in, however I'm not sure if it might be more correct to strip off the module name. Note also that as a temporary workaround, annotating the test class definition with `@objc(TestClassName)` will avoid the assertion failure.
