### PR TITLE
Copy simulator environment and override TMPDIR value when running app tests

### DIFF
--- a/xctool/xctool/OCUnitIOSAppTestRunner.m
+++ b/xctool/xctool/OCUnitIOSAppTestRunner.m
@@ -209,11 +209,11 @@ static const NSInteger kMaxRunTestsAttempts = 3;
   for (NSInteger remainingAttempts = kMaxRunTestsAttempts - 1; remainingAttempts >= 0; --remainingAttempts) {
     NSError *error = nil;
     BOOL infraSucceeded = [SimulatorWrapper runHostAppTests:testHostAppPath
-                        simulatorInfo:self.simulatorInfo
-                        appLaunchArgs:[self testArguments]
-                 appLaunchEnvironment:[self otestEnvironmentWithOverrides:[self.simulatorInfo simulatorLaunchEnvironment]]
-                    feedOutputToBlock:outputLineBlock
-                                error:&error];
+                                              simulatorInfo:self.simulatorInfo
+                                              appLaunchArgs:[self testArguments]
+                                       appLaunchEnvironment:[self otestEnvironmentWithOverrides:[self.simulatorInfo simulatorLaunchEnvironment]]
+                                          feedOutputToBlock:outputLineBlock
+                                                      error:&error];
 
     if (infraSucceeded) {
       break;

--- a/xctool/xctool/SimulatorWrapper/SimulatorWrapperXcode6.m
+++ b/xctool/xctool/SimulatorWrapper/SimulatorWrapperXcode6.m
@@ -34,7 +34,14 @@
                                                applicationLaunchEnvironment:(NSDictionary *)launchEnvironment
                                                                  outputPath:(NSString *)outputPath
 {
-  DTiPhoneSimulatorSessionConfig *sessionConfig = [SimulatorWrapper sessionConfigForRunningTestsOnSimulator:simInfo applicationLaunchArgs:launchArgs applicationLaunchEnvironment:launchEnvironment outputPath:outputPath];
+  NSDictionary *deviceEnvironment = [[simInfo simulatedDevice] environment] ?: @{};
+  NSMutableDictionary *launchEnvironmentEdited = [[deviceEnvironment mutableCopy] autorelease];
+  [launchEnvironmentEdited addEntriesFromDictionary:launchEnvironment];
+  if (deviceEnvironment[@"TMPDIR"]) {
+    launchEnvironmentEdited[@"TMPDIR"] = deviceEnvironment[@"TMPDIR"];
+  }
+
+  DTiPhoneSimulatorSessionConfig *sessionConfig = [SimulatorWrapper sessionConfigForRunningTestsOnSimulator:simInfo applicationLaunchArgs:launchArgs applicationLaunchEnvironment:launchEnvironmentEdited outputPath:outputPath];
 
   [sessionConfig setDevice:[simInfo simulatedDevice]];
   [sessionConfig setRuntime:[simInfo simulatedRuntime]];


### PR DESCRIPTION
Simulator environment is already copied for logic tests but weren't doing that when running application tests.
In this PR I am updating that behaviour. Tricky part here is that priority of simulator environment should have lower priority then the one set by xctool. But in that case `TMPDIR` would have the value passed to xctool which is wrong. To fix that we are overriding `TMPDIR` environment value with the one given by the simulator device.