### PR TITLE
Improve error output when xcodebuild crashes

### DIFF
--- a/xctool/xctool/TaskUtil.h
+++ b/xctool/xctool/TaskUtil.h
@@ -16,6 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
+@class NSConcreteTask;
+
 /**
  * Launchs a task, waits for exit, and returns a dictionary like
  * { @"stdout": "...", @"stderr": "..." }
@@ -73,3 +75,11 @@ NSTask *CreateTaskForSimulatorExecutable(NSString *sdkName,
                                          NSString *launchPath,
                                          NSArray *arguments,
                                          NSDictionary *environment);
+
+
+/**
+ * Returns a command-line expression which includes the environment, launch
+ * path, and args to reproduce a given task.
+ */
+NSString *CommandLineEquivalentForTask(NSConcreteTask *task);
+

--- a/xctool/xctool/TaskUtil.m
+++ b/xctool/xctool/TaskUtil.m
@@ -351,10 +351,6 @@ static NSString *CommandLineEquivalentForTaskArchGenericTask(NSConcreteTask *tas
   return buffer;
 }
 
-/**
- * Returns a command-line expression which includes the environment, launch
- * path, and args to reproduce a given task.
- */
 NSString *CommandLineEquivalentForTask(NSConcreteTask *task)
 {
   NSCAssert(task.launchPath != nil, @"Should have a launchPath");

--- a/xctool/xctool/XCToolUtil.h
+++ b/xctool/xctool/XCToolUtil.h
@@ -211,3 +211,8 @@ NSString *MakeTemporaryDirectory(NSString *nameTemplate);
  * i.e. we have a TEST_HOST, and that TEST_HOST refers to an executable.
  */
 BOOL TestableSettingsIndicatesApplicationTest(NSDictionary *settings);
+
+/**
+ * Returns path to the latest xcodebuild crash report or nil.
+ */
+NSString *LatestXcodebuildCrashReportPath();


### PR DESCRIPTION
When xcodebuild crashes xctool doesn't print any errors or warnings.

For example, before this fix output would be something like:

    [Info] Loading settings for scheme 'TestXcode6iOs8' ... (3415 ms)

    === TEST ===

      xcodebuild build build

    ** TEST FAILED: 0 passed, 0 failed, 0 errored, 0 total ** (967 ms)

After the fix:

    === BUILDING XCTOOL ===

      /Users/nekto/Projects/xctool/scripts/build.sh
          ✓ Built xctool (11000 ms)

    [Info] Loading settings for scheme 'TestXcode6iOs8' ... (3429 ms)

    === TEST ===

      xcodebuild build build
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
    xcodebuild crashed when running the task below:
    <NSTask string representation>

    Latest available xcodebuild crash report (/Users/nekto/Library/Logs/DiagnosticReports/xcodebuild_2015-03-04-153408_Nekto.crash):
    Process:               xcodebuild [76447]
    Path:                  /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild
    Identifier:            xcodebuild
    Version:               6028
    Code Type:             X86-64 (Native)
    Parent Process:        xctool [76426]
    Responsible:           iTerm [513]
    User ID:               1168769313

    Date/Time:             2015-03-04 15:34:07.407 -0800
    OS Version:            Mac OS X 10.10.2 (14C109)
    Report Version:        11
    Anonymous UUID:        00000000000

    Sleep/Wake UUID:       00000000000

    Time Awake Since Boot: 23000 seconds
    Time Since Wake:       22000 seconds

    Crashed Thread:        0  Dispatch queue: com.apple.main-thread

    Exception Type:        EXC_CRASH (SIGABRT)
    Exception Codes:       0x0000000000000000, 0x0000000000000000

    Application Specific Information:
    ProductBuildVersion: 6A2008a
    abort() called

    Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
    ...

    ** TEST FAILED: 0 passed, 0 failed, 0 errored, 0 total ** (6109 ms)