### PR TITLE
Fix problem with moving Xcode location after compiling xctool

### DIFF
--- a/xctool/xctool.xcconfig
+++ b/xctool/xctool.xcconfig
@@ -27,8 +27,7 @@ XCTOOL_VENDOR_DIR = $(SRCROOT)/../Vendor
 // xctool will weak link iPhoneSimulatorRemoteClient, and then configure the necessary
 // DYLD paths on startup to make sure the framework can be loaded.
 OTHER_LDFLAGS_0500 = -weak_framework DVTFoundation -weak_framework DVTiPhoneSimulatorRemoteClient -weak_framework SimulatorHost
-OTHER_LDFLAGS_0600 = -weak_framework DVTFoundation -weak_framework DVTiPhoneSimulatorRemoteClient -weak_framework CoreSimulator -Wl,-rpath -Wl,$(PRIVATE_FRAMEWORKS_DIR) -Wl,-rpath -Wl,$(SHARED_FRAMEWORKS_DIR)
-
+OTHER_LDFLAGS_0600 = -weak_framework DVTFoundation -weak_framework DVTiPhoneSimulatorRemoteClient -weak_framework CoreSimulator
 OTHER_LDFLAGS = $(OTHER_LDFLAGS_$(XCODE_VERSION_MAJOR))
 
 FRAMEWORK_SEARCH_PATHS = "$(DEVELOPER_LIBRARY_DIR)/Frameworks" "$(SHARED_FRAMEWORKS_DIR)" "$(PRIVATE_FRAMEWORKS_DIR)" "$(DEVELOPER_PRIVATE_FRAMEWORKS_DIR)" "$(XCTOOL_VENDOR_DIR)"

--- a/xctool/xctool/main.m
+++ b/xctool/xctool/main.m
@@ -22,13 +22,13 @@
 int main(int argc, const char * argv[])
 {
   @autoreleasepool {
-    // xctool depends on iPhoneSimulatorRemoteClient.framework, which is a private
-    // framework for interacting with the simulator that comes bundled with
-    // Xcode.
+    // xctool depends on iPhoneSimulatorRemoteClient.framework or CoreSimulator.framework,
+    // which are private framework for interacting with the simulator that come bundled
+    // with respectively Xcode 5 and 6.
     //
     // Since xctool can work with multiple verstions of Xcode and since each of
     // these Xcode versions might live at different paths, we don't want to strongly
-    // link iPhoneSimulatorRemoteClient.framework.  e.g., if we linked to
+    // link those frameworks.  e.g., if we linked to
     // `/Applications/Xcode.app/.../.../iPhoneSimulatorRemoteClient.framework`
     // but Xcode was installed elsewhere, xctool would fail to run.
     //
@@ -56,9 +56,11 @@ int main(int argc, const char * argv[])
         fallbackFrameworkPath = @"";
       }
 
-      fallbackFrameworkPath = [fallbackFrameworkPath stringByAppendingFormat:@":%@:%@:%@",
+      fallbackFrameworkPath = [fallbackFrameworkPath stringByAppendingFormat:@":%@:%@:%@:%@",
                                // The path to iPhoneSimulatorRemoteClient.framework.
                                [developerDirPath stringByAppendingPathComponent:@"Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks"],
+                               // The path to CoreSimulator.framework for Xcode 6.
+                               [developerDirPath stringByAppendingPathComponent:@"Library/PrivateFrameworks"],
                                // The path to other dependencies of iPhoneSimulatorRemoteClient.framework.
                                [developerDirPath stringByAppendingPathComponent:@"../OtherFrameworks"],
                                [developerDirPath stringByAppendingPathComponent:@"../SharedFrameworks"]


### PR DESCRIPTION
xctool depends on the CoreSimulator.framework from Xcode 6 and links
with it using @rpath, which is set to a path withing $(DEVELOPER_DIR)
at compile time.

Then, if Xcode.app is moved after xctool was built, it will fail to find
the framework. I extended the fix for iPhoneSimulatorRemoteClient
introduced in 8f7bf6c64cb64c274649592335eb3d1ee1c850fb to dynamically
update the DYLD_FALLBACK_FRAMEWORK_PATH at runtime to allow finding
CoreSimulator and thus decoupling the binary from the Xcode.app location.
