### PR TITLE
Shutdown iOS Simulator before killing simulator jobs to avoid bad simulator state.

### DIFF
--- a/xctool/xctool/OCUnitIOSAppTestRunner.m
+++ b/xctool/xctool/OCUnitIOSAppTestRunner.m
@@ -22,6 +22,7 @@
 #import "SimulatorUtils.h"
 #import "SimulatorWrapper.h"
 #import "XcodeBuildSettings.h"
+#import "XCToolUtil.h"
 
 static const NSInteger kMaxInstallOrUninstallAttempts = 3;
 static const NSInteger kMaxRunTestsAttempts = 3;
@@ -65,6 +66,22 @@ static const NSInteger kMaxRunTestsAttempts = 3;
 
   void (^prepareSimulator)(BOOL freshSimulator, BOOL resetSimulator) = ^(BOOL freshSimulator, BOOL resetSimulator) {
     if (freshSimulator || resetSimulator) {
+      if (ToolchainIsXcode6OrBetter()) {
+        ReportStatusMessageBegin(_reporters,
+                                 REPORTER_MESSAGE_INFO,
+                                 @"Shutting down iOS Simulator...");
+        NSString *shutdownError = nil;
+        if (ShutdownSimulator(self.simulatorInfo, &shutdownError)) {
+          ReportStatusMessageEnd(_reporters,
+                                 REPORTER_MESSAGE_INFO,
+                                 @"Shut down iOS Simulator...");
+        } else {
+          ReportStatusMessageEnd(_reporters,
+                                 REPORTER_MESSAGE_WARNING,
+                                 @"Failed to shut down iOS Simulator with error: %@", shutdownError);
+        }
+      }
+
       ReportStatusMessageBegin(_reporters,
                                REPORTER_MESSAGE_INFO,
                                @"Stopping any existing iOS simulator jobs to get a "

--- a/xctool/xctool/SimulatorWrapper/SimulatorUtils.h
+++ b/xctool/xctool/SimulatorWrapper/SimulatorUtils.h
@@ -20,4 +20,4 @@
 
 void KillSimulatorJobs();
 BOOL RemoveSimulatorContentAndSettings(SimulatorInfo *simulatorInfo, NSString **removedPath, NSString **errorMessage);
-
+BOOL ShutdownSimulator(SimulatorInfo *simulatorInfo, NSString **errorMessage);

--- a/xctool/xctool/SimulatorWrapper/SimulatorUtils.m
+++ b/xctool/xctool/SimulatorWrapper/SimulatorUtils.m
@@ -140,3 +140,21 @@ BOOL RemoveSimulatorContentAndSettings(SimulatorInfo *simulatorInfo, NSString **
     return RemoveSimulatorContentAndSettingsFolder([simulatorInfo simulatedSdkShortVersion], [simulatorInfo cpuType], removedPath, errorMessage);
   }
 }
+
+BOOL ShutdownSimulator(SimulatorInfo *simulatorInfo, NSString **errorMessage)
+{
+  if ([simulatorInfo isKindOfClass:[SimulatorInfoXcode6 class]]) {
+    SimDevice *simulatedDevice = [(SimulatorInfoXcode6 *)simulatorInfo simulatedDevice];
+    NSError *error = nil;
+
+    if (simulatedDevice.state != SimDeviceStateShutdown) {
+      if (![simulatedDevice shutdownWithError:&error]) {
+        *errorMessage = [NSString stringWithFormat:@"Tried to shutdown the simulator but failed: %@; %@.",
+                         error.localizedDescription ?: @"Unknown error.",
+                         [error.userInfo[NSUnderlyingErrorKey] localizedDescription] ?: @""];
+        return NO;
+      }
+    }
+  }
+  return YES;
+}


### PR DESCRIPTION
In Xcode 6 simulator could be in different states: creating, shutdown, booting, booted or shutting down. If simulator is killed and didn't have chance to reset its state to `shutdown` and stuck in state `booted` then xctool will not be able to use that simulator anymore until the state is reset to `shutdown`. 

Luckily CoreSimulator framework provides methods to reset iOS Simulator state to `shutdown` which xctool will be using every time before killing all simulator jobs.
