### PR TITLE
Add support for running logic and app test bundles directly, without Xcode projects

### DIFF
--- a/xctool/xctool-tests/FakeTaskManager.m
+++ b/xctool/xctool-tests/FakeTaskManager.m
@@ -122,19 +122,33 @@ __attribute__((constructor)) static void initialize()
                [[FakeTaskManager sharedManager] hideTaskFromLaunchedTasks:task];
              }
            },
-            // GetAvailableSDKsAndAliases()
+            // GetAvailableSDKsInfo()
             ^(FakeTask *task){
               if ([[task launchPath] hasSuffix:@"usr/bin/xcodebuild"] &&
                   [[task arguments] isEqualToArray:@[@"-sdk", @"-version"
                    ]]) {
                 [task pretendTaskReturnsStandardOutput:
-                 @"MacOSX10.7.sdk - OS X 10.7 (macosx10.7)\n\n"
-                 @"MacOSX10.8.sdk - OS X 10.8 (macosx10.8)\n\n"
-                 @"iPhoneOS6.1.sdk - iOS 6.1 (iphoneos6.1)\n\n"
-                 @"iPhoneSimulator5.0.sdk - Simulator - iOS 5.0 (iphonesimulator5.0)\n\n"
-                 @"iPhoneSimulator5.1.sdk - Simulator - iOS 5.1 (iphonesimulator5.1)\n\n"
-                 @"iPhoneSimulator6.0.sdk - Simulator - iOS 6.0 (iphonesimulator6.0)\n\n"
-                 @"iPhoneSimulator6.1.sdk - Simulator - iOS 6.1 (iphonesimulator6.1)\n\n"
+                 @"MacOSX10.7.sdk - OS X 10.7 (macosx10.7)\n"
+                 @"Path: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk\n"
+                 @"\n"
+                 @"MacOSX10.8.sdk - OS X 10.8 (macosx10.8)\n"
+                 @"Path: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk\n"
+                 @"\n"
+                 @"iPhoneOS6.1.sdk - iOS 6.1 (iphoneos6.1)\n"
+                 @"Path: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS6.1.sdk\n"
+                 @"\n"
+                 @"iPhoneSimulator5.0.sdk - Simulator - iOS 5.0 (iphonesimulator5.0)\n"
+                 @"Path: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator6.1.sdk\n"
+                 @"\n"
+                 @"iPhoneSimulator5.1.sdk - Simulator - iOS 5.1 (iphonesimulator5.1)\n"
+                 @"Path: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator5.1.sdk\n"
+                 @"\n"
+                 @"iPhoneSimulator6.0.sdk - Simulator - iOS 6.0 (iphonesimulator6.0)\n"
+                 @"Path: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator6.0.sdk\n"
+                 @"\n"
+                 @"iPhoneSimulator6.1.sdk - Simulator - iOS 6.1 (iphonesimulator6.1)\n"
+                 @"Path: /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator6.1.sdk\n"
+                 @"\n"
                  @"Xcode 5.0.2\nBuild version 5A3005"];
                 [[FakeTaskManager sharedManager] hideTaskFromLaunchedTasks:task];
               }

--- a/xctool/xctool-tests/LaunchHandlers.h
+++ b/xctool/xctool-tests/LaunchHandlers.h
@@ -53,5 +53,7 @@ BOOL IsOtestTask(NSTask *task);
                                           hide:(BOOL)hide;
 
 + (id)handlerForOtestQueryReturningTestList:(NSArray *)testList;
++ (id)handlerForOtestQueryWithTestHost:(NSString *)testHost
+                     returningTestList:(NSArray *)testList;
 
 @end

--- a/xctool/xctool-tests/LaunchHandlers.m
+++ b/xctool/xctool-tests/LaunchHandlers.m
@@ -196,4 +196,25 @@ BOOL IsOtestTask(NSTask *task)
   } copy];
 }
 
++ (id)handlerForOtestQueryWithTestHost:(NSString *)testHost
+                     returningTestList:(NSArray *)testList
+{
+  return [^(FakeTask *task){
+
+    BOOL isOtestQuery = NO;
+
+    if ([[task launchPath] isEqualToString:testHost]) {
+      isOtestQuery = YES;
+    }
+
+    if (isOtestQuery) {
+      [task pretendExitStatusOf:0];
+      [task pretendTaskReturnsStandardOutput:
+       [[NSString alloc] initWithData:[NSJSONSerialization dataWithJSONObject:testList options:0 error:nil]
+                              encoding:NSUTF8StringEncoding]];
+      [[FakeTaskManager sharedManager] hideTaskFromLaunchedTasks:task];
+    }
+  } copy];
+}
+
 @end

--- a/xctool/xctool-tests/LaunchHandlers.m
+++ b/xctool/xctool-tests/LaunchHandlers.m
@@ -203,7 +203,17 @@ BOOL IsOtestTask(NSTask *task)
 
     BOOL isOtestQuery = NO;
 
-    if ([[task launchPath] isEqualToString:testHost]) {
+    if ([[task launchPath] hasSuffix:@"usr/bin/sim"]) {
+      // iOS tests get queried through the 'sim' launcher.
+      if ([task environment][@"SIMSHIM_OtestQueryBundlePath"]) {
+        for (NSString *arg in [task arguments]) {
+          if ([arg hasSuffix:testHost]) {
+            isOtestQuery = YES;
+            break;
+          }
+        }
+      }
+    } else if ([[task launchPath] isEqualToString:testHost]) {
       isOtestQuery = YES;
     }
 

--- a/xctool/xctool-tests/Options+Testing.h
+++ b/xctool/xctool-tests/Options+Testing.h
@@ -36,6 +36,12 @@
                    withBuildSettingsFromFile:(NSString *)path;
 
 /**
+ * Assert that validation passes.  An empty XcodeSubjectInfo is given to
+ * validateOptions:.
+ */
+- (Options *)assertOptionsValidate;
+
+/**
  * Assert that validation passes.  A fake XcodeSubjectInfo is given to
  * validateOptions: populated with build settings from the given path.
  */

--- a/xctool/xctool-tests/Options+Testing.m
+++ b/xctool/xctool-tests/Options+Testing.m
@@ -59,7 +59,8 @@
 - (void)assertOptionsFailToValidateWithError:(NSString *)message
 {
   NSString *errorMessage = nil;
-  BOOL valid = [self validateAndReturnXcodeSubjectInfo:nil
+  XcodeSubjectInfo *xcodeSubjectInfo;
+  BOOL valid = [self validateAndReturnXcodeSubjectInfo:&xcodeSubjectInfo
                                           errorMessage:&errorMessage];
 
   if (valid) {
@@ -150,6 +151,22 @@
   [self evaluateOptionsWithBuildSettingsFromFile:path
                                            valid:&valid
                                            error:&errorMessage];
+
+  if (!valid) {
+    [NSException raise:NSGenericException
+                format:
+     @"Expected validation to pass but failed with message '%@'", errorMessage];
+  }
+
+  return self;
+}
+
+- (Options *)assertOptionsValidate
+{
+  NSString *errorMessage = nil;
+  XcodeSubjectInfo *xcodeSubjectInfo = [[XcodeSubjectInfo alloc] init];
+  BOOL valid = [self validateAndReturnXcodeSubjectInfo:&xcodeSubjectInfo
+                                          errorMessage:&errorMessage];
 
   if (!valid) {
     [NSException raise:NSGenericException

--- a/xctool/xctool-tests/OptionsTests.m
+++ b/xctool/xctool-tests/OptionsTests.m
@@ -24,6 +24,7 @@
 #import "Options+Testing.h"
 #import "Options.h"
 #import "ReporterTask.h"
+#import "RunTestsAction.h"
 #import "TaskUtil.h"
 #import "XCToolUtil.h"
 #import "XcodeSubjectInfo.h"
@@ -81,6 +82,18 @@
   assertThat(buildSettings,
              equalTo(@{@"ABC" : @"123",
                        @"DEF" : @"456"}));
+}
+
+- (void)testDisallowRunTestsWithBothTestsAndWorkspaceAndProject
+{
+  [[Options optionsFrom:@[
+    @"-workspace", @"Something.xcworkspace",
+    @"-project", @"Something.xcodeproj",
+    @"run-tests",
+    @"-logicTest", TEST_DATA @"tests-ios-test-bundle/TestProject-LibraryTests.octest",
+    ]]
+   assertOptionsFailToValidateWithError:
+      @"If -logicTest or -appTest are specified, -workspace, -project, and -scheme must not be specified."];
 }
 
 - (void)testDisallowBothWorkspaceAndProjectSpecified
@@ -465,5 +478,4 @@
    [NSString stringWithFormat:@"Unable to find projects (.xcodeproj) in directory %@. Please specify with -workspace, -project, or -find-target.",
     options.findProjectPath]];
 }
-
 @end

--- a/xctool/xctool-tests/RunTestsActionTests.m
+++ b/xctool/xctool-tests/RunTestsActionTests.m
@@ -1083,6 +1083,186 @@ static BOOL areEqualJsonOutputsIgnoringKeys(NSString *output1, NSString *output2
   }];
 }
 
+- (void)testi386CpuTypeReadFromLogicTestBundle
+{
+  [[FakeTaskManager sharedManager] runBlockWithFakeTasks:^{
+    [[FakeTaskManager sharedManager] addLaunchHandlerBlocks:@[
+     [LaunchHandlers handlerForOtestQueryReturningTestList:@[@"FakeTest/TestA", @"FakeTest/TestB"]],
+     ]];
+
+    XCTool *tool = [[XCTool alloc] init];
+
+    tool.arguments = @[@"-sdk", @"iphonesimulator6.1",
+                       @"run-tests",
+                       @"-logicTest", TEST_DATA @"tests-ios-test-bundle/TestProject-LibraryTests.octest",
+                      ];
+
+    __block OCUnitTestRunner *runner = nil;
+
+    [Swizzler whileSwizzlingSelector:@selector(runTests)
+                 forInstancesOfClass:[OCUnitTestRunner class]
+                           withBlock:
+     ^(id self, SEL sel){
+       // Don't actually run anything and just save a reference to the runner.
+       runner = self;
+       // Pretend tests succeeded.
+       return YES;
+     }
+                            runBlock:
+     ^{
+       [TestUtil runWithFakeStreams:tool];
+
+       assertThat(runner, notNilValue());
+       assertThatInteger([runner cpuType], equalToInteger(CPU_TYPE_I386));
+     }];
+  }];
+}
+
+- (void)testX86_64CpuTypeReadFromLogicTestBundle
+{
+  [[FakeTaskManager sharedManager] runBlockWithFakeTasks:^{
+    [[FakeTaskManager sharedManager] addLaunchHandlerBlocks:@[
+     [LaunchHandlers handlerForOtestQueryReturningTestList:@[@"FakeTest/TestA", @"FakeTest/TestB"]],
+     ]];
+
+    XCTool *tool = [[XCTool alloc] init];
+
+    tool.arguments = @[@"-sdk", @"iphonesimulator6.1",
+                       @"run-tests",
+                       @"-logicTest", TEST_DATA @"tests-ios-test-bundle/TestProject-Library-64bitTests.xctest",
+                      ];
+
+    __block OCUnitTestRunner *runner = nil;
+
+    [Swizzler whileSwizzlingSelector:@selector(runTests)
+                 forInstancesOfClass:[OCUnitTestRunner class]
+                           withBlock:
+     ^(id self, SEL sel){
+       // Don't actually run anything and just save a reference to the runner.
+       runner = self;
+       // Pretend tests succeeded.
+       return YES;
+     }
+                            runBlock:
+     ^{
+       [TestUtil runWithFakeStreams:tool];
+
+       assertThat(runner, notNilValue());
+       assertThatInteger([runner cpuType], equalToInteger(CPU_TYPE_X86_64));
+     }];
+  }];
+}
+
+- (void)testAnyCpuTypeReadFromLogicTestBundle
+{
+  [[FakeTaskManager sharedManager] runBlockWithFakeTasks:^{
+    [[FakeTaskManager sharedManager] addLaunchHandlerBlocks:@[
+     [LaunchHandlers handlerForOtestQueryReturningTestList:@[@"FakeTest/TestA", @"FakeTest/TestB"]],
+     ]];
+
+    XCTool *tool = [[XCTool alloc] init];
+
+    tool.arguments = @[@"-sdk", @"iphonesimulator6.1",
+                       @"run-tests",
+                       @"-logicTest", TEST_DATA @"tests-ios-test-bundle/TestProject-Library-32And64bitTests.xctest"
+                      ];
+
+    __block OCUnitTestRunner *runner = nil;
+
+    [Swizzler whileSwizzlingSelector:@selector(runTests)
+                 forInstancesOfClass:[OCUnitTestRunner class]
+                           withBlock:
+     ^(id self, SEL sel){
+       // Don't actually run anything and just save a reference to the runner.
+       runner = self;
+       // Pretend tests succeeded.
+       return YES;
+     }
+                            runBlock:
+     ^{
+       [TestUtil runWithFakeStreams:tool];
+
+       assertThat(runner, notNilValue());
+       assertThatInteger([runner cpuType], equalToInteger(CPU_TYPE_ANY));
+     }];
+  }];
+}
+
+- (void)testX86_64CpuTypeReadFromAppTestBundle
+{
+  [[FakeTaskManager sharedManager] runBlockWithFakeTasks:^{
+    [[FakeTaskManager sharedManager] addLaunchHandlerBlocks:@[
+      [LaunchHandlers handlerForOtestQueryWithTestHost:TEST_DATA @"TestProject-App-OSX/Build/Products/Debug/TestProject-App-OSX.app/Contents/MacOS/TestProject-App-OSX"
+                                     returningTestList:@[@"FakeTest/TestA", @"FakeTest/TestB"]],
+     ]];
+
+    XCTool *tool = [[XCTool alloc] init];
+
+    tool.arguments = @[@"-sdk", @"macosx10.8",
+                       @"run-tests",
+                       @"-appTest",
+                       TEST_DATA @"TestProject-App-OSX/Build/Products/Debug/TestProject-App-OSXTests.octest:" TEST_DATA @"TestProject-App-OSX/Build/Products/Debug/TestProject-App-OSX.app/Contents/MacOS/TestProject-App-OSX",
+                       ];
+
+    __block OCUnitTestRunner *runner = nil;
+
+    [Swizzler whileSwizzlingSelector:@selector(runTests)
+                 forInstancesOfClass:[OCUnitTestRunner class]
+                           withBlock:
+     ^(id self, SEL sel){
+       // Don't actually run anything and just save a reference to the runner.
+       runner = self;
+       // Pretend tests succeeded.
+       return YES;
+     }
+                            runBlock:
+     ^{
+       [TestUtil runWithFakeStreams:tool];
+
+       assertThat(runner, notNilValue());
+       assertThatInteger([runner cpuType], equalToInteger(CPU_TYPE_X86_64));
+     }];
+  }];
+}
+
+- (void)testi386CpuTypeReadFromAppTestBundle
+{
+  [[FakeTaskManager sharedManager] runBlockWithFakeTasks:^{
+    [[FakeTaskManager sharedManager] addLaunchHandlerBlocks:@[
+      [LaunchHandlers handlerForOtestQueryWithTestHost:TEST_DATA @"KiwiTests/Build/Products/Debug-iphonesimulator/KiwiTests-TestHost.app/KiwiTests-TestHost"
+                                     returningTestList:@[@"FakeTest/TestA", @"FakeTest/TestB"]],
+    ]];
+
+    XCTool *tool = [[XCTool alloc] init];
+
+    tool.arguments = @[@"-sdk", @"iphonesimulator6.1",
+                       @"run-tests",
+                       @"-appTest",
+                       TEST_DATA @"KiwiTests/Build/Products/Debug-iphonesimulator/KiwiTests-OCUnit-AppTests.octest:"
+                         TEST_DATA @"KiwiTests/Build/Products/Debug-iphonesimulator/KiwiTests-TestHost.app/KiwiTests-TestHost",
+                      ];
+
+    __block OCUnitTestRunner *runner = nil;
+
+    [Swizzler whileSwizzlingSelector:@selector(runTests)
+                 forInstancesOfClass:[OCUnitTestRunner class]
+                           withBlock:
+     ^(id self, SEL sel){
+       // Don't actually run anything and just save a reference to the runner.
+       runner = self;
+       // Pretend tests succeeded.
+       return YES;
+     }
+                            runBlock:
+     ^{
+       [TestUtil runWithFakeStreams:tool];
+
+       assertThat(runner, notNilValue());
+       assertThatInteger([runner cpuType], equalToInteger(CPU_TYPE_I386));
+     }];
+  }];
+}
+
 - (void)testPassingAppTestViaCommandLine
 {
   [[FakeTaskManager sharedManager] runBlockWithFakeTasks:^{

--- a/xctool/xctool-tests/RunTestsActionTests.m
+++ b/xctool/xctool-tests/RunTestsActionTests.m
@@ -1045,7 +1045,78 @@ static BOOL areEqualJsonOutputsIgnoringKeys(NSString *output1, NSString *output2
        assertOptionsFailToValidateWithError:
            @"run-tests: The same test bundle '"TEST_DATA @"TestProject-App-OSX/Build/Products/Debug/TestProject-App-OSXTests.octest' cannot test "
            @"more than one test host app (got '"TEST_DATA @"TestProject-App-OSX/Build/Products/Debug/TestProject-App-OSX.app/Contents/MacOS/TestProject-App-OSX' and '" TEST_DATA @"TestProject-App-OSX/Build/Products/Debug/TestProject-App-OSX.app/Contents/MacOS/TestProject-App-OSX')"];
+  }];
+}
 
+- (void)testPassingLogicTestViaCommandLine
+{
+  [[FakeTaskManager sharedManager] runBlockWithFakeTasks:^{
+    [[FakeTaskManager sharedManager] addLaunchHandlerBlocks:@[
+     [LaunchHandlers handlerForOtestQueryReturningTestList:@[@"FakeTest/TestA", @"FakeTest/TestB"]],
+     ]];
+
+    XCTool *tool = [[XCTool alloc] init];
+
+    tool.arguments = @[@"-sdk", @"iphonesimulator6.1",
+                       @"run-tests",
+                        @"-logicTest", TEST_DATA @"tests-ios-test-bundle/TestProject-LibraryTests.octest",
+                      ];
+
+    __block OCUnitTestRunner *runner = nil;
+
+    [Swizzler whileSwizzlingSelector:@selector(runTests)
+                 forInstancesOfClass:[OCUnitTestRunner class]
+                           withBlock:
+     ^(id self, SEL sel){
+       // Don't actually run anything and just save a reference to the runner.
+       runner = self;
+       // Pretend tests succeeded.
+       return YES;
+     }
+                            runBlock:
+     ^{
+       [TestUtil runWithFakeStreams:tool];
+
+       assertThat(runner, notNilValue());
+       assertThat([runner testBundlePath], equalTo(TEST_DATA @"tests-ios-test-bundle/TestProject-LibraryTests.octest"));
+     }];
+  }];
+}
+
+- (void)testPassingAppTestViaCommandLine
+{
+  [[FakeTaskManager sharedManager] runBlockWithFakeTasks:^{
+    [[FakeTaskManager sharedManager] addLaunchHandlerBlocks:@[
+        [LaunchHandlers handlerForOtestQueryWithTestHost:TEST_DATA @"TestProject-App-OSX/Build/Products/Debug/TestProject-App-OSX.app/Contents/MacOS/TestProject-App-OSX"
+                                        returningTestList:@[@"FakeTest/TestA", @"FakeTest/TestB"]],
+        ]];
+
+    XCTool *tool = [[XCTool alloc] init];
+
+    tool.arguments = @[@"-sdk", @"macosx10.8",
+                       @"run-tests",
+                       @"-appTest",
+                       TEST_DATA @"TestProject-App-OSX/Build/Products/Debug/TestProject-App-OSXTests.octest:" TEST_DATA @"TestProject-App-OSX/Build/Products/Debug/TestProject-App-OSX.app/Contents/MacOS/TestProject-App-OSX",
+                       ];
+
+    __block OCUnitTestRunner *runner = nil;
+
+    [Swizzler whileSwizzlingSelector:@selector(runTests)
+                 forInstancesOfClass:[OCUnitTestRunner class]
+                           withBlock:
+     ^(id self, SEL sel){
+       // Don't actually run anything and just save a reference to the runner.
+       runner = self;
+       // Pretend tests succeeded.
+       return YES;
+     }
+                            runBlock:
+     ^{
+       [TestUtil runWithFakeStreams:tool];
+
+       assertThat(runner, notNilValue());
+       assertThat([runner testBundlePath], equalTo(TEST_DATA @"TestProject-App-OSX/Build/Products/Debug/TestProject-App-OSXTests.octest"));
+     }];
   }];
 }
 

--- a/xctool/xctool.xcodeproj/project.pbxproj
+++ b/xctool/xctool.xcodeproj/project.pbxproj
@@ -307,6 +307,7 @@
 		32707EE31725FE9500AF2F53 /* TestActionInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestActionInternal.h; sourceTree = "<group>"; };
 		32A90C521725F05800C2349E /* TestAction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestAction.m; sourceTree = "<group>"; };
 		32A90C531725F05800C2349E /* TestAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestAction.h; sourceTree = "<group>"; };
+		32F66B5C1B0E5DFD00BDCA61 /* TestRunning.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestRunning.h; sourceTree = "<group>"; };
 		3892D73F1811A5CC00E68652 /* EventGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EventGenerator.h; sourceTree = "<group>"; };
 		3892D7401811A5CC00E68652 /* EventGenerator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EventGenerator.m; sourceTree = "<group>"; };
 		40623EBC190EA61B004FB374 /* InstallAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InstallAction.h; sourceTree = "<group>"; };
@@ -434,6 +435,7 @@
 				283479B416E2B39B003C3B77 /* RunTestsAction.m */,
 				32A90C531725F05800C2349E /* TestAction.h */,
 				32A90C521725F05800C2349E /* TestAction.m */,
+				32F66B5C1B0E5DFD00BDCA61 /* TestRunning.h */,
 				32707EE31725FE9500AF2F53 /* TestActionInternal.h */,
 				40623EBC190EA61B004FB374 /* InstallAction.h */,
 				40623EBD190EA61B004FB374 /* InstallAction.m */,

--- a/xctool/xctool/OCUnitIOSLogicTestRunner.m
+++ b/xctool/xctool/OCUnitIOSLogicTestRunner.m
@@ -62,10 +62,8 @@
   // and merging with process environments and `_environment` variable contents
   env = [self otestEnvironmentWithOverrides:env];
 
-  cpu_type_t cpuType = _cpuType != CPU_TYPE_ANY ? _cpuType : CpuTypeForTestBundleAtPath(testBundlePath);
-
   return CreateTaskForSimulatorExecutable(_buildSettings[Xcode_SDK_NAME],
-                                          cpuType,
+                                          _cpuType,
                                           [SimulatorInfo baseVersionForSDKShortVersion:[self.simulatorInfo simulatedSdkVersion]],
                                           launchPath,
                                           args,

--- a/xctool/xctool/OCUnitTestRunner.m
+++ b/xctool/xctool/OCUnitTestRunner.m
@@ -124,8 +124,9 @@
     _freshInstall = freshInstall;
     _testTimeout = testTimeout;
     _reporters = [reporters copy];
-    _framework = [FrameworkInfoForTestBundleAtPath([self testBundlePath]) copy];
-    _cpuType = CPU_TYPE_ANY;
+    NSString *testBundlePath = [self testBundlePath];
+    _framework = [FrameworkInfoForTestBundleAtPath(testBundlePath) copy];
+    _cpuType = CpuTypeForTestBundleAtPath(testBundlePath);
   }
   return self;
 }

--- a/xctool/xctool/OCUnitTestRunner.m
+++ b/xctool/xctool/OCUnitTestRunner.m
@@ -300,7 +300,7 @@
                       // the test.
                       [[NSProcessInfo processInfo] environment],
                       // Any special environment vars set in the scheme.
-                      _environment,
+                      _environment ?: @{},
                       // Internal environment that should be passed to xctool libs
                       internalEnvironment,
                       // Whatever values we need to make the test run at all for

--- a/xctool/xctool/Options.h
+++ b/xctool/xctool/Options.h
@@ -32,6 +32,7 @@
 @property (nonatomic, copy) NSString *scheme;
 @property (nonatomic, copy) NSString *configuration;
 @property (nonatomic, copy) NSString *sdk;
+@property (nonatomic, copy) NSString *sdkPath;
 @property (nonatomic, copy) NSString *arch;
 @property (nonatomic, copy) NSString *destination;
 @property (nonatomic, copy) NSString *destinationTimeout;

--- a/xctool/xctool/Options.m
+++ b/xctool/xctool/Options.m
@@ -319,6 +319,14 @@
     return (BOOL)(exists && isDirectory);
   };
 
+  if (![self _validateSdkWithErrorMessage:errorMessage]) {
+    return NO;
+  }
+
+  if (![self _validateDestinationWithErrorMessage:errorMessage]) {
+    return NO;
+  }
+
   if (!_workspace && !_project && !_findTarget) {
     NSString *defaultProject = [self findDefaultProjectErrorMessage:errorMessage];
     if (!defaultProject) {
@@ -483,9 +491,35 @@
     return NO;
   }
 
+  XcodeSubjectInfo *xcodeSubjectInfo = [[XcodeSubjectInfo alloc] init];
+  xcodeSubjectInfo.subjectWorkspace = _workspace;
+  xcodeSubjectInfo.subjectProject = _project;
+  xcodeSubjectInfo.subjectScheme = _scheme;
+
+  if (xcodeSubjectInfoOut) {
+    *xcodeSubjectInfoOut = xcodeSubjectInfo;
+  }
+
+  // We can pass nil for the scheme action since we don't care to use the
+  // scheme's specific configuration.
+  NSArray *commonXcodeBuildArguments = [self commonXcodeBuildArgumentsForSchemeAction:nil
+                                                                     xcodeSubjectInfo:nil];
+  xcodeSubjectInfo.subjectXcodeBuildArguments =
+    [[self xcodeBuildArgumentsForSubject] arrayByAddingObjectsFromArray:commonXcodeBuildArguments];
+
+  ReportStatusMessageBegin(_reporters, REPORTER_MESSAGE_INFO, @"Loading settings for scheme '%@' ...", _scheme);
+  [xcodeSubjectInfo loadSubjectInfo];
+  ReportStatusMessageEnd(_reporters, REPORTER_MESSAGE_INFO, @"Loading settings for scheme '%@' ...", _scheme);
+
+  return [self _validateActionsWithSubjectInfo:xcodeSubjectInfo
+                                  errorMessage:errorMessage];
+}
+
+- (BOOL)_validateSdkWithErrorMessage:(NSString **)errorMessage {
   NSDictionary *sdksAndAliases = nil;
   if (_sdk) {
-    sdksAndAliases = GetAvailableSDKsAndAliases();
+    NSDictionary *sdkInfo = GetAvailableSDKsInfo();
+    sdksAndAliases = GetAvailableSDKsAndAliasesWithSDKInfo(sdkInfo);
 
     // Is this an available SDK?
     if (!sdksAndAliases[_sdk]) {
@@ -499,7 +533,8 @@
     // Map SDK param to actual SDK name.  This allows for aliases like 'iphoneos' to map
     // to 'iphoneos6.1'.
     _sdk = sdksAndAliases[_sdk];
-    
+    _sdkPath = sdkInfo[_sdk][@"Path"];
+
     // Xcode 5's xcodebuild has a bug where it won't build targets for the
     // iphonesimulator SDK.  It fails with...
     //
@@ -512,7 +547,10 @@
       _buildSettings[Xcode_PLATFORM_NAME] = @"iphonesimulator";
     }
   }
+  return YES;
+}
 
+- (BOOL)_validateDestinationWithErrorMessage:(NSString **)errorMessage {
   if (_destination) {
     NSDictionary *destInfo = ParseDestinationString(_destination, errorMessage);
 
@@ -552,26 +590,11 @@
     }
   }
 
-  XcodeSubjectInfo *xcodeSubjectInfo = [[XcodeSubjectInfo alloc] init];
-  xcodeSubjectInfo.subjectWorkspace = _workspace;
-  xcodeSubjectInfo.subjectProject = _project;
-  xcodeSubjectInfo.subjectScheme = _scheme;
+  return YES;
+}
 
-  if (xcodeSubjectInfoOut) {
-    *xcodeSubjectInfoOut = xcodeSubjectInfo;
-  }
-
-  // We can pass nil for the scheme action since we don't care to use the
-  // scheme's specific configuration.
-  NSArray *commonXcodeBuildArguments = [self commonXcodeBuildArgumentsForSchemeAction:nil
-                                                                     xcodeSubjectInfo:nil];
-  xcodeSubjectInfo.subjectXcodeBuildArguments =
-    [[self xcodeBuildArgumentsForSubject] arrayByAddingObjectsFromArray:commonXcodeBuildArguments];
-
-  ReportStatusMessageBegin(_reporters, REPORTER_MESSAGE_INFO, @"Loading settings for scheme '%@' ...", _scheme);
-  [xcodeSubjectInfo loadSubjectInfo];
-  ReportStatusMessageEnd(_reporters, REPORTER_MESSAGE_INFO, @"Loading settings for scheme '%@' ...", _scheme);
-
+- (BOOL)_validateActionsWithSubjectInfo:(XcodeSubjectInfo *)xcodeSubjectInfo
+                           errorMessage:(NSString **)errorMessage {
   for (Action *action in _actions) {
     BOOL valid = [action validateWithOptions:self
                             xcodeSubjectInfo:xcodeSubjectInfo

--- a/xctool/xctool/Options.m
+++ b/xctool/xctool/Options.m
@@ -330,7 +330,7 @@
 
   __block BOOL testsPresentInOptions = NO;
   [_actions enumerateObjectsUsingBlock:^(Action *action, NSUInteger idx, BOOL *stop) {
-    if ([[action class] conformsToProtocol:@protocol(TestRunning)]) {
+    if ([action conformsToProtocol:@protocol(TestRunning)]) {
       testsPresentInOptions = [(id<TestRunning>)action testsPresentInOptions];
       *stop = YES;
     }

--- a/xctool/xctool/RunTestsAction.h
+++ b/xctool/xctool/RunTestsAction.h
@@ -65,6 +65,7 @@ typedef NS_ENUM(NSInteger, BucketBy) {
 @property (nonatomic, copy) NSString *OSVersion;
 @property (nonatomic, strong) NSMutableArray *logicTests;
 @property (nonatomic, strong) NSMutableDictionary *appTests;
+@property (nonatomic, copy) NSString *targetedDeviceFamily;
 
 - (void)setLogicTestBucketSizeValue:(NSString *)str;
 - (void)setAppTestBucketSizeValue:(NSString *)str;

--- a/xctool/xctool/RunTestsAction.h
+++ b/xctool/xctool/RunTestsAction.h
@@ -15,6 +15,7 @@
 //
 
 #import "Action.h"
+#import "TestRunning.h"
 
 /**
  * Break test cases into groups of `bucketSize` test cases.  Test methods in
@@ -49,7 +50,7 @@ typedef NS_ENUM(NSInteger, BucketBy) {
 
 } ;
 
-@interface RunTestsAction : Action
+@interface RunTestsAction : Action<TestRunning>
 
 @property (nonatomic, assign) BOOL freshSimulator;
 @property (nonatomic, assign) BOOL resetSimulator;
@@ -62,6 +63,8 @@ typedef NS_ENUM(NSInteger, BucketBy) {
 @property (nonatomic, strong) NSMutableArray *onlyList;
 @property (nonatomic, copy) NSString *deviceName;
 @property (nonatomic, copy) NSString *OSVersion;
+@property (nonatomic, strong) NSMutableArray *logicTests;
+@property (nonatomic, strong) NSMutableDictionary *appTests;
 
 - (void)setLogicTestBucketSizeValue:(NSString *)str;
 - (void)setAppTestBucketSizeValue:(NSString *)str;
@@ -69,4 +72,3 @@ typedef NS_ENUM(NSInteger, BucketBy) {
 - (void)setTestTimeoutValue:(NSString *)str;
 
 @end
-

--- a/xctool/xctool/RunTestsAction.m
+++ b/xctool/xctool/RunTestsAction.m
@@ -619,7 +619,9 @@ typedef BOOL (^TestableBlock)(NSArray *reporters);
                                      freshInstall:_freshInstall
                                      testTimeout:_testTimeout
                                      reporters:reporters];
-    [testRunner setCpuType:_cpuType];
+    if (_cpuType != CPU_TYPE_ANY) {
+      [testRunner setCpuType:_cpuType];
+    }
 
     if ([testRunner isKindOfClass:[OCUnitIOSAppTestRunner class]]) {
       if (_deviceName) {

--- a/xctool/xctool/SimulatorWrapper/SimulatorInfo.m
+++ b/xctool/xctool/SimulatorWrapper/SimulatorInfo.m
@@ -99,8 +99,8 @@
 
   return @{
     @"DYLD_FALLBACK_FRAMEWORK_PATH" : IOSTestFrameworkDirectories(),
-    @"DYLD_FRAMEWORK_PATH" : _buildSettings[Xcode_TARGET_BUILD_DIR],
-    @"DYLD_LIBRARY_PATH" : _buildSettings[Xcode_TARGET_BUILD_DIR],
+    @"DYLD_FRAMEWORK_PATH" : _buildSettings[Xcode_TARGET_BUILD_DIR] ?: @"",
+    @"DYLD_LIBRARY_PATH" : _buildSettings[Xcode_TARGET_BUILD_DIR] ?: @"",
     @"DYLD_INSERT_LIBRARIES" : [@[
       [XCToolLibPath() stringByAppendingPathComponent:@"otest-shim-ios.dylib"],
       ideBundleInjectionLibPath,

--- a/xctool/xctool/SimulatorWrapper/SimulatorInfoXcode6.m
+++ b/xctool/xctool/SimulatorWrapper/SimulatorInfoXcode6.m
@@ -73,11 +73,21 @@ static const NSInteger KProductTypeIpad = 2;
 
   switch ([[self simulatedDeviceFamily] integerValue]) {
     case KProductTypeIphone:
-      _deviceName = @"iPhone 4s";
+      if (_cpuType == CPU_TYPE_I386) {
+        _deviceName = @"iPhone 4s";
+      } else {
+        // CPU_TYPE_X86_64 or CPU_TYPE_ANY
+        _deviceName = @"iPhone 5s";
+      }
       break;
 
     case KProductTypeIpad:
-      _deviceName = @"iPad 2";
+      if (_cpuType == CPU_TYPE_I386) {
+        _deviceName = @"iPad 2";
+      } else {
+        // CPU_TYPE_X86_64 or CPU_TYPE_ANY
+        _deviceName = @"iPad Air";
+      }
       break;
   }
 
@@ -92,7 +102,16 @@ static const NSInteger KProductTypeIpad = 2;
   NSMutableArray *supportedDeviceTypes = [NSMutableArray array];
   for (SimDevice *device in [[SimDeviceSetStub defaultSet] availableDevices]) {
     if ([device.runtime isEqual:runtime]) {
-      [supportedDeviceTypes addObject:device.deviceType];
+      if (_cpuType == CPU_TYPE_ANY) {
+        [supportedDeviceTypes addObject:device.deviceType];
+      } else {
+        for (NSNumber *supportedArch in [[device deviceType] supportedArchs]) {
+          if (([supportedArch longLongValue] & _cpuType) == _cpuType) {
+            [supportedDeviceTypes addObject:device.deviceType];
+            break;
+          }
+        }
+      }
     }
   }
 

--- a/xctool/xctool/SimulatorWrapper/SimulatorWrapperXcode6.m
+++ b/xctool/xctool/SimulatorWrapper/SimulatorWrapperXcode6.m
@@ -70,7 +70,7 @@
   NSDictionary *configuration = @{NSWorkspaceLaunchConfigurationArguments: @[@"-CurrentDeviceUDID", [[[simInfo simulatedDevice] UDID] UUIDString]]};
   NSError *launchError = nil;
   NSRunningApplication *app = [[NSWorkspace sharedWorkspace] launchApplicationAtURL:iOSSimulatorURL
-                                                                            options:NSWorkspaceLaunchDefault
+                                                                            options:NSWorkspaceLaunchAsync | NSWorkspaceLaunchWithoutActivation | NSWorkspaceLaunchAndHide
                                                                       configuration:configuration
                                                                               error:&launchError];
   if (!app) {

--- a/xctool/xctool/TestRunning.h
+++ b/xctool/xctool/TestRunning.h
@@ -1,0 +1,25 @@
+//
+// Copyright 2015 Facebook
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+@protocol TestRunning <NSObject>
+
+/**
+ * If tests are passed via -logicTest or -appTest, returns YES.
+ * Otherwise, returns NO.
+ */
+- (BOOL)testsPresentInOptions;
+
+@end

--- a/xctool/xctool/TestableExecutionInfo.h
+++ b/xctool/xctool/TestableExecutionInfo.h
@@ -65,11 +65,23 @@
 @property (nonatomic, copy) NSDictionary *expandedEnvironment;
 
 /**
+ * Extracts testable build settings from an Xcode project.
+ */
++ (NSDictionary *)testableBuildSettingsForProject:(NSString *)projectPath
+                                           target:(NSString *)target
+                                          objRoot:(NSString *)objRoot
+                                          symRoot:(NSString *)symRoot
+                                sharedPrecompsDir:(NSString *)sharedPrecompsDir
+                             targetedDeviceFamily:(NSString *)targetedDeviceFamily
+                                   xcodeArguments:(NSArray *)xcodeArguments
+                                          testSDK:(NSString *)testSDK
+                                            error:(NSString **)error;
+
+/**
  * @return A populated TestableExecutionInfo instance.
  */
 + (instancetype)infoForTestable:(Testable *)testable
-               xcodeSubjectInfo:(XcodeSubjectInfo *)xcodeSubjectInfo
-            xcodebuildArguments:(NSArray *)xcodebuildArguments
-                        testSDK:(NSString *)testSDK
+                  buildSettings:(NSDictionary *)buildSettings
                         cpuType:(cpu_type_t)cpuType;
+
 @end

--- a/xctool/xctool/TestableExecutionInfo.m
+++ b/xctool/xctool/TestableExecutionInfo.m
@@ -28,31 +28,12 @@
 @implementation TestableExecutionInfo
 
 + (instancetype)infoForTestable:(Testable *)testable
-               xcodeSubjectInfo:(XcodeSubjectInfo *)xcodeSubjectInfo
-            xcodebuildArguments:(NSArray *)xcodebuildArguments
-                        testSDK:(NSString *)testSDK
+                  buildSettings:(NSDictionary *)buildSettings
                         cpuType:(cpu_type_t)cpuType
 {
   TestableExecutionInfo *info = [[TestableExecutionInfo alloc] init];
   info.testable = testable;
-
-  NSString *buildSettingsError = nil;
-  NSDictionary *buildSettings = [[self class] testableBuildSettingsForProject:testable.projectPath
-                                                                       target:testable.target
-                                                                      objRoot:xcodeSubjectInfo.objRoot
-                                                                      symRoot:xcodeSubjectInfo.symRoot
-                                                            sharedPrecompsDir:xcodeSubjectInfo.sharedPrecompsDir
-                                                         targetedDeviceFamily:xcodeSubjectInfo.targetedDeviceFamily
-                                                               xcodeArguments:xcodebuildArguments
-                                                                      testSDK:testSDK
-                                                                        error:&buildSettingsError];
-
-  if (buildSettings) {
-    info.buildSettings = buildSettings;
-  } else {
-    info.buildSettingsError = buildSettingsError;
-    return info;
-  }
+  info.buildSettings = buildSettings;
 
   NSString *otestQueryError = nil;
   NSArray *testCases = [[self class] queryTestCasesWithBuildSettings:info.buildSettings

--- a/xctool/xctool/XCTool.m
+++ b/xctool/xctool/XCTool.m
@@ -198,7 +198,7 @@
           kReporter_BeginAction_NameKey: [[action class] name],
           kReporter_BeginAction_WorkspaceKey: options.workspace ?: [NSNull null],
           kReporter_BeginAction_ProjectKey: options.project ?: [NSNull null],
-          kReporter_BeginAction_SchemeKey: options.scheme,
+          kReporter_BeginAction_SchemeKey: options.scheme ?: [NSNull null],
           }));
 
       BOOL succeeded = [action performActionWithOptions:options xcodeSubjectInfo:xcodeSubjectInfo];
@@ -210,7 +210,7 @@
           kReporter_EndAction_NameKey: [[action class] name],
           kReporter_EndAction_WorkspaceKey: options.workspace ?: [NSNull null],
           kReporter_EndAction_ProjectKey: options.project ?: [NSNull null],
-          kReporter_EndAction_SchemeKey: options.scheme,
+          kReporter_EndAction_SchemeKey: options.scheme ?: [NSNull null],
           kReporter_EndAction_SucceededKey: @(succeeded),
           kReporter_EndAction_DurationKey: @(stopTime - startTime),
           }));

--- a/xctool/xctool/XCToolUtil.h
+++ b/xctool/xctool/XCToolUtil.h
@@ -77,6 +77,7 @@ NSDictionary *GetAvailableSDKsInfo();
        GetAvailableSDKsAndAliases()[whichSDK])
  */
 NSDictionary *GetAvailableSDKsAndAliases();
+NSDictionary *GetAvailableSDKsAndAliasesWithSDKInfo(NSDictionary *sdkInfo);
 
 BOOL IsRunningUnderTest();
 

--- a/xctool/xctool/XCToolUtil.m
+++ b/xctool/xctool/XCToolUtil.m
@@ -833,7 +833,13 @@ NSString *HashForString(NSString *string)
 
 cpu_type_t CpuTypeForTestBundleAtPath(NSString *testBundlePath)
 {
-  NSArray *archs = [[NSBundle bundleWithPath:testBundlePath] executableArchitectures];
+  NSBundle *testBundle = [NSBundle bundleWithPath:testBundlePath];
+  if (!testBundle) {
+    // Many unit tests specify a nonexistent bundle.
+    return CPU_TYPE_ANY;
+  }
+
+  NSArray *archs = [testBundle executableArchitectures];
 
   BOOL isI386Only = YES;
   BOOL isX86_64Only = YES;

--- a/xctool/xctool/XCToolUtil.m
+++ b/xctool/xctool/XCToolUtil.m
@@ -304,14 +304,10 @@ NSDictionary *GetAvailableSDKsInfo()
   return versionsAvailable;
 }
 
-NSDictionary *GetAvailableSDKsAndAliases()
+NSDictionary *GetAvailableSDKsAndAliasesWithSDKInfo(NSDictionary *sdkInfo)
 {
   NSMutableDictionary *versionsAvailable = [NSMutableDictionary dictionary];
 
-  // GetAvailableSDKsInfo already does the hard work for us; we just need to
-  //  iterate through its result to pull out the values cooresponding to the
-  // "SDK" field for each of the SDK entries.
-  NSDictionary *sdkInfo = GetAvailableSDKsInfo();
   NSArray *keys = [sdkInfo allKeys];
 
   for (NSString *key in keys) {
@@ -319,6 +315,15 @@ NSDictionary *GetAvailableSDKsAndAliases()
   }
 
   return versionsAvailable;
+}
+
+NSDictionary *GetAvailableSDKsAndAliases()
+{
+  // GetAvailableSDKsInfo already does the hard work for us; we just need to
+  //  iterate through its result to pull out the values cooresponding to the
+  // "SDK" field for each of the SDK entries.
+  NSDictionary *sdkInfo = GetAvailableSDKsInfo();
+  return GetAvailableSDKsAndAliasesWithSDKInfo(sdkInfo);
 }
 
 BOOL IsRunningUnderTest()


### PR DESCRIPTION
In this series of diffs, I add support for running logic and application test bundles directly from xctool, without scraping data from Xcode projects and schemes.

I also included a tweak to make running application tests with the iOS Simulator from Xcode 6 more pleasant: we now launch the simulator in the background and do not steal focus.

Lots of unit tests included.