### PR TITLE
Resolve symlinks in sdk paths and improve default simulator selection approach.

### DIFF
--- a/xctool/xctool/SimulatorWrapper/SimulatorInfoXcode6.m
+++ b/xctool/xctool/SimulatorWrapper/SimulatorInfoXcode6.m
@@ -89,12 +89,13 @@ static const NSInteger KProductTypeIpad = 2;
     return _deviceName;
   }
 
-  // return lowest device that supports simulated sdk
+  // return lowest device that has configuration with simulated sdk where lowest is defined
+  // by the order in the returned array of devices from `-[SimDeviceSet availableDevices]`
   SimRuntime *runtime = systemRoot.runtime;
   NSMutableArray *supportedDeviceTypes = [NSMutableArray array];
-  for (SimDeviceType *deviceType in [SimDeviceType supportedDeviceTypes]) {
-    if ([runtime supportsDeviceType:deviceType]) {
-      [supportedDeviceTypes addObject:deviceType];
+  for (SimDevice *device in [[SimDeviceSet defaultSet] availableDevices]) {
+    if ([device.runtime isEqual:runtime]) {
+      [supportedDeviceTypes addObject:device.deviceType];
     }
   }
 
@@ -311,6 +312,10 @@ static const NSInteger KProductTypeIpad = 2;
     map = [@{} mutableCopy];
     accessQueue = dispatch_queue_create("com.xctool.access_root_with_sdk_path", NULL);
   });
+
+  // In Xcode 6 latest sdk path could be a symlink to iPhoneSimulator.sdk.
+  // It should be resolved before comparing with `knownRoots` paths.
+  path = [path stringByResolvingSymlinksInPath];
 
   __block DTiPhoneSimulatorSystemRoot *root = nil;
   dispatch_sync(accessQueue, ^{


### PR DESCRIPTION
In this commit 2 problems are resolved, both could happen only if `-destination` option is not specified:
1) If xcodebuild is using latest sdk then sdk path could contain symlinks which should be resolved before trying to find appropriate `DTiPhoneSimulatorSystemRoot` instance to use. For example, in Xcode 6 last path component of `/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator8.0.sdk` is symlink pointing to `iPhoneSimulator.sdk` in the same directory.
2) It could happen that `SimRuntime` supports `SimDeviceType` but there is no available configuration of device with that runtime and device type. It is better to loop through available devices and choose the one that is available.

This commit should resolver issues mentioned in https://github.com/facebook/xctool/issues/405.
