### PR TITLE
Fix StaticAnalyzer plist files search 

### DIFF
--- a/xctool/xctool/AnalyzeAction.m
+++ b/xctool/xctool/AnalyzeAction.m
@@ -181,7 +181,7 @@
                                                                  options.arch ? options.arch : @"armv7",
                                                                  ]];
 
-    NSMutableArray *pathContents = [[[NSFileManager defaultManager] contentsOfDirectoryAtPath:analyzerFilesPath error:nil] mutableCopy];
+    NSArray *pathContents = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:analyzerFilesPath error:nil];
     
     for (NSString *path in pathContents) {
       if([[path pathExtension] isEqualToString:@".plist"]) {

--- a/xctool/xctool/AnalyzeAction.m
+++ b/xctool/xctool/AnalyzeAction.m
@@ -147,13 +147,12 @@
                                                 error:0];
   }
 
-  NSString *path = [[self class]
-                    intermediatesDirForProject:projectName
-                        target:targetName
-                        configuration:[options effectiveConfigurationForSchemeAction:@"AnalyzeAction"
-                                                                    xcodeSubjectInfo:xcodeSubjectInfo]
-                        platform:xcodeSubjectInfo.effectivePlatformName
-                        objroot:xcodeSubjectInfo.objRoot];
+  NSString *path = [[self class] intermediatesDirForProject:projectName
+                                                     target:targetName
+                                              configuration:[options effectiveConfigurationForSchemeAction:@"AnalyzeAction"
+                                                                                          xcodeSubjectInfo:xcodeSubjectInfo]
+                                                   platform:xcodeSubjectInfo.effectivePlatformName
+                                                    objroot:xcodeSubjectInfo.objRoot];
   NSString *buildStatePath = [path stringByAppendingPathComponent:@"build-state.dat"];
   NSMutableArray *plistPaths = [NSMutableArray array];
   BOOL buildPathExists = [[NSFileManager defaultManager] fileExistsAtPath:buildStatePath];


### PR DESCRIPTION
With Xcode 6 it seems build-state.dat is not generated anymore.
As the TextReporter was parsing it to find StaticAnalyzer plist file to show analyze summary, this was not working anymore.
I added a small search function to find the output plist and build analyze summary as before.