### PR TITLE
Allow xctool to build with Buck

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -4,7 +4,7 @@
 
 [cxx]
     cflags = -std=gnu11
-    cxxflags = -std=c++14 -stdlib=libc++
+    cxxflags = -std=c++11 -stdlib=libc++
     default_platform = macosx-x86_64
     combined_preprocess_and_compile = true
 

--- a/.buckconfig
+++ b/.buckconfig
@@ -1,0 +1,17 @@
+[cache]
+    mode = dir
+    dir_max_size = 512MB
+
+[cxx]
+    cflags = -std=gnu11
+    cxxflags = -std=c++14 -stdlib=libc++
+    default_platform = macosx-x86_64
+    combined_preprocess_and_compile = true
+
+[project]
+  ide = xcode
+  ignore = \
+    .git, \
+    .hg, \
+    .buckd, \
+    build

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ xcuserdata
 build
 *.swp
 *.xccheckout
+.buckd
+buck-out
+buck-cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: objective-c
 before_script:
+  - sudo brew tap caskroom/cask
+  - sudo brew tap caskroom/versions
   - sudo brew update
   - sudo brew install brew-cask
-  - sudo brew tap caskroom/versions
   - sudo brew cask install java7
   - sudo brew install ant
 script: ./scripts/travis-ci.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: objective-c
-jdk:
-  - oraclejdk7
+before_script:
+  - sudo brew update
+  - sudo brew install brew-cask
+  - sudo brew tap caskroom/versions
+  - sudo brew cask install java7
+  - sudo brew install ant
 script: ./scripts/travis-ci.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,4 @@
 language: objective-c
-script: scripts/build.sh && ./xctool.sh -workspace xctool.xcworkspace -scheme xctool build build-tests run-tests
+jdk:
+  - oraclejdk7
+script: ./scripts/travis-ci.sh

--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,0 +1,8 @@
+{
+  "ignore_dirs": [
+    "buck-out",
+    "buck-cache",
+    ".buckd",
+    "build",
+  ]
+}

--- a/BUCK
+++ b/BUCK
@@ -1,0 +1,424 @@
+COMMON_PREPROCESSOR_FLAGS = ['-fobjc-arc', '-mmacosx-version-min=10.7']
+
+COMMON_OTEST_SRCS = [
+    'Common/DuplicateTestNameFix.m',
+    'Common/NSInvocationInSetFix.m',
+    'Common/ParseTestName.m',
+    'Common/SenIsSuperclassOfClassPerformanceFix.m',
+    'Common/Swizzle.m',
+    'Common/TestingFramework.m',
+]
+
+COMMON_OTEST_HEADERS = [
+    'Common/DuplicateTestNameFix.h',
+    'Common/NSInvocationInSetFix.h',
+    'Common/ParseTestName.h',
+    'Common/SenIsSuperclassOfClassPerformanceFix.h',
+    'Common/Swizzle.h',
+    'Common/TestingFramework.h',
+]
+
+COMMON_REPORTERS_SRCS = [
+    'Common/EventGenerator.m',
+    'Common/NSFileHandle+Print.m',
+    'Common/Reporter.m',
+]
+
+COMMON_REPORTERS_HEADERS = [
+    'Common/EventGenerator.h',
+    'Common/NSFileHandle+Print.h',
+    'Common/Reporter.h',
+    'Common/ReporterEvents.h',
+]
+
+TEXT_REPORTERS_SRCS = COMMON_REPORTERS_SRCS + glob(['reporters/text/**/*.m']) + [
+    'reporters/TestResultCounter.m',
+]
+
+TEXT_REPORTERS_HEADERS = COMMON_REPORTERS_HEADERS + glob(['reporters/text/**/*.h']) + [
+    'reporters/TestResultCounter.h',
+]
+
+apple_binary(
+    name = 'xctool-bin',
+    srcs = glob([
+        'Common/**/*.m',
+        'xctool/xctool/**/*.m',
+        'xctool/xctool/**/*.mm',
+    ]),
+    headers = glob([
+        'Common/**/*.h',
+        'xctool/Headers/**/*.h',
+        'xctool/xctool/**/*.h',
+    ]),
+    linker_flags = [
+        '-F$DEVELOPER_DIR/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks',
+        '-F$DEVELOPER_DIR/../SharedFrameworks',
+        '-F$DEVELOPER_DIR/Library/PrivateFrameworks',
+        '-weak_framework',
+        'DVTFoundation',
+        '-weak_framework',
+        'DVTiPhoneSimulatorRemoteClient',
+        '-weak_framework',
+        'CoreSimulator',
+    ],
+    preprocessor_flags = COMMON_PREPROCESSOR_FLAGS + [
+        '-DXCODE_VERSION=0630',
+    ],
+    frameworks = [
+        '$SDKROOT/System/Library/Frameworks/AppKit.framework',
+        '$SDKROOT/System/Library/Frameworks/CoreFoundation.framework',
+        '$SDKROOT/System/Library/Frameworks/Foundation.framework',
+        '$SDKROOT/System/Library/Frameworks/QuartzCore.framework',
+    ],
+)
+
+apple_binary(
+    name = 'pretty',
+    srcs = TEXT_REPORTERS_SRCS,
+    headers = TEXT_REPORTERS_HEADERS,
+    preprocessor_flags = COMMON_PREPROCESSOR_FLAGS,
+    frameworks = [
+        '$SDKROOT/System/Library/Frameworks/Foundation.framework',
+    ],
+)
+
+apple_binary(
+    name = 'plain',
+    srcs = TEXT_REPORTERS_SRCS,
+    headers = TEXT_REPORTERS_HEADERS,
+    preprocessor_flags = COMMON_PREPROCESSOR_FLAGS,
+    frameworks = [
+        '$SDKROOT/System/Library/Frameworks/Foundation.framework',
+    ],
+)
+
+apple_binary(
+    name = 'phabricator',
+    srcs = COMMON_REPORTERS_SRCS + glob([
+        'reporters/phabricator/**/*.m',
+    ]),
+    headers = COMMON_REPORTERS_HEADERS + glob([
+        'reporters/phabricator/**/*.h'
+    ]),
+    preprocessor_flags = COMMON_PREPROCESSOR_FLAGS,
+    frameworks = [
+        '$SDKROOT/System/Library/Frameworks/Foundation.framework',
+    ],
+)
+
+apple_binary(
+    name = 'junit',
+    srcs = COMMON_REPORTERS_SRCS + glob([
+        'reporters/junit/**/*.m',
+    ]),
+    headers = COMMON_REPORTERS_HEADERS + glob([
+        'reporters/junit/**/*.h'
+    ]),
+    preprocessor_flags = COMMON_PREPROCESSOR_FLAGS,
+    frameworks = [
+        '$SDKROOT/System/Library/Frameworks/Foundation.framework',
+    ],
+)
+
+apple_binary(
+    name = 'json-compilation-database',
+    srcs = COMMON_REPORTERS_SRCS + glob([
+        'reporters/json-compilation-database/**/*.m',
+    ]),
+    headers = COMMON_REPORTERS_HEADERS + glob([
+        'reporters/json-compilation-database/**/*.h'
+    ]),
+    preprocessor_flags = COMMON_PREPROCESSOR_FLAGS,
+    frameworks = [
+        '$SDKROOT/System/Library/Frameworks/Foundation.framework',
+    ],
+)
+
+apple_binary(
+    name = 'user-notifications',
+    srcs = COMMON_REPORTERS_SRCS + glob([
+        'reporters/user-notifications/**/*.m',
+    ]),
+    headers = COMMON_REPORTERS_HEADERS + glob([
+        'reporters/user-notifications/**/*.h'
+    ]),
+    preprocessor_flags = COMMON_PREPROCESSOR_FLAGS,
+    frameworks = [
+        '$SDKROOT/System/Library/Frameworks/Foundation.framework',
+    ],
+)
+
+apple_binary(
+    name = 'teamcity',
+    srcs = COMMON_REPORTERS_SRCS + glob([
+        'reporters/teamcity/**/*.m',
+    ]),
+    headers = COMMON_REPORTERS_HEADERS + glob([
+        'reporters/teamcity/**/*.h'
+    ]),
+    preprocessor_flags = COMMON_PREPROCESSOR_FLAGS,
+    frameworks = [
+        '$SDKROOT/System/Library/Frameworks/Foundation.framework',
+    ],
+)
+
+apple_binary(
+    name = 'json-stream',
+    srcs = COMMON_REPORTERS_SRCS + glob([
+        'reporters/json-stream/**/*.m',
+    ]),
+    headers = COMMON_REPORTERS_HEADERS,
+    preprocessor_flags = COMMON_PREPROCESSOR_FLAGS,
+    frameworks = [
+        '$SDKROOT/System/Library/Frameworks/Foundation.framework',
+    ],
+)
+
+apple_binary(
+    name = 'otest-query-ios-bin',
+    srcs = glob(['otest-query/otest-query-ios/**/*.m']),
+    frameworks = [
+        '$SDKROOT/System/Library/Frameworks/Foundation.framework',
+    ],
+)
+
+genrule(
+    name = 'otest-query-ios',
+    srcs = [
+        ':otest-query-ios-bin#iphonesimulator-i386',
+        ':otest-query-ios-bin#iphonesimulator-x86_64',
+    ],
+    out = 'otest-query-ios',
+    cmd = 'lipo $SRCS -create -output $OUT',
+)
+
+apple_binary(
+    name = 'otest-query-osx-bin',
+    srcs = COMMON_OTEST_SRCS + glob([
+        'otest-query/OtestQuery/**/*.m',
+        'otest-query/otest-query-osx/**/*.m',
+    ]),
+    headers = COMMON_OTEST_HEADERS + glob([
+        'otest-query/OtestQuery/**/*.h',
+    ]),
+    frameworks = [
+        '$SDKROOT/System/Library/Frameworks/Foundation.framework',
+    ],
+)
+
+genrule(
+    name = 'otest-query-osx',
+    srcs = [
+        ':otest-query-osx-bin#macosx-i386',
+        ':otest-query-osx-bin#macosx-x86_64',
+    ],
+    out = 'otest-query-osx',
+    cmd = 'lipo $SRCS -create -output $OUT',
+)
+
+apple_library(
+    name = 'otest-query-lib',
+    srcs = COMMON_OTEST_SRCS + glob([
+        'otest-query/otest-query-lib/**/*.m',
+        'otest-query/OtestQuery/**/*.m',
+    ]),
+    headers = COMMON_OTEST_HEADERS + glob([
+        'otest-query/OtestQuery/**/*.h',
+    ]),
+    frameworks = [
+        '$SDKROOT/System/Library/Frameworks/Foundation.framework',
+    ],
+)
+
+genrule(
+    name = 'otest-query-lib-ios',
+    srcs = [
+        ':otest-query-lib#iphonesimulator-i386,shared',
+        ':otest-query-lib#iphonesimulator-x86_64,shared',
+    ],
+    out = 'otest-query-lib-ios.dylib',
+    cmd = 'lipo $SRCS -create -output $OUT',
+)
+
+genrule(
+    name = 'otest-query-lib-osx',
+    srcs = [
+        ':otest-query-lib#macosx-i386,shared',
+        ':otest-query-lib#macosx-x86_64,shared',
+    ],
+    out = 'otest-query-lib-osx.dylib',
+    cmd = 'lipo $SRCS -create -output $OUT',
+)
+
+apple_library(
+    name = 'sim-shim-lib',
+    srcs = [
+        'Common/Swizzle.m',
+        'Common/XcodeRequiredVersion.m',
+    ] + glob([
+        'sim-shim/sim-shim/**/*.m',
+    ]),
+    headers = [
+        'Common/Swizzle.h',
+        'Common/dyld-interposing.h',
+        'Common/dyld_priv.h',
+    ],
+    preprocessor_flags = ['-mmacosx-version-min=10.7'],
+    frameworks = [
+        '$SDKROOT/System/Library/Frameworks/Cocoa.framework',
+    ],
+)
+
+genrule(
+    name = 'sim-shim',
+    srcs = [
+        ':sim-shim-lib#macosx-i386,shared',
+        ':sim-shim-lib#macosx-x86_64,shared',
+    ],
+    out = 'sim-shim.dylib',
+    cmd = 'lipo $SRCS -create -output $OUT',
+)
+
+apple_library(
+    name = 'otest-shim',
+    srcs = COMMON_OTEST_SRCS + glob([
+        'otest-shim/otest-shim/**/*.m',
+    ]) + [
+        'Common/EventGenerator.m',
+    ],
+    headers = COMMON_OTEST_HEADERS + glob([
+        'otest-shim/otest-shim/**/*.h',
+    ]) + [
+        'Common/dyld-interposing.h',
+        'Common/dyld_priv.h',
+        'Common/EventGenerator.h',
+        'Common/ReporterEvents.h',
+        'Common/XCTest.h',
+    ],
+    preprocessor_flags = [
+        '-DSENTEST_IGNORE_DEPRECATION_WARNING',
+        '-F$SDKROOT/Developer/Library/Frameworks',
+        '-F$DEVELOPER_DIR/Library/Frameworks',
+    ],
+    compiler_flags = [
+        # otest-shim/otest-shim/otest-shim.m:118:69: warning: trigraph ignored [-Wtrigraphs]
+        # [NSRegularExpression regularExpressionWithPattern:@"\\e\\[(\\d;)??(\\d{1,2}[mHfABCDJhI])"
+        '-Wno-trigraphs',
+    ],
+    linker_flags = [
+        '-F$SDKROOT/Developer/Library/Frameworks',
+        '-F$DEVELOPER_DIR/Library/Frameworks',
+    ],
+    frameworks = [
+        '$SDKROOT/System/Library/Frameworks/Foundation.framework',
+        '$PLATFORM_DIR/Developer/Library/Frameworks/XCTest.framework',
+        '$SDKROOT/Developer/Library/Frameworks/SenTestingKit.framework',
+    ],
+)
+
+genrule(
+    name = 'otest-shim-ios',
+    srcs = [
+        ':otest-shim#iphonesimulator-i386,shared',
+        ':otest-shim#iphonesimulator-x86_64,shared',
+    ],
+    out = 'otest-shim-ios.dylib',
+    cmd = 'lipo $SRCS -create -output $OUT',
+)
+
+genrule(
+    name = 'otest-shim-osx',
+    srcs = [
+        ':otest-shim#macosx-i386,shared',
+        ':otest-shim#macosx-x86_64,shared',
+    ],
+    out = 'otest-shim-osx.dylib',
+    cmd = 'lipo $SRCS -create -output $OUT',
+)
+
+genrule(
+    name = 'xctool-zip',
+    deps = [
+        ':xctool-bin#macosx-x86_64',
+        ':pretty#macosx-x86_64',
+        ':plain#macosx-x86_64',
+        ':phabricator#macosx-x86_64',
+        ':junit#macosx-x86_64',
+        ':json-compilation-database#macosx-x86_64',
+        ':json-stream#macosx-x86_64',
+        ':user-notifications#macosx-x86_64',
+        ':teamcity#macosx-x86_64',
+        ':otest-query-ios',
+        ':otest-query-osx',
+        ':otest-query-lib-ios',
+        ':otest-query-lib-osx',
+        ':otest-shim-ios',
+        ':otest-shim-osx',
+        ':sim-shim',
+    ],
+    srcs = [
+        'scripts/create_xctool_zip.sh',
+    ],
+    cmd = 'scripts/create_xctool_zip.sh ' +
+        # Binary
+        '-b $(location :xctool-bin#macosx-x86_64) ' +
+        # Libs
+        '-l $(location :otest-query-lib-ios):' +
+           '$(location :otest-query-lib-osx):' +
+           '$(location :otest-shim-ios):' +
+           '$(location :otest-shim-osx):' +
+           '$(location :sim-shim) ' +
+        # Libexecs
+        '-x $(location :otest-query-ios):' +
+           '$(location :otest-query-osx) ' +
+        # Reporters
+        '-r $(location :pretty#macosx-x86_64):' +
+           '$(location :plain#macosx-x86_64):' +
+           '$(location :phabricator#macosx-x86_64):' +
+           '$(location :junit#macosx-x86_64):' +
+           '$(location :json-compilation-database#macosx-x86_64):' +
+           '$(location :json-stream#macosx-x86_64):' +
+           '$(location :user-notifications#macosx-x86_64):' +
+           '$(location :teamcity#macosx-x86_64) ' +
+        # Output zip location
+        '-o $OUT',
+    out = 'xctool.zip',
+    visibility = ['PUBLIC'],
+)
+
+genrule(
+    name = 'xctool-minimal-zip',
+    deps = [
+        ':xctool-bin#macosx-x86_64',
+        ':json-stream#macosx-x86_64',
+        ':otest-query-ios',
+        ':otest-query-osx',
+        ':otest-query-lib-ios',
+        ':otest-query-lib-osx',
+        ':otest-shim-ios',
+        ':otest-shim-osx',
+        ':sim-shim',
+    ],
+    srcs = [
+        'scripts/create_xctool_zip.sh',
+    ],
+    cmd = 'scripts/create_xctool_zip.sh ' +
+        # Binary
+        '-b $(location :xctool-bin#macosx-x86_64) ' +
+        # Libs
+        '-l $(location :otest-query-lib-ios):' +
+           '$(location :otest-query-lib-osx):' +
+           '$(location :otest-shim-ios):' +
+           '$(location :otest-shim-osx):' +
+           '$(location :sim-shim) ' +
+        # Libexecs
+        '-x $(location :otest-query-ios):' +
+           '$(location :otest-query-osx) ' +
+        # Reporters
+        '-r $(location :json-stream#macosx-x86_64) ' +
+        # Output zip location
+        '-o $OUT',
+    out = 'xctool-minimal.zip',
+    visibility = ['PUBLIC'],
+)

--- a/BUCK
+++ b/BUCK
@@ -337,6 +337,32 @@ genrule(
     cmd = 'lipo $SRCS -create -output $OUT',
 )
 
+apple_resource(
+    name = 'mobile-installation-helper-resources',
+    files = glob(['mobile-installation-helper/*.png']),
+    dirs = [],
+)
+
+apple_binary(
+    name = 'mobile-installation-helper-bin',
+    srcs = [
+        'mobile-installation-helper/mobile-installation-helper/main.m',
+    ],
+    frameworks = [
+        '$SDKROOT/System/Library/Frameworks/CoreGraphics.framework',
+        '$SDKROOT/System/Library/Frameworks/Foundation.framework',
+        '$SDKROOT/System/Library/Frameworks/UIKit.framework',
+    ],
+    deps = [':mobile-installation-helper-resources'],
+)
+
+apple_bundle(
+    name = 'mobile-installation-helper',
+    binary = ':mobile-installation-helper-bin',
+    extension = 'app',
+    info_plist = 'mobile-installation-helper/mobile-installation-helper/mobile-installation-helper-Info.plist',
+)
+
 genrule(
     name = 'xctool-zip',
     deps = [
@@ -349,6 +375,7 @@ genrule(
         ':json-stream#macosx-x86_64',
         ':user-notifications#macosx-x86_64',
         ':teamcity#macosx-x86_64',
+        ':mobile-installation-helper#iphonesimulator-i386',
         ':otest-query-ios',
         ':otest-query-osx',
         ':otest-query-lib-ios',
@@ -372,6 +399,8 @@ genrule(
         # Libexecs
         '-x $(location :otest-query-ios):' +
            '$(location :otest-query-osx) ' +
+        # Mobile installation helper app (only used for the 32-bit simulator)
+        '-m $(location :mobile-installation-helper#iphonesimulator-i386) ' +
         # Reporters
         '-r $(location :pretty#macosx-x86_64):' +
            '$(location :plain#macosx-x86_64):' +
@@ -387,6 +416,8 @@ genrule(
     visibility = ['PUBLIC'],
 )
 
+# Minimal xctool which doesn't include mobile-installation-helper.app (only needed for Xcode 5)
+# and only includes the json-stream reporter
 genrule(
     name = 'xctool-minimal-zip',
     deps = [

--- a/scripts/create_xctool_zip.sh
+++ b/scripts/create_xctool_zip.sh
@@ -41,7 +41,7 @@ for libexec in ${libexecs//:/ }; do
 done
 
 if [[ "$mobile_installation_helper_app" ]]; then
-    pushd out/libexec/mobile-installation-helper.app && unzip "$helper" && popd
+    pushd out/libexec/mobile-installation-helper.app && unzip "$mobile_installation_helper_app" && popd
 fi
 
 for reporter in ${reporters//:/ }; do

--- a/scripts/create_xctool_zip.sh
+++ b/scripts/create_xctool_zip.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -e
+
+# Creates xctool.zip with the binary, libraries, etc. laid out how the process expects it.
+
+PLATFORM="macosx-x86_64"
+
+while getopts "b:l:x:r:m:o:" opt; do
+    case "$opt" in
+        b)
+            binary=$OPTARG
+            ;;
+        l)
+            libs=$OPTARG
+            ;;
+        m)
+            mobile_installation_helper_app=$OPTARG
+            ;;
+        x)
+            libexecs=$OPTARG
+            ;;
+        r)
+            reporters=$OPTARG
+            ;;
+        o)
+            output=$OPTARG
+            ;;
+    esac
+done
+
+mkdir -p out/bin out/lib out/libexec out/libexec/mobile-installation-helper.app out/reporters
+cp "$binary" out/bin/xctool
+
+for lib in ${libs//:/ }; do
+    cp "$lib" out/lib/$(basename $lib \#$PLATFORM)
+done
+
+for libexec in ${libexecs//:/ }; do
+    cp "$libexec" out/libexec/$(basename $libexec \#$PLATFORM)
+done
+
+if [[ "$mobile_installation_helper_app" ]]; then
+    pushd out/libexec/mobile-installation-helper.app && unzip "$helper" && popd
+fi
+
+for reporter in ${reporters//:/ }; do
+    cp "$reporter" out/reporters/$(basename $reporter \#$PLATFORM)
+done
+
+cd out && zip -r -0 "$output" bin lib libexec reporters

--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -3,6 +3,8 @@
 set -e
 set -x
 
+export JAVA_HOME=$(/usr/libexec/java_home -v 1.7)
+
 # Build xctool with xcodebuild
 scripts/build.sh && ./xctool.sh -workspace xctool.xcworkspace -scheme xctool build build-tests run-tests
 

--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+set -x
+
+# Build xctool with xcodebuild
+scripts/build.sh && ./xctool.sh -workspace xctool.xcworkspace -scheme xctool build build-tests run-tests
+
+# Fetch latest upstream Buck version
+git clone https://github.com/facebook/buck.git Vendor/buck
+
+# Build xctool with Buck
+PATH=Vendor/buck/bin:$PATH buck build //:xctool-zip

--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -12,4 +12,4 @@ scripts/build.sh && ./xctool.sh -workspace xctool.xcworkspace -scheme xctool bui
 git clone https://github.com/facebook/buck.git Vendor/buck
 
 # Build xctool with Buck
-PATH=Vendor/buck/bin:$PATH buck build //:xctool-zip
+TERM=dumb PATH=Vendor/buck/bin:$PATH buck build //:xctool-zip


### PR DESCRIPTION
This doesn't yet build the mobile-installation-helper.app, but that's next.

I'm thinking about how we might want to run xctool tests via Buck. Maybe directly with `xctest`?

I tested this with:

```
% buck build :xctool-zip
% unzip -l buck-out/gen/xctool.zip
Archive:  buck-out/gen/xctool.zip
  Length     Date   Time    Name
 --------    ----   ----    ----
        0  05-27-15 21:28   bin/
   690468  05-27-15 21:28   bin/xctool
        0  05-27-15 21:28   lib/
    59004  05-27-15 21:28   lib/otest-query-lib-ios.dylib
    62868  05-27-15 21:28   lib/otest-query-lib-osx.dylib
   102496  05-27-15 21:28   lib/otest-shim-ios.dylib
   106360  05-27-15 21:28   lib/otest-shim-osx.dylib
    39668  05-27-15 21:28   lib/sim-shim.dylib
        0  05-27-15 21:28   libexec/
        0  05-27-15 21:28   libexec/mobile-installation-helper.app/
    24896  05-27-15 21:28   libexec/otest-query-ios
    63020  05-27-15 21:28   libexec/otest-query-osx
        0  05-27-15 21:28   reporters/
    35600  05-27-15 21:28   reporters/json-compilation-database
    25292  05-27-15 21:28   reporters/json-stream
    43844  05-27-15 21:28   reporters/junit
    35804  05-27-15 21:28   reporters/phabricator
    83356  05-27-15 21:28   reporters/plain
    83356  05-27-15 21:28   reporters/pretty
    39392  05-27-15 21:28   reporters/teamcity
    31088  05-27-15 21:28   reporters/user-notifications
 --------                   -------
  1526512                   21 files
```

I also ran the compiled `xctool` by hand to run a few tests for iOS, it worked fine.