### PR TITLE
Always list tests and invert scope when running logic tests in Xcode 6.

### DIFF
--- a/xctool/xctool-tests/OCUnitTestRunnerTests.m
+++ b/xctool/xctool-tests/OCUnitTestRunnerTests.m
@@ -314,12 +314,22 @@ static int NumberOfEntries(NSArray *array, NSObject *target)
 
   OCUnitTestRunner *runner = TestRunnerWithTestList([OCUnitTestRunner class], testSettings, @[@"Cls1/testA", @"Cls2/testB"]);
 
-  assertThat([runner testArguments],
-             containsArray(@[@"-SenTest",
-                             @"Self",
-                             @"-SenTestInvertScope",
-                             @"NO",
-                             ]));
+  // in Xcode 6 we are always inverting scope
+  if (ToolchainIsXcode6OrBetter()) {
+    assertThat([runner testArguments],
+               containsArray(@[@"-SenTest",
+                               @"",
+                               @"-SenTestInvertScope",
+                               @"YES",
+                               ]));
+  } else {
+    assertThat([runner testArguments],
+               containsArray(@[@"-SenTest",
+                               @"Self",
+                               @"-SenTestInvertScope",
+                               @"NO",
+                               ]));
+  }
 }
 
 - (void)testTestSpecifierIsAllWhenRunningAllTestsInApplicationTestBundle

--- a/xctool/xctool-tests/RunTestsActionTests.m
+++ b/xctool/xctool-tests/RunTestsActionTests.m
@@ -289,14 +289,25 @@ static BOOL areEqualJsonOutputsIgnoringKeys(NSString *output1, NSString *output2
                        @"test",
                        @"-showBuildSettings",
                        ]));
-    assertThat([launchedTasks[1] arguments],
-               containsArray(@[
-                               @"-NSTreatUnknownArgumentsAsOpen", @"NO",
-                               @"-ApplePersistenceIgnoreState", @"YES",
-                               @"-SenTest", @"Self",
-                               @"-SenTestInvertScope", @"NO",
-                               @"/Users/fpotter/Library/Developer/Xcode/DerivedData/TestProject-Library-amxcwsnetnrvhrdeikqmcczcgmwn/Build/Products/Debug-iphonesimulator/TestProject-LibraryTests.octest",
-                               ]));
+    if (ToolchainIsXcode6OrBetter()) {
+      assertThat([launchedTasks[1] arguments],
+                 containsArray(@[
+                                 @"-NSTreatUnknownArgumentsAsOpen", @"NO",
+                                 @"-ApplePersistenceIgnoreState", @"YES",
+                                 @"-SenTest", @"",
+                                 @"-SenTestInvertScope", @"YES",
+                                 @"/Users/fpotter/Library/Developer/Xcode/DerivedData/TestProject-Library-amxcwsnetnrvhrdeikqmcczcgmwn/Build/Products/Debug-iphonesimulator/TestProject-LibraryTests.octest",
+                                 ]));
+    } else {
+      assertThat([launchedTasks[1] arguments],
+                 containsArray(@[
+                                 @"-NSTreatUnknownArgumentsAsOpen", @"NO",
+                                 @"-ApplePersistenceIgnoreState", @"YES",
+                                 @"-SenTest", @"Self",
+                                 @"-SenTestInvertScope", @"NO",
+                                 @"/Users/fpotter/Library/Developer/Xcode/DerivedData/TestProject-Library-amxcwsnetnrvhrdeikqmcczcgmwn/Build/Products/Debug-iphonesimulator/TestProject-LibraryTests.octest",
+                                 ]));
+    }
     assertThatInt(tool.exitStatus, equalToInt(1));
   }];
 }
@@ -406,14 +417,26 @@ static BOOL areEqualJsonOutputsIgnoringKeys(NSString *output1, NSString *output2
                        @"test",
                        @"-showBuildSettings",
                        ]));
-    assertThat([launchedTasks[1] arguments],
-               containsArray(@[
-                               @"-NSTreatUnknownArgumentsAsOpen", @"NO",
-                               @"-ApplePersistenceIgnoreState", @"YES",
-                               @"-SenTest", @"Self",
-                               @"-SenTestInvertScope", @"NO",
-                               @"/Users/fpotter/Library/Developer/Xcode/DerivedData/TestProject-Library-amxcwsnetnrvhrdeikqmcczcgmwn/Build/Products/Debug-iphonesimulator/TestProject-LibraryTests.octest",
-                               ]));
+    // in Xcode 6 we are always inverting scope
+    if (ToolchainIsXcode6OrBetter()) {
+      assertThat([launchedTasks[1] arguments],
+                 containsArray(@[
+                                 @"-NSTreatUnknownArgumentsAsOpen", @"NO",
+                                 @"-ApplePersistenceIgnoreState", @"YES",
+                                 @"-SenTest", @"",
+                                 @"-SenTestInvertScope", @"YES",
+                                 @"/Users/fpotter/Library/Developer/Xcode/DerivedData/TestProject-Library-amxcwsnetnrvhrdeikqmcczcgmwn/Build/Products/Debug-iphonesimulator/TestProject-LibraryTests.octest",
+                                 ]));
+    } else {
+      assertThat([launchedTasks[1] arguments],
+                 containsArray(@[
+                                 @"-NSTreatUnknownArgumentsAsOpen", @"NO",
+                                 @"-ApplePersistenceIgnoreState", @"YES",
+                                 @"-SenTest", @"Self",
+                                 @"-SenTestInvertScope", @"NO",
+                                 @"/Users/fpotter/Library/Developer/Xcode/DerivedData/TestProject-Library-amxcwsnetnrvhrdeikqmcczcgmwn/Build/Products/Debug-iphonesimulator/TestProject-LibraryTests.octest",
+                                 ]));
+    }
     assertThatInt(tool.exitStatus, equalToInt(1));
   }];
 }

--- a/xctool/xctool/OCUnitTestRunner.m
+++ b/xctool/xctool/OCUnitTestRunner.m
@@ -174,7 +174,8 @@
   NSString *testSpecifier = nil;
   BOOL invertScope = NO;
 
-  if ([focusedSet isEqualToSet:allSet]) {
+  if ((!ToolchainIsXcode6OrBetter() || TestableSettingsIndicatesApplicationTest(_buildSettings)) &&
+      [focusedSet isEqualToSet:allSet]) {
 
     if (TestableSettingsIndicatesApplicationTest(_buildSettings)) {
       // Xcode.app will always pass 'All' when running all tests in an


### PR DESCRIPTION
For some reason if logic tests are run in parallel under Xcode 6 it happens that none of the tests are run in test bundle and only `{begin,end}-test-suite` events are populated to reporters.
Though the fix looks weird because now it will generate `-SenTest   -SenTestInvertScope YES` it seems to fix the issue and actually work.

The main suspicion is that it happens because of usage of `NSUserDefaults` in SenTesting/XCTest frameworks. Probably logic tests are overlapping at some point though it is not clear why it has started to happen only in Xcode 6.
