### PR TITLE
Append xcodebuild version to xctool build output directory.

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,7 +10,10 @@ REVISION=$( (\
   git --git-dir="${XCTOOL_DIR}/.git" log -n 1 --format=%h 2> /dev/null) || \
   echo ".")
 
-BUILD_OUTPUT_DIR="$XCTOOL_DIR"/build/$REVISION
+XCODEBUILD_VERSION=$(xcodebuild -version)
+XCODEBUILD_VERSION=`expr "$XCODEBUILD_VERSION" : '^.*Build version \(.*\)'`
+
+BUILD_OUTPUT_DIR="$XCTOOL_DIR"/build/$REVISION/$XCODEBUILD_VERSION
 XCTOOL_PATH="$BUILD_OUTPUT_DIR"/Products/Release/xctool
 BUILD_NEEDED_TOOL_PATH="$XCTOOL_DIR"/scripts/build_needed.sh
 BUILD_NEEDED=$("$BUILD_NEEDED_TOOL_PATH" $*)

--- a/scripts/build_needed.sh
+++ b/scripts/build_needed.sh
@@ -19,7 +19,10 @@ else
   HAS_GIT_CHANGES=NO
 fi
 
-BUILD_OUTPUT_DIR="$XCTOOL_DIR"/build/$REVISION
+XCODEBUILD_VERSION=$(xcodebuild -version)
+XCODEBUILD_VERSION=`expr "$XCODEBUILD_VERSION" : '^.*Build version \(.*\)'`
+
+BUILD_OUTPUT_DIR="$XCTOOL_DIR"/build/$REVISION/$XCODEBUILD_VERSION
 XCTOOL_PATH="$BUILD_OUTPUT_DIR"/Products/Release/bin/xctool
 
 if [[ -e "$XCTOOL_PATH" && $REVISION != "." && $HAS_GIT_CHANGES == "NO" && \

--- a/scripts/xctool.sh
+++ b/scripts/xctool.sh
@@ -48,4 +48,7 @@ REVISION=$((\
   git --git-dir="${XCTOOL_DIR}/.git" log -n 1 --format=%h 2> /dev/null) || \
   echo ".")
 
-"$XCTOOL_DIR"/build/$REVISION/Products/Release/bin/xctool "$@"
+XCODEBUILD_VERSION=$(xcodebuild -version)
+XCODEBUILD_VERSION=`expr "$XCODEBUILD_VERSION" : '^.*Build version \(.*\)'`
+
+"$XCTOOL_DIR"/build/$REVISION/$XCODEBUILD_VERSION/Products/Release/bin/xctool "$@"


### PR DESCRIPTION
After Xcode 6 support was added several macros were introduced to simplify switching between Xcode 5 and Xcode 6 implementations. These macros cause different runtime issues after switching from Xcode 5 to 6 or back that are hard to debug.
Let's improve build scripts so builds for different versions of xcodebuild are saved in different directories.
