### PR TITLE
Added ability to override Xcode Developer directory.

### DIFF
--- a/xctool/xctool/XCToolUtil.m
+++ b/xctool/xctool/XCToolUtil.m
@@ -154,6 +154,11 @@ NSString *XcodeDeveloperDirPath(void)
 NSString *XcodeDeveloperDirPathViaForcedConcreteTask(BOOL forceConcreteTask)
 {
   NSString *(^getPath)() = ^{
+    char *envPathCStr = getenv("DEVELOPER_DIR");
+    if (envPathCStr) {
+      return [NSString stringWithCString:envPathCStr encoding:NSUTF8StringEncoding];
+    }
+
     NSTask *task = (forceConcreteTask ?
                     CreateConcreteTaskInSameProcessGroup() :
                     CreateTaskInSameProcessGroup());


### PR DESCRIPTION
Setting `DEVELOPER_DIR` variable forces `xctool` to use it instead of
default directory specified by `xcode-select`

This feature is desperately needed in cases when you want to build using different versions of Xcode on the same build box.
