### PR TITLE
fix parsing iphone simulator sdk versions for xcode 6.6

### DIFF
--- a/Vendor/clang-as-ios-dylib/clang-as-ios-dylib.py
+++ b/Vendor/clang-as-ios-dylib/clang-as-ios-dylib.py
@@ -100,14 +100,14 @@ def get_args_without_osxims():
 
 
 def get_iphonesimulator_sdk_versions_for_arch(developer_dir, arch):
-    sdk_paths = glob.glob(os.path.join(
-        developer_dir,
-        'Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator*.sdk'))
-    sdk_paths.sort()
-    sdk_names = [os.path.basename(sdk_path) for sdk_path in sdk_paths]
+    sdks_dir = os.path.join(
+        developer_dir, 'Platforms/iPhoneSimulator.platform/Developer/SDKs/')
+    filenames = os.listdir(sdks_dir)
+    pattern = re.compile(r'iPhoneSimulator(.+?)\.sdk')
+
     sdk_versions = [
-        re.match(r'iPhoneSimulator(.+?)\.sdk', sdk_name).group(1) for sdk_name
-        in sdk_names]
+        re.match(pattern, filename).group(1) for filename
+        in filenames if re.match(pattern, filename)]
 
     # Only 7.0+ supports x86_64 builds.
     if arch == 'x86_64':
@@ -118,7 +118,7 @@ def get_iphonesimulator_sdk_versions_for_arch(developer_dir, arch):
     if len(sdk_versions) == 0:
         raise Exception('No matching SDK for arch %s' % arch)
 
-    return sdk_versions
+    return sorted(sdk_versions, key=float)
 
 
 def get_latest_iphonesimulator_sdk_version_arch(developer_dir, arch):


### PR DESCRIPTION
In the new beta version 6 of XCode 6 the 
**$DEVELOPER_DIR/Platforms/iPhoneSimulator.platform/Developer/SDKs** directory now includes a folder named  _iPhoneSimulator.sdk_. The directory does not appear to be present in Xcode 5, nor in any other Xcode 6 beta versions. This change causes the current xctool code to fail with an **AttributeError** on **NoneType** object. This is due to the fact that the _glob_ expression matches this new directory (even though it does not include a version specifier) and the regular expression group lookup for the version specifier is done without checking for a match.

The changes I have made:
1. since _glob_ does not provide a way to specify 'at least one' quantifier (+), I have used _os.listdir()_ instead, this simplifies the code such that _basename_ calls are no longer needed.  
2. added the match check to the list comprehension to only look up the group for matching directories
3. the final change concerns sorting. if filenames are sorted as strings, version _10.0_ appears before version _9.0_. I have sorted them as floats instead.
