### PR TITLE
Performance improvements.

### DIFF
--- a/xctool/xctool/SimulatorWrapper/SimulatorInfoXcode6.m
+++ b/xctool/xctool/SimulatorWrapper/SimulatorInfoXcode6.m
@@ -41,6 +41,11 @@ static const NSInteger KProductTypeIpad = 2;
 
 @end
 
+@interface SimulatorInfoXcode6 ()
+@property (nonatomic, retain) SimDevice *simulatedDevice;
+@property (nonatomic, retain) SimRuntime *simulatedRuntime;
+@end
+
 @implementation SimulatorInfoXcode6
 @synthesize buildSettings = _buildSettings;
 @synthesize cpuType = _cpuType;
@@ -158,20 +163,26 @@ static const NSInteger KProductTypeIpad = 2;
 
 - (SimRuntime *)simulatedRuntime
 {
-  return [[self systemRootForSimulatedSdk] runtime];
+  if (!_simulatedRuntime) {
+    _simulatedRuntime = [[self systemRootForSimulatedSdk] runtime];
+  }
+  return _simulatedRuntime;
 }
 
 - (SimDevice *)simulatedDevice
 {
-  SimRuntime *runtime = [self simulatedRuntime];
-  SimDeviceType *deviceType = [SimDeviceType supportedDeviceTypesByAlias][[self simulatedDeviceInfoName]];
-  for (SimDevice *device in [[SimDeviceSet defaultSet] availableDevices]) {
-    if ([device.deviceType isEqual:deviceType] &&
-        [device.runtime isEqual:runtime]) {
-      return device;
+  if (!_simulatedDevice) {
+    SimRuntime *runtime = [self simulatedRuntime];
+    SimDeviceType *deviceType = [SimDeviceType supportedDeviceTypesByAlias][[self simulatedDeviceInfoName]];
+    for (SimDevice *device in [[SimDeviceSet defaultSet] availableDevices]) {
+      if ([device.deviceType isEqual:deviceType] &&
+          [device.runtime isEqual:runtime]) {
+        _simulatedDevice = device;
+        break;
+      }
     }
   }
-  return nil;
+  return _simulatedDevice;
 }
 
 #pragma mark -

--- a/xctool/xctool/XCToolUtil.m
+++ b/xctool/xctool/XCToolUtil.m
@@ -711,14 +711,24 @@ NSString *XcodebuildVersion()
 
 BOOL ToolchainIsXcode5OrBetter(void)
 {
-  NSComparisonResult result = [XcodebuildVersion() compare:@"0500"];
-  return result == NSOrderedSame || result == NSOrderedDescending;
+  static BOOL result;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    NSComparisonResult cmpResult = [XcodebuildVersion() compare:@"0500"];
+    result = (cmpResult != NSOrderedAscending);
+  });
+  return result;
 }
 
 BOOL ToolchainIsXcode6OrBetter(void)
 {
-  NSComparisonResult result = [XcodebuildVersion() compare:@"0600"];
-  return result == NSOrderedSame || result == NSOrderedDescending;
+  static BOOL result;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    NSComparisonResult cmpResult = [XcodebuildVersion() compare:@"0600"];
+    result = (cmpResult != NSOrderedAscending);
+  });
+  return result;
 }
 
 NSString *MakeTemporaryDirectory(NSString *nameTemplate)


### PR DESCRIPTION
- `ToolchainIsXcodeXOrBetter` methods are going to be called in enough number of places to be finally cached.
- As soon as interacting with CoreSimulator framework is a little bit painful, `simulatedDevice` and `simulatedRuntime` could be cached as soon as they are not changed during tests.
