### PR TITLE
Improve xctool binary compatibility when switching between different Xcode versions.

### DIFF
--- a/xctool/Headers/CoreSimulator/SimDevice.h
+++ b/xctool/Headers/CoreSimulator/SimDevice.h
@@ -6,7 +6,7 @@
 
 typedef void (^CDUnknownBlockType)(void);
 
-@class SimDeviceNotificationManager, SimDeviceSet, SimDeviceType, SimRuntime, SimServiceConnectionManager;
+@class SimDeviceNotificationManager, SimDeviceSet, SimDeviceType, SimRuntimeStub, SimServiceConnectionManager;
 
 typedef NS_ENUM(long long, SimDeviceState) {
   SimDeviceStateCreating = 0,
@@ -20,11 +20,11 @@ typedef NS_ENUM(long long, SimDeviceState) {
 @optional
 
 // initializers
-+ (id)createDeviceWithName:(NSString *)arg1 setPath:(NSString *)arg2 deviceType:(SimDeviceType *)arg3 runtime:(SimRuntime *)arg4;
-+ (id)simDevice:(id)arg1 UDID:(id)arg2 deviceType:(SimDeviceType *)arg3 runtime:(SimRuntime *)arg4 state:(unsigned long long)arg5 connectionManager:(id)arg6 setPath:(NSString *)arg7;
++ (id)createDeviceWithName:(NSString *)arg1 setPath:(NSString *)arg2 deviceType:(SimDeviceType *)arg3 runtime:(SimRuntimeStub *)arg4;
++ (id)simDevice:(id)arg1 UDID:(id)arg2 deviceType:(SimDeviceType *)arg3 runtime:(SimRuntimeStub *)arg4 state:(unsigned long long)arg5 connectionManager:(id)arg6 setPath:(NSString *)arg7;
 + (id)simDeviceAtPath:(id)arg1;
 
-- (id)initDevice:(id)arg1 UDID:(id)arg2 deviceType:(SimDeviceType *)arg3 runtime:(SimRuntime *)arg4 state:(unsigned long long)arg5 connectionManager:(id)arg6 setPath:(NSString *)arg7;
+- (id)initDevice:(id)arg1 UDID:(id)arg2 deviceType:(SimDeviceType *)arg3 runtime:(SimRuntimeStub *)arg4 state:(unsigned long long)arg5 connectionManager:(id)arg6 setPath:(NSString *)arg7;
 
 // properties
 @property(copy) NSUUID *UDID;
@@ -42,7 +42,7 @@ typedef NS_ENUM(long long, SimDeviceState) {
 @property(copy) NSString *name;
 @property(retain) SimDeviceNotificationManager *notificationManager;
 @property(retain) NSMutableDictionary *registeredServices;
-@property(retain) SimRuntime *runtime;
+@property(retain) SimRuntimeStub *runtime;
 @property(copy) NSString *setPath;
 @property(retain, nonatomic) NSDistantObject *simBridgeDistantObject;
 @property(retain, nonatomic) NSMachPort *simBridgePort;

--- a/xctool/Headers/CoreSimulator/SimDeviceSet.h
+++ b/xctool/Headers/CoreSimulator/SimDeviceSet.h
@@ -48,6 +48,13 @@
 
 @end
 
+#if XCODE_VERSION < 0600
+@interface SimDeviceSetStub : NSObject<SimDeviceSet>
+@end
+#else
 @interface SimDeviceSet : NSObject<SimDeviceSet>
 @end
+@interface SimDeviceSetStub : SimDeviceSet
+@end
+#endif
 

--- a/xctool/Headers/CoreSimulator/SimDeviceType.h
+++ b/xctool/Headers/CoreSimulator/SimDeviceType.h
@@ -51,6 +51,13 @@
 
 @end
 
+#if XCODE_VERSION < 0600
+@interface SimDeviceTypeStub : NSObject<SimDeviceType>
+@end
+#else
 @interface SimDeviceType : NSObject<SimDeviceType>
 @end
+@interface SimDeviceTypeStub : SimDeviceType
+@end
+#endif
 

--- a/xctool/Headers/CoreSimulator/SimRuntime.h
+++ b/xctool/Headers/CoreSimulator/SimRuntime.h
@@ -72,5 +72,12 @@ typedef void (^CDUnknownFunctionPointerType)(void);
 
 @end
 
+#if XCODE_VERSION < 0600
+@interface SimRuntimeStub : NSObject<SimRuntime, SimRuntimeDVTAdditions>
+@end
+#else
 @interface SimRuntime : NSObject<SimRuntime, SimRuntimeDVTAdditions>
 @end
+@interface SimRuntimeStub : SimRuntime
+@end
+#endif

--- a/xctool/Headers/SimulatorHost/ISHDeviceInfo.h
+++ b/xctool/Headers/SimulatorHost/ISHDeviceInfo.h
@@ -63,6 +63,12 @@
 
 @end
 
+#if XCODE_VERSION >= 0600
+@interface ISHDeviceInfoStub : NSObject<ISHDeviceInfo>
+@end
+#else
 @interface ISHDeviceInfo : NSObject<ISHDeviceInfo>
 @end
-
+@interface ISHDeviceInfoStub : ISHDeviceInfo
+@end
+#endif

--- a/xctool/Headers/SimulatorHost/ISHDeviceVersions.h
+++ b/xctool/Headers/SimulatorHost/ISHDeviceVersions.h
@@ -42,5 +42,12 @@
 
 @end
 
+#if XCODE_VERSION >= 0600
+@interface ISHDeviceVersionsStub : NSObject<ISHDeviceVersions>
+@end
+#else
 @interface ISHDeviceVersions : NSObject<ISHDeviceVersions>
 @end
+@interface ISHDeviceVersionsStub : ISHDeviceVersions
+@end
+#endif

--- a/xctool/Headers/SimulatorHost/ISHSDKInfo.h
+++ b/xctool/Headers/SimulatorHost/ISHSDKInfo.h
@@ -33,6 +33,12 @@
 
 @end
 
+#if XCODE_VERSION >= 0600
+@interface ISHSDKInfoStub : NSObject<ISHSDKInfo>
+@end
+#else
 @interface ISHSDKInfo : NSObject<ISHSDKInfo>
 @end
-
+@interface ISHSDKInfoStub : ISHSDKInfo
+@end
+#endif

--- a/xctool/Headers/iPhoneSimulatorRemoteClient/DTiPhoneSimulatorRemoteClient.h
+++ b/xctool/Headers/iPhoneSimulatorRemoteClient/DTiPhoneSimulatorRemoteClient.h
@@ -165,7 +165,7 @@ typedef void DVTConfinementServiceConnection;
 
 @end
 
-@class SimDevice, SimRuntime;
+@class SimDevice, SimRuntimeStub;
 
 @interface DTiPhoneSimulatorSessionConfig : NSObject <NSCopying>
 
@@ -174,7 +174,7 @@ typedef void DVTConfinementServiceConnection;
 @property(copy) DTiPhoneSimulatorApplicationSpecifier *applicationToSimulateOnStart;
 @property(retain) id confinementService;
 @property(retain) SimDevice *device;
-@property(retain) SimRuntime *runtime;
+@property(retain) SimRuntimeStub *runtime;
 @property BOOL launchForBackgroundFetch;
 @property(copy) NSString *localizedClientName;
 @property(copy) NSNumber *pid;
@@ -197,12 +197,12 @@ typedef void DVTConfinementServiceConnection;
 
 @interface DTiPhoneSimulatorSystemRoot : NSObject <NSCopying>
 
-@property(readonly) SimRuntime *runtime;
+@property(readonly) SimRuntimeStub *runtime;
 @property(copy) NSString *sdkDisplayName;
 @property(copy) NSString *sdkVersion;
 @property(copy) NSString *sdkRootPath;
 
-+ (id)rootWithSimRuntime:(id)arg1;
++ (id)rootWithSimRuntimeStub:(id)arg1;
 + (id)rootWithSDKVersion:(id)arg1;
 + (id)rootWithSDKPath:(id)arg1;
 + (id)defaultRoot;

--- a/xctool/xctool/SimulatorWrapper/SimulatorInfo.m
+++ b/xctool/xctool/SimulatorWrapper/SimulatorInfo.m
@@ -14,7 +14,7 @@
 // limitations under the License.
 //
 
-#import <Foundation/Foundation.h>
+#import "SimulatorInfo.h"
 
 #import "SimulatorInfoXcode5.h"
 #import "SimulatorInfoXcode6.h"
@@ -23,19 +23,9 @@
 
 @implementation SimulatorInfo
 
-+ (BOOL)isXcode6OrHigher
-{
-  static BOOL isXcode6OrHigher;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    isXcode6OrHigher = ToolchainIsXcode6OrBetter();
-  });
-  return isXcode6OrHigher;
-}
-
 + (Class)classBasedOnCurrentVersionOfXcode
 {
-  if ([self isXcode6OrHigher]) {
+  if (ToolchainIsXcode6OrBetter()) {
     return [SimulatorInfoXcode6 class];
   } else {
     return [SimulatorInfoXcode5 class];

--- a/xctool/xctool/SimulatorWrapper/SimulatorInfoXcode5.m
+++ b/xctool/xctool/SimulatorWrapper/SimulatorInfoXcode5.m
@@ -35,10 +35,10 @@ static const NSInteger KProductTypeIpad = 2;
 #pragma mark -
 #pragma mark Private methods
 
-+ (ISHSDKInfo *)sdkInfoForShortVersion:(NSString *)sdkVersion
++ (ISHSDKInfoStub *)sdkInfoForShortVersion:(NSString *)sdkVersion
 {
-  ISHDeviceVersions *versions = [ISHDeviceVersions sharedInstance];
-  for (ISHSDKInfo *sdkInfo in [versions allSDKs]) {
+  ISHDeviceVersionsStub *versions = [ISHDeviceVersionsStub sharedInstance];
+  for (ISHSDKInfoStub *sdkInfo in [versions allSDKs]) {
     if ([[sdkInfo shortVersionString] isEqualToString:sdkVersion]) {
       return sdkInfo;
     }
@@ -48,12 +48,12 @@ static const NSInteger KProductTypeIpad = 2;
 
 - (NSString *)maxSdkVersionForSimulatedDevice
 {
-  ISHDeviceVersions *versions = [ISHDeviceVersions sharedInstance];
-  ISHDeviceInfo *deviceInfo = [versions deviceInfoNamed:[self simulatedDeviceInfoName]];
+  ISHDeviceVersionsStub *versions = [ISHDeviceVersionsStub sharedInstance];
+  ISHDeviceInfoStub *deviceInfo = [versions deviceInfoNamed:[self simulatedDeviceInfoName]];
   NSAssert(deviceInfo, @"Device info wasn't found for device with name: %@", [self simulatedDeviceInfoName]);
-  ISHSDKInfo *maxSdk = nil;
+  ISHSDKInfoStub *maxSdk = nil;
   do {
-    for (ISHSDKInfo *sdkInfo in [versions allSDKs]) {
+    for (ISHSDKInfoStub *sdkInfo in [versions allSDKs]) {
       if (![deviceInfo supportsSDK:sdkInfo]) {
         continue;
       }
@@ -67,8 +67,8 @@ static const NSInteger KProductTypeIpad = 2;
       break;
     }
     if (!deviceInfo) {
-      NSArray *availableSdks = [[[ISHDeviceVersions sharedInstance] allSDKs] valueForKeyPath:@"shortVersionString"];
-      NSArray *availableDevices = [[ISHDeviceVersions sharedInstance] allDeviceNames];
+      NSArray *availableSdks = [[[ISHDeviceVersionsStub sharedInstance] allSDKs] valueForKeyPath:@"shortVersionString"];
+      NSArray *availableDevices = [[ISHDeviceVersionsStub sharedInstance] allDeviceNames];
       NSAssert(deviceInfo, @"There are not comptable devices and SDKs to simulate. Available devices: %@, sdk: %@", availableDevices, availableSdks);
     }
   } while (true);
@@ -111,13 +111,13 @@ static const NSInteger KProductTypeIpad = 2;
       break;
   }
 
-  ISHSDKInfo *sdkInfo = [[ISHDeviceVersions sharedInstance] sdkFromSDKRoot:_buildSettings[Xcode_SDKROOT]];
+  ISHSDKInfoStub *sdkInfo = [[ISHDeviceVersionsStub sharedInstance] sdkFromSDKRoot:_buildSettings[Xcode_SDKROOT]];
   if (!sdkInfo) {
     return _deviceName;
   }
 
-  ISHDeviceVersions *versions = [ISHDeviceVersions sharedInstance];
-  ISHDeviceInfo *deviceInfo = [versions deviceInfoNamed:_deviceName];
+  ISHDeviceVersionsStub *versions = [ISHDeviceVersionsStub sharedInstance];
+  ISHDeviceInfoStub *deviceInfo = [versions deviceInfoNamed:_deviceName];
   while (deviceInfo && ![deviceInfo supportsSDK:sdkInfo]) {
     deviceInfo = [deviceInfo newerEquivalent];
     self.deviceName = [deviceInfo displayName];
@@ -142,7 +142,7 @@ static const NSInteger KProductTypeIpad = 2;
 {
   if (_OSVersion) {
     if ([_OSVersion isEqualTo:@"latest"]) {
-      return [[[ISHDeviceVersions sharedInstance] sdkFromSDKRoot:[[ISHDeviceVersions sharedInstance] latestSDKRoot]] shortVersionString];
+      return [[[ISHDeviceVersionsStub sharedInstance] sdkFromSDKRoot:[[ISHDeviceVersionsStub sharedInstance] latestSDKRoot]] shortVersionString];
     } else {
       return _OSVersion;
     }
@@ -158,7 +158,7 @@ static const NSInteger KProductTypeIpad = 2;
 
 - (NSString *)simulatedSdkShortVersion
 {
-  ISHSDKInfo *sdkInfo = [[ISHDeviceVersions sharedInstance] sdkFromSDKRoot:[self simulatedSdkRootPath]];
+  ISHSDKInfoStub *sdkInfo = [[ISHDeviceVersionsStub sharedInstance] sdkFromSDKRoot:[self simulatedSdkRootPath]];
   return [sdkInfo shortVersionString];
 }
 
@@ -172,7 +172,7 @@ static const NSInteger KProductTypeIpad = 2;
 
   systemRoot = [SimulatorInfoXcode5 _systemRootWithSDKVersion:sdkVersion];
   if (!systemRoot) {
-    NSArray *availableSdks = [[[ISHDeviceVersions sharedInstance] allSDKs] valueForKeyPath:@"shortVersionString"];
+    NSArray *availableSdks = [[[ISHDeviceVersionsStub sharedInstance] allSDKs] valueForKeyPath:@"shortVersionString"];
     NSAssert(systemRoot != nil, @"Unable to instantiate DTiPhoneSimulatorSystemRoot for sdk version: %@. Available sdks: %@", sdkVersion, availableSdks);
   }
   return systemRoot;
@@ -183,7 +183,7 @@ static const NSInteger KProductTypeIpad = 2;
 
 + (NSArray *)availableDevices
 {
-  return [[ISHDeviceVersions sharedInstance] allDeviceNames];
+  return [[ISHDeviceVersionsStub sharedInstance] allDeviceNames];
 }
 
 + (NSString *)deviceNameForAlias:(NSString *)deviceAlias
@@ -193,13 +193,13 @@ static const NSInteger KProductTypeIpad = 2;
 
 + (BOOL)isDeviceAvailableWithAlias:(NSString *)deviceName
 {
-  return [[ISHDeviceVersions sharedInstance] deviceInfoNamed:deviceName] != nil;
+  return [[ISHDeviceVersionsStub sharedInstance] deviceInfoNamed:deviceName] != nil;
 }
 
-+ (ISHSDKInfo *)sdkWithVersion:(NSString *)sdkVersion
++ (ISHSDKInfoStub *)sdkWithVersion:(NSString *)sdkVersion
 {
-  __block ISHSDKInfo *sdkInfo = nil;
-  [[[ISHDeviceVersions sharedInstance] allSDKs] enumerateObjectsUsingBlock:^(ISHSDKInfo *currentSdkInfo, NSUInteger idx, BOOL *stop) {
+  __block ISHSDKInfoStub *sdkInfo = nil;
+  [[[ISHDeviceVersionsStub sharedInstance] allSDKs] enumerateObjectsUsingBlock:^(ISHSDKInfoStub *currentSdkInfo, NSUInteger idx, BOOL *stop) {
     if ([[currentSdkInfo shortVersionString] hasPrefix:sdkVersion]) {
       sdkInfo = currentSdkInfo;
       *stop = YES;
@@ -210,16 +210,16 @@ static const NSInteger KProductTypeIpad = 2;
 
 + (BOOL)isSdkVersion:(NSString *)sdkVersion supportedByDevice:(NSString *)deviceName
 {
-  ISHDeviceInfo *deviceInfo = [[ISHDeviceVersions sharedInstance] deviceInfoNamed:deviceName];
-  ISHSDKInfo *sdkInfo = [self sdkWithVersion:sdkVersion];
+  ISHDeviceInfoStub *deviceInfo = [[ISHDeviceVersionsStub sharedInstance] deviceInfoNamed:deviceName];
+  ISHSDKInfoStub *sdkInfo = [self sdkWithVersion:sdkVersion];
   return [deviceInfo supportsSDK:sdkInfo];
 }
 
 + (NSString *)sdkVersionForOSVersion:(NSString *)osVersion
 {
-  ISHSDKInfo *sdkInfo = nil;
+  ISHSDKInfoStub *sdkInfo = nil;
   if ([osVersion isEqualToString:@"latest"]) {
-    sdkInfo = [[ISHDeviceVersions sharedInstance] sdkFromSDKRoot:[[ISHDeviceVersions sharedInstance] latestSDKRoot]];
+    sdkInfo = [[ISHDeviceVersionsStub sharedInstance] sdkFromSDKRoot:[[ISHDeviceVersionsStub sharedInstance] latestSDKRoot]];
   } else {
     sdkInfo = [self sdkWithVersion:osVersion];
   }
@@ -228,14 +228,14 @@ static const NSInteger KProductTypeIpad = 2;
 
 + (NSArray *)availableSdkVersions
 {
-  return [[[ISHDeviceVersions sharedInstance] allSDKs] valueForKeyPath:@"shortVersionString"];
+  return [[[ISHDeviceVersionsStub sharedInstance] allSDKs] valueForKeyPath:@"shortVersionString"];
 }
 
 + (NSArray *)sdksSupportedByDevice:(NSString *)deviceName
 {
-  ISHDeviceInfo *deviceInfo = [[ISHDeviceVersions sharedInstance] deviceInfoNamed:deviceName];
+  ISHDeviceInfoStub *deviceInfo = [[ISHDeviceVersionsStub sharedInstance] deviceInfoNamed:deviceName];
   NSMutableArray *supportedSdks = [NSMutableArray array];
-  for (ISHSDKInfo *sdk in [[ISHDeviceVersions sharedInstance] allSDKs]) {
+  for (ISHSDKInfoStub *sdk in [[ISHDeviceVersionsStub sharedInstance] allSDKs]) {
     if ([deviceInfo supportsSDK:sdk]) {
       [supportedSdks addObject:sdk];
     }
@@ -245,7 +245,7 @@ static const NSInteger KProductTypeIpad = 2;
 
 + (cpu_type_t)cpuTypeForDevice:(NSString *)deviceName
 {
-  ISHDeviceInfo *deviceInfo = [[ISHDeviceVersions sharedInstance] deviceInfoNamed:deviceName];
+  ISHDeviceInfoStub *deviceInfo = [[ISHDeviceVersionsStub sharedInstance] deviceInfoNamed:deviceName];
   if ([[deviceInfo architecture] isEqualToString:@"x86_64"]) {
     return CPU_TYPE_X86_64;
   } else {
@@ -315,7 +315,7 @@ static const NSInteger KProductTypeIpad = 2;
     return root;
   }
 
-  ISHSDKInfo *sdkInfo = [self sdkInfoForShortVersion:version];
+  ISHSDKInfoStub *sdkInfo = [self sdkInfoForShortVersion:version];
   root = [DTiPhoneSimulatorSystemRoot rootWithSDKPath:sdkInfo.root];
 
   if (root) {
@@ -329,11 +329,74 @@ static const NSInteger KProductTypeIpad = 2;
 
 @end
 
+/*
+ *  In order to make xctool linkable in Xcode 6 we need to provide stub implementations
+ *  of iOS simulator private classes used in xctool and defined in
+ *  the SimulatorHost framework (introduced in Xcode 5 and deprecated in Xcode 6).
+ *
+ *  But xctool, when built with Xcode 6 but running in Xcode 5, should use the
+ *  implementations of those classes from SimulatorHost framework rather than the stub
+ *  implementations. That is why we need to create stubs and forward all selector
+ *  invocations to the original implementation of the class if it exists.
+ */
+
 #if XCODE_VERSION >= 0600
-@implementation ISHSDKInfo
+
+void LoadFrameworkIfNeeded()
+{
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    if (![[[[NSBundle allFrameworks] valueForKeyPath:@"bundlePath"] valueForKey:@"lastPathComponent"] containsObject:@"SimulatorHost.framework"]) {
+      NSString *frameworkPath = [XcodeDeveloperDirPath() stringByAppendingPathComponent:@"Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks/SimulatorHost.framework"];
+      NSBundle *bundle = [NSBundle bundleWithPath:frameworkPath];
+      [bundle principalClass];
+    }
+  });
+}
+
+@implementation ISHSDKInfoStub
++ (id)forwardingTargetForSelector:(SEL)aSelector
+{
+  LoadFrameworkIfNeeded();
+  Class class = NSClassFromString(@"ISHSDKInfo");
+  NSAssert(class, @"Class ISHSDKInfo wasn't found though it was expected to exist.");
+  return class;
+}
 @end
-@implementation ISHDeviceVersions
+
+@implementation ISHDeviceVersionsStub
++ (id)forwardingTargetForSelector:(SEL)aSelector
+{
+  LoadFrameworkIfNeeded();
+  Class class = NSClassFromString(@"ISHDeviceVersions");
+  NSAssert(class, @"Class ISHDeviceVersions wasn't found though it was expected to exist.");
+  return class;
+}
 @end
-@implementation ISHDeviceInfo
+
+@implementation ISHDeviceInfoStub
++ (id)forwardingTargetForSelector:(SEL)aSelector
+{
+  LoadFrameworkIfNeeded();
+  Class class = NSClassFromString(@"ISHDeviceInfo");
+  NSAssert(class, @"Class ISHDeviceInfo wasn't found though it was expected to exist.");
+  return class;
+}
 @end
+
+#else
+
+/*
+ *  If xctool is built using Xcode 5 then we just need to provide empty implementations
+ *  of the stubs because they simply inherit original SimulatorHost private classes in
+ *  that case.
+ */
+
+@implementation ISHSDKInfoStub
+@end
+@implementation ISHDeviceVersionsStub
+@end
+@implementation ISHDeviceInfoStub
+@end
+
 #endif

--- a/xctool/xctool/SimulatorWrapper/SimulatorInfoXcode6.h
+++ b/xctool/xctool/SimulatorWrapper/SimulatorInfoXcode6.h
@@ -17,11 +17,11 @@
 #import "SimulatorInfo.h"
 
 @class SimDevice;
-@class SimRuntime;
+@class SimRuntimeStub;
 
 @interface SimulatorInfoXcode6 : SimulatorInfo
 
 - (SimDevice *)simulatedDevice;
-- (SimRuntime *)simulatedRuntime;
+- (SimRuntimeStub *)simulatedRuntime;
 
 @end

--- a/xctool/xctool/SimulatorWrapper/SimulatorInfoXcode6.m
+++ b/xctool/xctool/SimulatorWrapper/SimulatorInfoXcode6.m
@@ -27,15 +27,15 @@
 static const NSInteger KProductTypeIphone = 1;
 static const NSInteger KProductTypeIpad = 2;
 
-@interface SimRuntime (Latest)
-+ (SimRuntime *)latest;
+@interface SimRuntimeStub (Latest)
++ (SimRuntimeStub *)latest;
 @end
 
-@implementation SimRuntime (Latest)
+@implementation SimRuntimeStub (Latest)
 
-+ (SimRuntime *)latest
++ (SimRuntimeStub *)latest
 {
-  NSArray *sorted = [[SimRuntime supportedRuntimes] sortedArrayUsingDescriptors:@[[NSSortDescriptor sortDescriptorWithKey:@"version" ascending:YES]]];
+  NSArray *sorted = [[SimRuntimeStub supportedRuntimes] sortedArrayUsingDescriptors:@[[NSSortDescriptor sortDescriptorWithKey:@"version" ascending:YES]]];
   return [sorted lastObject];
 }
 
@@ -43,7 +43,7 @@ static const NSInteger KProductTypeIpad = 2;
 
 @interface SimulatorInfoXcode6 ()
 @property (nonatomic, retain) SimDevice *simulatedDevice;
-@property (nonatomic, retain) SimRuntime *simulatedRuntime;
+@property (nonatomic, retain) SimRuntimeStub *simulatedRuntime;
 @end
 
 @implementation SimulatorInfoXcode6
@@ -90,16 +90,16 @@ static const NSInteger KProductTypeIpad = 2;
   }
 
   // return lowest device that has configuration with simulated sdk where lowest is defined
-  // by the order in the returned array of devices from `-[SimDeviceSet availableDevices]`
-  SimRuntime *runtime = systemRoot.runtime;
+  // by the order in the returned array of devices from `-[SimDeviceSetStub availableDevices]`
+  SimRuntimeStub *runtime = systemRoot.runtime;
   NSMutableArray *supportedDeviceTypes = [NSMutableArray array];
-  for (SimDevice *device in [[SimDeviceSet defaultSet] availableDevices]) {
+  for (SimDevice *device in [[SimDeviceSetStub defaultSet] availableDevices]) {
     if ([device.runtime isEqual:runtime]) {
       [supportedDeviceTypes addObject:device.deviceType];
     }
   }
 
-  NSAssert([supportedDeviceTypes count] > 0, @"There are no available devices that support provided sdk: %@. Supported devices: %@", [systemRoot sdkVersion], [[SimDeviceType supportedDevices] valueForKeyPath:@"name"]);
+  NSAssert([supportedDeviceTypes count] > 0, @"There are no available devices that support provided sdk: %@. Supported devices: %@", [systemRoot sdkVersion], [[SimDeviceTypeStub supportedDevices] valueForKeyPath:@"name"]);
   self.deviceName = [supportedDeviceTypes[0] name];
   return _deviceName;
 }
@@ -127,7 +127,7 @@ static const NSInteger KProductTypeIpad = 2;
 {
   if (_OSVersion) {
     if ([_OSVersion isEqualTo:@"latest"]) {
-      return [[SimRuntime latest] versionString];
+      return [[SimRuntimeStub latest] versionString];
     } else {
       return _OSVersion;
     }
@@ -162,11 +162,11 @@ static const NSInteger KProductTypeIpad = 2;
 #pragma mark -
 #pragma mark v6 methods
 
-- (SimRuntime *)simulatedRuntime
+- (SimRuntimeStub *)simulatedRuntime
 {
   if (!_simulatedRuntime) {
     _simulatedRuntime = [[self systemRootForSimulatedSdk] runtime];
-    NSAssert(_simulatedRuntime != nil, @"Unable to find simulated runtime for simulated sdk of version %@ at path %@. Supported runtimes: %@", [[self systemRootForSimulatedSdk] sdkVersion], [[self systemRootForSimulatedSdk] sdkRootPath], [SimRuntime supportedRuntimes]);
+    NSAssert(_simulatedRuntime != nil, @"Unable to find simulated runtime for simulated sdk of version %@ at path %@. Supported runtimes: %@", [[self systemRootForSimulatedSdk] sdkVersion], [[self systemRootForSimulatedSdk] sdkRootPath], [SimRuntimeStub supportedRuntimes]);
   }
   return _simulatedRuntime;
 }
@@ -174,10 +174,10 @@ static const NSInteger KProductTypeIpad = 2;
 - (SimDevice *)simulatedDevice
 {
   if (!_simulatedDevice) {
-    SimRuntime *runtime = [self simulatedRuntime];
-    SimDeviceType *deviceType = [SimDeviceType supportedDeviceTypesByAlias][[self simulatedDeviceInfoName]];
-    NSAssert(deviceType != nil, @"Unable to find SimDeviceType for the device with name \"%@\". Available device names: %@", [self simulatedDeviceInfoName], [[SimDeviceType supportedDeviceTypesByAlias] allKeys]);
-    for (SimDevice *device in [[SimDeviceSet defaultSet] availableDevices]) {
+    SimRuntimeStub *runtime = [self simulatedRuntime];
+    SimDeviceTypeStub *deviceType = [SimDeviceTypeStub supportedDeviceTypesByAlias][[self simulatedDeviceInfoName]];
+    NSAssert(deviceType != nil, @"Unable to find SimDeviceTypeStub for the device with name \"%@\". Available device names: %@", [self simulatedDeviceInfoName], [[SimDeviceTypeStub supportedDeviceTypesByAlias] allKeys]);
+    for (SimDevice *device in [[SimDeviceSetStub defaultSet] availableDevices]) {
       if ([device.deviceType isEqual:deviceType] &&
           [device.runtime isEqual:runtime]) {
         _simulatedDevice = device;
@@ -195,24 +195,24 @@ static const NSInteger KProductTypeIpad = 2;
 
 + (NSArray *)availableDevices
 {
-  return [[SimDeviceType supportedDeviceTypesByName] allKeys];
+  return [[SimDeviceTypeStub supportedDeviceTypesByName] allKeys];
 }
 
 + (BOOL)isDeviceAvailableWithAlias:(NSString *)deviceName
 {
-  return [[SimDeviceType supportedDeviceTypesByAlias] objectForKey:deviceName] != nil;
+  return [[SimDeviceTypeStub supportedDeviceTypesByAlias] objectForKey:deviceName] != nil;
 }
 
 + (NSString *)deviceNameForAlias:(NSString *)deviceAlias
 {
-  SimDeviceType *deviceType = [[SimDeviceType supportedDeviceTypesByAlias] objectForKey:deviceAlias];
+  SimDeviceTypeStub *deviceType = [[SimDeviceTypeStub supportedDeviceTypesByAlias] objectForKey:deviceAlias];
   return [deviceType name];
 }
 
 + (BOOL)isSdkVersion:(NSString *)sdkVersion supportedByDevice:(NSString *)deviceName
 {
-  SimDeviceType *deviceType = [SimDeviceType supportedDeviceTypesByAlias][deviceName];
-  SimRuntime *runtime = [self _runtimeForSdkVersion:sdkVersion];
+  SimDeviceTypeStub *deviceType = [SimDeviceTypeStub supportedDeviceTypesByAlias][deviceName];
+  SimRuntimeStub *runtime = [self _runtimeForSdkVersion:sdkVersion];
 
   return [runtime supportsDeviceType:deviceType];
 }
@@ -220,7 +220,7 @@ static const NSInteger KProductTypeIpad = 2;
 + (NSString *)sdkVersionForOSVersion:(NSString *)osVersion
 {
   if ([osVersion isEqualToString:@"latest"]) {
-    return [[SimRuntime latest] versionString];
+    return [[SimRuntimeStub latest] versionString];
   } else {
     return [[self _runtimeForSdkVersion:osVersion] versionString];
   }
@@ -228,7 +228,7 @@ static const NSInteger KProductTypeIpad = 2;
 
 + (NSArray *)availableSdkVersions
 {
-  return [[SimRuntime supportedRuntimes] valueForKeyPath:@"versionString"];
+  return [[SimRuntimeStub supportedRuntimes] valueForKeyPath:@"versionString"];
 }
 
 + (NSArray *)sdksSupportedByDevice:(NSString *)deviceName
@@ -239,7 +239,7 @@ static const NSInteger KProductTypeIpad = 2;
 
 + (cpu_type_t)cpuTypeForDevice:(NSString *)deviceName
 {
-  SimDeviceType *deviceType = [SimDeviceType supportedDeviceTypesByAlias][deviceName];
+  SimDeviceTypeStub *deviceType = [SimDeviceTypeStub supportedDeviceTypesByAlias][deviceName];
   if ([deviceType.supportedArchs containsObject:@(CPU_TYPE_X86_64)]) {
     return CPU_TYPE_X86_64;
   } else {
@@ -263,9 +263,9 @@ static const NSInteger KProductTypeIpad = 2;
 + (NSMutableArray *)_runtimesSupportedByDevice:(NSString *)deviceName
 {
   NSMutableArray *supportedRuntimes = [NSMutableArray array];
-  SimDeviceType *deviceType = [SimDeviceType supportedDeviceTypesByAlias][deviceName];
-  NSAssert(deviceType != nil, @"Unable to find SimDeviceType for the device with name \"%@\". Available device names: %@", deviceName, [[SimDeviceType supportedDeviceTypesByAlias] allKeys]);
-  for (SimRuntime *runtime in [SimRuntime supportedRuntimes]) {
+  SimDeviceTypeStub *deviceType = [SimDeviceTypeStub supportedDeviceTypesByAlias][deviceName];
+  NSAssert(deviceType != nil, @"Unable to find SimDeviceTypeStub for the device with name \"%@\". Available device names: %@", deviceName, [[SimDeviceTypeStub supportedDeviceTypesByAlias] allKeys]);
+  for (SimRuntimeStub *runtime in [SimRuntimeStub supportedRuntimes]) {
     if ([runtime supportsDeviceType:deviceType]) {
       [supportedRuntimes addObject:runtime];
     }
@@ -273,11 +273,11 @@ static const NSInteger KProductTypeIpad = 2;
   return supportedRuntimes;
 }
 
-+ (SimRuntime *)_runtimeForSdkVersion:(NSString *)sdkVersion
++ (SimRuntimeStub *)_runtimeForSdkVersion:(NSString *)sdkVersion
 {
   NSAssert(sdkVersion != nil, @"Sdk version shouldn't be nil.");
-  NSArray *runtimes = [SimRuntime supportedRuntimes];
-  for (SimRuntime *runtime in runtimes) {
+  NSArray *runtimes = [SimRuntimeStub supportedRuntimes];
+  for (SimRuntimeStub *runtime in runtimes) {
     if ([runtime.versionString hasPrefix:sdkVersion]) {
       return runtime;
     }
@@ -285,7 +285,7 @@ static const NSInteger KProductTypeIpad = 2;
   return nil;
 }
 
-+ (SimRuntime *)_runtimeForSDKPath:(NSString *)sdkPath
++ (SimRuntimeStub *)_runtimeForSDKPath:(NSString *)sdkPath
 {
   DTiPhoneSimulatorSystemRoot *root = [SimulatorInfoXcode6 _systemRootWithSDKPath:sdkPath];
   return [root runtime];
@@ -294,7 +294,7 @@ static const NSInteger KProductTypeIpad = 2;
 + (NSArray *)_availableDeviceConfigurationsInHumanReadableFormat
 {
   NSMutableArray *configs = [NSMutableArray array];
-  for (SimDevice *device in [[SimDeviceSet defaultSet] availableDevices]) {
+  for (SimDevice *device in [[SimDeviceSetStub defaultSet] availableDevices]) {
     [configs addObject:[NSString stringWithFormat:@"%@: %@", device.name, device.runtime.versionString]];
   }
   return configs;

--- a/xctool/xctool/SimulatorWrapper/SimulatorWrapper.m
+++ b/xctool/xctool/SimulatorWrapper/SimulatorWrapper.m
@@ -79,14 +79,9 @@ static const NSString * kOtestShimStderrFilePath __unused = @"OTEST_SHIM_STDERR_
 #pragma mark -
 #pragma mark Helpers
 
-+ (BOOL)isXcode6OrHigher
-{
-  return NSClassFromString(@"SimDevice") != nil;
-}
-
 + (Class)classBasedOnCurrentVersionOfXcode
 {
-  if ([self isXcode6OrHigher]) {
+  if (ToolchainIsXcode6OrBetter()) {
     return [SimulatorWrapperXcode6 class];
   } else {
     return [SimulatorWrapperXcode5 class];

--- a/xctool/xctool/SimulatorWrapper/SimulatorWrapperXcode6.m
+++ b/xctool/xctool/SimulatorWrapper/SimulatorWrapperXcode6.m
@@ -155,11 +155,61 @@
 @end
 
 
+/*
+ *  In order to make xctool linkable in Xcode 5 we need to provide stub implementations
+ *  of iOS simulator private classes used in xctool and defined in
+ *  the CoreSimulator framework (introduced in Xcode 6).
+ *
+ *  But xctool, when built with Xcode 5 but running in Xcode 6, should use the 
+ *  implementations of those classes from CoreSimulator framework rather than the stub 
+ *  implementations. That is why we need to create stubs and forward all selector
+ *  invocations to the original implementation of the class if it exists.
+ */
+
 #if XCODE_VERSION < 0600
-@implementation SimDeviceSet
+
+@implementation SimDeviceSetStub
++ (id)forwardingTargetForSelector:(SEL)aSelector
+{
+  Class class = NSClassFromString(@"SimDeviceSet");
+  NSAssert(class, @"Class SimDeviceType wasn't found though it was expected to exist.");
+  return class;
+}
 @end
-@implementation SimDeviceType
+
+@implementation SimDeviceTypeStub
++ (id)forwardingTargetForSelector:(SEL)aSelector
+{
+  Class class = NSClassFromString(@"SimDeviceType");
+  NSAssert(class, @"Class SimDeviceType wasn't found though it was expected to exist.");
+  return class;
+}
 @end
-@implementation SimRuntime
+
+@implementation SimRuntimeStub
++ (id)forwardingTargetForSelector:(SEL)aSelector
+{
+  Class class = NSClassFromString(@"SimRuntime");
+  NSAssert(class, @"Class SimRuntime wasn't found though it was expected to exist.");
+  return class;
+}
 @end
+
+#else
+
+/*
+ *  If xctool is built using Xcode 6 then we just need to provide empty implementations
+ *  of the stubs because they simply inherit original CoreSimulator private classes in 
+ *  that case.
+ */
+
+@implementation SimDeviceSetStub
+@end
+
+@implementation SimDeviceTypeStub
+@end
+
+@implementation SimRuntimeStub
+@end
+
 #endif


### PR DESCRIPTION
Xcode 5 and Xcode 6 have different sets of private frameworks that are used by xctool. When Xcode 6 support was added it was decided to use `#if XCODE_VERSION < 0600` and `#if XCODE_VERSION >= 0600` macros to choose which source codes to compile. This approach reduced number of `NSClassFromString` and `performSelector:` usages and works perfectly when xctool.sh is used to run xctool.
But when xctool is compiled only once (for example, using Xcode 5) and then used with another Xcode version (for example, Xcode 6) it could causes crashes because during runtime xctool will decide to use classes that don't provide implementations of expected methods.

In this PR for all private classes, that exist in one version of Xcode and don't exist in another, were created _stubs_ which do next:
- if original class implementation is available when xctool is built, original implementation is used (stub just inherits from original class)
- if original class implementation is not available when xctool is built, `+ (id)forwardingTargetForSelector:(SEL)aSelector` is implemented and during runtime required class from private framework is returned by calling `NSClassFromString`. Required frameworks are loaded if needed (for Xcode 6 -> Xcode 5 switch only).
