### PR TITLE
Run available pre and post actions scripts in the active scheme

### DIFF
--- a/xctool/xctool-tests/ActionScriptsTests.m
+++ b/xctool/xctool-tests/ActionScriptsTests.m
@@ -1,0 +1,89 @@
+//
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "Action.h"
+#import "FakeTask.h"
+#import "FakeTaskManager.h"
+#import "LaunchHandlers.h"
+#import "TestUtil.h"
+#import "XCTool.h"
+
+@interface ActionScriptsTests : XCTestCase
+@end
+
+@implementation ActionScriptsTests
+
+- (void)setUp
+{
+  [super setUp];
+}
+
+static NSArray *GetArgs(NSString *action)
+{
+  return @[@"-project", TEST_DATA @"TestProject-Library-OSX/TestProject-Library-OSX.xcodeproj",
+           @"-scheme", @"TestProject-Library-OSX-With-Scripts",
+           @"-sdk", @"macosx",
+           @"-actionScripts",
+           action,
+           @"-reporter", @"plain",
+           ];
+}
+
+- (void)checkOuput:(NSDictionary *)output actions:(NSArray *)actions
+{
+  XCTAssertEqual([output[@"stderr"] length], 0, @"stderr is not empty");
+
+  NSString *out = output[@"stdout"];
+
+  for (NSString *action in actions) {
+    NSRange range = [out rangeOfString:[NSString stringWithFormat:@"[Info] Running PreAction %@ Scripts...", action]];
+    XCTAssertNotEqual(range.location, NSNotFound, @"Failed to match action pattern");
+    range = [out rangeOfString:[NSString stringWithFormat:@"[Info] Running PostAction %@ Scripts...", action]];
+    XCTAssertNotEqual(range.location, NSNotFound, @"Failed to match action pattern");
+  }
+}
+
+- (void)testActionScripts
+{
+
+  NSArray *testTuple = @[
+                         @[@"build", @[@"build"]],
+                         @[@"build-tests", @[@"build"]],
+                         @[@"run-tests", @[@"test"]],
+                         @[@"test", @[@"build", @"test"]],
+                         @[@"archive", @[@"archive"]],
+                         @[@"analyze", @[@"analyze"]]
+                         ];
+
+  for (NSArray *test in testTuple) {
+
+    NSString *action = test[0];
+    XCTool *tool = [[XCTool alloc] init];
+    tool.arguments = GetArgs(action);
+
+    NSDictionary *out = [TestUtil runWithFakeStreams:tool];
+    [self checkOuput:out actions:test[1]];
+  }
+}
+
+- (void) tearDown
+{
+  [super tearDown];
+}
+
+@end

--- a/xctool/xctool-tests/TestData/TestProject-Library-OSX/TestProject-Library-OSX.xcodeproj/xcshareddata/xcschemes/TestProject-Library-OSX-With-Scripts.xcscheme
+++ b/xctool/xctool-tests/TestData/TestProject-Library-OSX/TestProject-Library-OSX.xcodeproj/xcshareddata/xcschemes/TestProject-Library-OSX-With-Scripts.xcscheme
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0460"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "echo `date -u +%s` &gt; ${BUILD_DIR}/ActionScripts-pre-build.out&#10;">
+            </ActionContent>
+         </ExecutionAction>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "env | sort &gt;&gt; ${BUILD_DIR}/ActionScripts-pre-build.out">
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
+      <PostActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "echo `date -u +%s` &gt; ${BUILD_DIR}/ActionScripts-post-build.out">
+            </ActionContent>
+         </ExecutionAction>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "env | sort &gt;&gt; ${BUILD_DIR}/ActionScripts-post-build.out">
+            </ActionContent>
+         </ExecutionAction>
+      </PostActions>
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "282BFDE81715E8520022F9FF"
+               BuildableName = "TestProject-Library-OSX.dylib"
+               BlueprintName = "TestProject-Library-OSX"
+               ReferencedContainer = "container:TestProject-Library-OSX.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "echo `date -u +%s` &gt; ${BUILD_DIR}/ActionScripts-pre-test.out"
+               shellToInvoke = "/bin/sh">
+            </ActionContent>
+         </ExecutionAction>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "env | sort &gt;&gt; ${BUILD_DIR}/ActionScripts-pre-test.out"
+               shellToInvoke = "/bin/sh">
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
+      <PostActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "echo `date -u +%s` &gt; ${BUILD_DIR}/ActionScripts-post-test.out">
+            </ActionContent>
+         </ExecutionAction>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "env | sort &gt;&gt; ${BUILD_DIR}/ActionScripts-post-test.out">
+            </ActionContent>
+         </ExecutionAction>
+      </PostActions>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "282BFDFC1715E8520022F9FF"
+               BuildableName = "TestProject-Library-OSXTests.octest"
+               BlueprintName = "TestProject-Library-OSXTests"
+               ReferencedContainer = "container:TestProject-Library-OSX.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "282BFDE81715E8520022F9FF"
+            BuildableName = "TestProject-Library-OSX.dylib"
+            BlueprintName = "TestProject-Library-OSX"
+            ReferencedContainer = "container:TestProject-Library-OSX.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "echo `date -u +%s` &gt; ${BUILD_DIR}/ActionScripts-pre-archive.out&#10;">
+            </ActionContent>
+         </ExecutionAction>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "env | sort &gt;&gt; ${BUILD_DIR}/ActionScripts-pre-archive.out">
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
+      <PostActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "echo `date -u +%s` &gt; ${BUILD_DIR}/ActionScripts-post-archive.out&#10;">
+            </ActionContent>
+         </ExecutionAction>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "env | sort &gt;&gt; ${BUILD_DIR}/ActionScripts-post-archive.out">
+            </ActionContent>
+         </ExecutionAction>
+      </PostActions>
+   </ArchiveAction>
+</Scheme>

--- a/xctool/xctool.xcodeproj/project.pbxproj
+++ b/xctool/xctool.xcodeproj/project.pbxproj
@@ -104,6 +104,9 @@
 		3892D7421811A5CC00E68652 /* EventGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 3892D7401811A5CC00E68652 /* EventGenerator.m */; };
 		40623EBE190EA61B004FB374 /* InstallAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 40623EBD190EA61B004FB374 /* InstallAction.m */; };
 		40623EBF190EA61B004FB374 /* InstallAction.m in Sources */ = {isa = PBXBuildFile; fileRef = 40623EBD190EA61B004FB374 /* InstallAction.m */; };
+		4DC218071B238A4F000C9AA6 /* ActionScripts.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DC218061B238A4F000C9AA6 /* ActionScripts.m */; };
+		4DC2180A1B238AD3000C9AA6 /* ActionScripts.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DC218061B238A4F000C9AA6 /* ActionScripts.m */; };
+		4DD0C68A1B25E25E005FFF7F /* ActionScriptsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DD0C6891B25E25E005FFF7F /* ActionScriptsTests.m */; };
 		AA318BEF17E9BA3500BF159E /* TestingFramework.m in Sources */ = {isa = PBXBuildFile; fileRef = AA318BEE17E9BA3500BF159E /* TestingFramework.m */; };
 		AA318BF017E9BA3500BF159E /* TestingFramework.m in Sources */ = {isa = PBXBuildFile; fileRef = AA318BEE17E9BA3500BF159E /* TestingFramework.m */; };
 		AA6C88F71808C2C5006A3581 /* OTestShimTests.m in Sources */ = {isa = PBXBuildFile; fileRef = AA6C88F61808C2C5006A3581 /* OTestShimTests.m */; };
@@ -301,6 +304,9 @@
 		3892D7401811A5CC00E68652 /* EventGenerator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EventGenerator.m; sourceTree = "<group>"; };
 		40623EBC190EA61B004FB374 /* InstallAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InstallAction.h; sourceTree = "<group>"; };
 		40623EBD190EA61B004FB374 /* InstallAction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InstallAction.m; sourceTree = "<group>"; };
+		4DC218061B238A4F000C9AA6 /* ActionScripts.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ActionScripts.m; sourceTree = "<group>"; };
+		4DC218091B238AB2000C9AA6 /* ActionScripts.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ActionScripts.h; sourceTree = "<group>"; };
+		4DD0C6891B25E25E005FFF7F /* ActionScriptsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ActionScriptsTests.m; sourceTree = "<group>"; };
 		AA194FD118091AE700F56AFC /* ContainsAssertionFailure.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ContainsAssertionFailure.h; sourceTree = "<group>"; };
 		AA318BEC17E9B7CA00BF159E /* XCTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = XCTest.h; sourceTree = "<group>"; };
 		AA318BED17E9BA3500BF159E /* TestingFramework.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestingFramework.h; sourceTree = "<group>"; };
@@ -468,6 +474,8 @@
 			isa = PBXGroup;
 			children = (
 				2834799516E199A9003C3B77 /* Actions */,
+				4DC218091B238AB2000C9AA6 /* ActionScripts.h */,
+				4DC218061B238A4F000C9AA6 /* ActionScripts.m */,
 				28BB043B17C7FF43004F6C13 /* Buildable.h */,
 				28BB043C17C7FF43004F6C13 /* Buildable.m */,
 				CD56770D1766782C003B727C /* BuildStateParser.h */,
@@ -541,6 +549,7 @@
 		283CCAC516C2EE9900F2E343 /* xctool-tests */ = {
 			isa = PBXGroup;
 			children = (
+				4DD0C6891B25E25E005FFF7F /* ActionScriptsTests.m */,
 				28046D2F16D76665000AA15C /* ActionTests.m */,
 				28302E1D175A8B6900C997B2 /* ArchiveActionTests.m */,
 				28ADB43A16E410F9006301ED /* BuildActionTests.m */,
@@ -878,6 +887,7 @@
 				2869F3C517C82FB80078F078 /* TestableExecutionInfo.m in Sources */,
 				EEB31CEA17C685E500CFB0E1 /* OCEventState.m in Sources */,
 				EEB31CF117C6A1EF00CFB0E1 /* OCTestEventState.m in Sources */,
+				4DC218071B238A4F000C9AA6 /* ActionScripts.m in Sources */,
 				AAC1E0BD18121071005A4FD5 /* OCUnitIOSLogicTestQueryRunner.m in Sources */,
 				40623EBE190EA61B004FB374 /* InstallAction.m in Sources */,
 				EEB31CF917C6D57B00CFB0E1 /* OCTestSuiteEventState.m in Sources */,
@@ -933,6 +943,7 @@
 				28ADB43B16E410F9006301ED /* BuildActionTests.m in Sources */,
 				287BF04D16F1A6EB00590E06 /* XcodeSubjectInfoTests.m in Sources */,
 				287BF08516F1A97900590E06 /* XcodeSubjectInfo.m in Sources */,
+				4DD0C68A1B25E25E005FFF7F /* ActionScriptsTests.m in Sources */,
 				28ACFC8416FBA888004BAF33 /* TaskUtil.m in Sources */,
 				288B9FB9171A50C1008F0BDF /* OCUnitOSXLogicTestRunner.m in Sources */,
 				288B9FBD171A5509008F0BDF /* OCUnitOSXAppTestRunner.m in Sources */,
@@ -953,6 +964,7 @@
 				AAC1E0BE18121071005A4FD5 /* OCUnitIOSLogicTestQueryRunner.m in Sources */,
 				28C81A63175562050072DDB8 /* ReportStatusTests.m in Sources */,
 				28302E1E175A8B6900C997B2 /* ArchiveActionTests.m in Sources */,
+				4DC2180A1B238AD3000C9AA6 /* ActionScripts.m in Sources */,
 				AA318BF017E9BA3500BF159E /* TestingFramework.m in Sources */,
 				CD098A2B175EBD20002E0CAC /* AnalyzeAction.m in Sources */,
 				CD5677101766782C003B727C /* BuildStateParser.mm in Sources */,

--- a/xctool/xctool/ActionScripts.h
+++ b/xctool/xctool/ActionScripts.h
@@ -1,0 +1,57 @@
+//
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+#import "Options.h"
+
+@interface ActionScriptInfo : NSObject
++ (instancetype)scriptInfoFromElement:(NSXMLElement *)node;
+@end
+
+@interface ActionScript : NSObject
++ (instancetype)actionFromDoc:(NSXMLDocument *)doc byName:(NSString *)name error:(NSError **)error;
++ (void)runScripts:(NSArray *)scripts options:(Options *)options environment:(NSDictionary *)env;
+@end
+
+/**
+ * ActionScripts finds all pre and post actions scripts described in the active scheme.
+ * The resulting object can then be used to execute the scripts.
+ */
+@interface ActionScripts : NSObject
+/**
+ * Init ActionScripts
+ *
+ *  @param schemePath path to the XML Scheme
+ *  @param env        The shell environement that have been defined so far
+ *
+ *  @return nil on failure
+ */
+- (instancetype)initWithSchemePath:(NSString *)schemePath
+                       environment:(NSDictionary *)env
+                             error:(NSError **)error;
+- (void)preBuildWithOptions:(Options *)options;
+- (void)postBuildWithOptions:(Options *)options;
+- (void)preRunWithOptions:(Options *)options;
+- (void)postRunWithOptions:(Options *)options;
+- (void)preTestWithOptions:(Options *)options;
+- (void)postTestWithOptions:(Options *)options;
+- (void)preProfileWithOptions:(Options *)options;
+- (void)postProfileWithOptions:(Options *)options;
+- (void)preAnalyzeWithOptions:(Options *)options;
+- (void)postAnalyzeWithOptions:(Options *)options;
+- (void)preArchiveWithOptions:(Options *)options;
+- (void)postArchiveWithOptions:(Options *)options;
+@end

--- a/xctool/xctool/ActionScripts.m
+++ b/xctool/xctool/ActionScripts.m
@@ -1,0 +1,330 @@
+//
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "ActionScripts.h"
+#import "EventGenerator.h"
+#import "ReportStatus.h"
+#import "TaskUtil.h"
+#import "XCToolUtil.h"
+
+@interface ActionScriptInfo ()
+
+@property (nonatomic, copy) NSString *title;
+@property (nonatomic, copy) NSString *shell;
+@property (nonatomic, copy) NSString *body;
+
+@end
+
+@implementation ActionScriptInfo
+
++ (instancetype)scriptInfoFromElement:(NSXMLElement *)node
+{
+  NSString *type = [[node attributeForName:@"ActionType"] stringValue];
+  // we only support shell script actions
+  if (![type isEqualToString:@"Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction"]) {
+    return nil;
+  }
+
+  NSXMLElement *content = [[node elementsForName:@"ActionContent"] firstObject];
+  if (!content) {
+    return nil;
+  }
+
+  NSString *title = [[content attributeForName:@"title"] stringValue];
+  NSString *script = [[content attributeForName:@"scriptText"] stringValue];
+  if (!script) {
+    return nil;
+  }
+
+  NSString *shell = [[content attributeForName:@"shellToInvoke"] stringValue];
+  if (!shell) {
+    // This is the default shell
+    shell = @"/bin/sh";
+  }
+
+  ActionScriptInfo *info = [ActionScriptInfo new];
+  [info setTitle:title];
+  [info setBody:script];
+  [info setShell:shell];
+
+  return info;
+}
+
+@end
+
+@interface ActionScript ()
+@property (nonatomic, copy) NSArray *preScripts;
+@property (nonatomic, copy) NSArray *postScripts;
+@end
+
+@implementation ActionScript
+
++ (NSArray *)bracketingScriptFromElement:(NSXMLElement *)node byType:(NSString *)type
+{
+  NSMutableArray *scripts = [NSMutableArray new];
+  NSArray *actions = [node elementsForName:type];
+
+  if ([actions count] == 0) {
+    return nil;
+  }
+
+  NSAssert([actions count] == 1, @"expected only one action");
+  NSXMLElement *action = [actions firstObject];
+
+  NSArray *executionList = [action elementsForName:@"ExecutionAction"];
+
+  for (NSXMLElement *execution in executionList) {
+    ActionScriptInfo *script = [ActionScriptInfo scriptInfoFromElement:execution];
+    if (script) {
+      [scripts addObject:script];
+    }
+  }
+
+  if (scripts.count) {
+    return scripts;
+  }
+
+  return nil;
+}
+
++ (instancetype)actionFromDoc:(NSXMLDocument *)doc byName:(NSString *)name error:(NSError **)error
+{
+  NSArray *actions = [doc nodesForXPath:name error:error];
+  if (!actions) {
+    return nil;
+  }
+
+  if ([actions count] == 0) {
+    return nil;
+  }
+
+  NSAssert([actions count] == 1, @"expecting only one action: %@", name);
+
+  NSXMLElement *action = [actions firstObject];
+
+  NSArray *pre = [ActionScript bracketingScriptFromElement:action byType:@"PreActions"];
+  NSArray *post = [ActionScript bracketingScriptFromElement:action byType:@"PostActions"];
+
+  if (!(pre || post)) {
+    return nil;
+  }
+
+  ActionScript *as = [ActionScript new];
+  if (!as) {
+    return nil;
+  }
+
+  [as setPreScripts:pre];
+  [as setPostScripts:post];
+
+  return as;
+}
+
++ (void)runScripts:(NSArray *)scripts options:(Options *)options environment:(NSDictionary *)env
+{
+  for (ActionScriptInfo *script in scripts) {
+    NSTask *task = CreateTaskInSameProcessGroup();
+    NSString *desc = [NSString stringWithFormat:@"Running: %@", script.title];
+
+    [task setLaunchPath:script.shell];
+    [task setArguments:@[ @"-c", script.body]];
+    [task setEnvironment:env];
+
+    NSString *out = LaunchTaskAndCaptureOutputInCombinedStream(task, desc);
+    PublishEventToReporters(options.reporters,
+      EventDictionaryWithNameAndContent(@"ActionScript", @{
+        kReporter_TestOutput_OutputKey: out
+        }));
+  }
+}
+
+@end
+
+@interface ActionScripts ()
+@property (nonatomic, copy) NSDictionary *environment;
+@property (nonatomic, strong) ActionScript *build;
+@property (nonatomic, strong) ActionScript *run;
+@property (nonatomic, strong) ActionScript *test;
+@property (nonatomic, strong) ActionScript *profile;
+@property (nonatomic, strong) ActionScript *analyze;
+@property (nonatomic, strong) ActionScript *archive;
+@end
+
+@implementation ActionScripts
+
+/**
+ *  The environment passed in is not sufficient to run most scripts.
+ *  This function allows additional environment variables to be specified or
+ *  modified.
+ *
+ *  @param oldEnv current environment of the tool
+ *
+ *  @return expanded environment after tweeking
+ */
++ (NSDictionary *)fixupScriptEnvironment:(NSDictionary *)oldEnv
+{
+  NSDictionary *procEnv = [[NSProcessInfo processInfo] environment];
+  NSMutableDictionary *env = [oldEnv mutableCopy];
+
+  env[@"PATH"] = [NSString stringWithFormat:@"%@:%@", oldEnv[@"PATH"], procEnv[@"PATH"]];
+
+  return env;
+}
+
+- (instancetype)initWithSchemePath:(NSString *)schemePath environment:(NSDictionary *)env error:(NSError **)error
+{
+  self = [super init];
+  if (!self) {
+    return nil;
+  }
+
+  NSXMLDocument *doc = [[NSXMLDocument alloc] initWithContentsOfURL:[NSURL fileURLWithPath:schemePath]
+                                                            options:0
+                                                              error:error];
+  if (!doc) {
+    return nil;
+  }
+
+  if (!(_build = [ActionScript actionFromDoc:doc byName:@"//BuildAction" error:error]) && *error) {
+    return nil;
+  }
+  if (!(_run = [ActionScript actionFromDoc:doc byName:@"//RunAction" error:error]) && *error) {
+    return nil;
+  }
+  if (!(_test = [ActionScript actionFromDoc:doc byName:@"//TestAction" error:error]) && *error) {
+    return nil;
+  }
+
+  // This is not accessible from xctool at the moment
+  if (!(_profile = [ActionScript actionFromDoc:doc byName:@"//ProfileAction" error:error]) && *error) {
+    return nil;
+  }
+
+  // Analyze actually uses the build action scripts
+  if (!(_analyze = [ActionScript actionFromDoc:doc byName:@"//BuildAction" error:error]) && *error) {
+    return nil;
+  }
+  if (!(_archive = [ActionScript actionFromDoc:doc byName:@"//ArchiveAction" error:error]) && *error) {
+    return nil;
+  }
+
+  // fill out environment
+  _environment = [[[self class] fixupScriptEnvironment:env] copy];
+
+  return self;
+}
+
+- (void)runPreScripts:(ActionScript *)scripts type:(NSString*)type options:(Options *)options
+{
+  if (!scripts) {
+    return;
+  }
+
+  if (!options.actionScripts) {
+    return;
+  }
+
+  ReportStatusMessageBegin(options.reporters, REPORTER_MESSAGE_INFO,
+                           @"Running PreAction %@ Scripts...", type);
+
+  [ActionScript runScripts:scripts.preScripts options:options environment:_environment];
+
+  ReportStatusMessageEnd(options.reporters, REPORTER_MESSAGE_INFO,
+                         @"Running PreAction %@ Scripts...", type);
+
+}
+
+- (void)runPostScripts:(ActionScript *)scripts type:(NSString*)type options:(Options *)options
+{
+  if (!scripts) {
+    return;
+  }
+
+  if (!options.actionScripts) {
+    return;
+  }
+
+  ReportStatusMessageBegin(options.reporters, REPORTER_MESSAGE_INFO,
+                           @"Running PostAction %@ Scripts...", type);
+
+  [ActionScript runScripts:scripts.postScripts options:options environment:_environment];
+
+  ReportStatusMessageEnd(options.reporters, REPORTER_MESSAGE_INFO,
+                         @"Running PostAction %@ Scripts...", type);
+
+}
+
+- (void)preBuildWithOptions:(Options *)options
+{
+  return [self runPreScripts:self.build type:@"build" options:options];
+}
+
+- (void)postBuildWithOptions:(Options *)options
+{
+  return [self runPostScripts:self.build type:@"build" options:options];
+}
+
+- (void)preRunWithOptions:(Options *)options
+{
+  return [self runPreScripts:self.run type:@"run" options:options];
+}
+
+- (void)postRunWithOptions:(Options *)options
+{
+  return [self runPostScripts:self.run type:@"run" options:options];
+}
+
+- (void)preTestWithOptions:(Options *)options
+{
+  return [self runPreScripts:self.test type:@"test" options:options];
+}
+
+- (void)postTestWithOptions:(Options *)options
+{
+  return [self runPostScripts:self.test type:@"test" options:options];
+}
+
+- (void)preProfileWithOptions:(Options *)options
+{
+  return [self runPreScripts:self.profile type:@"profile" options:options];
+}
+
+- (void)postProfileWithOptions:(Options *)options
+{
+  return [self runPostScripts:self.profile type:@"profile" options:options];
+}
+
+- (void)preAnalyzeWithOptions:(Options *)options
+{
+  return [self runPreScripts:self.analyze type:@"analyze" options:options];
+}
+
+- (void)postAnalyzeWithOptions:(Options *)options
+{
+  return [self runPostScripts:self.analyze type:@"analyze" options:options];
+}
+
+- (void)preArchiveWithOptions:(Options *)options
+{
+  return [self runPreScripts:self.archive type:@"archive" options:options];
+}
+
+- (void)postArchiveWithOptions:(Options *)options
+{
+  return [self runPostScripts:self.archive type:@"archive" options:options];
+}
+
+@end

--- a/xctool/xctool/AnalyzeAction.m
+++ b/xctool/xctool/AnalyzeAction.m
@@ -252,6 +252,8 @@
                 xcodeSubjectInfo:(XcodeSubjectInfo *)xcodeSubjectInfo
 {
 
+  [xcodeSubjectInfo.actionScripts preAnalyzeWithOptions:options];
+
   BuildTargetsCollector *buildTargetsCollector = [[BuildTargetsCollector alloc] init];
   NSArray *reporters = [options.reporters arrayByAddingObject:buildTargetsCollector];
 
@@ -293,6 +295,8 @@
                      @"analyze"]];
     success = RunXcodebuildAndFeedEventsToReporters(args, @"analyze", [options scheme], reporters);
   }
+
+  [xcodeSubjectInfo.actionScripts postAnalyzeWithOptions:options];
 
   if (!success) {
     return NO;

--- a/xctool/xctool/ArchiveAction.m
+++ b/xctool/xctool/ArchiveAction.m
@@ -19,6 +19,7 @@
 #import "BuildAction.h"
 #import "Options.h"
 #import "XCToolUtil.h"
+#import "XcodeSubjectInfo.h"
 
 @interface ArchiveAction ()
 
@@ -45,10 +46,16 @@
     [arguments addObjectsFromArray:@[@"-archivePath", _archivePath]];
   }
 
-  return RunXcodebuildAndFeedEventsToReporters(arguments,
-                                               @"archive",
-                                               [options scheme],
-                                               [options reporters]);
+  [xcodeSubjectInfo.actionScripts preArchiveWithOptions:options];
+
+  BOOL ret = RunXcodebuildAndFeedEventsToReporters(arguments,
+                                                   @"archive",
+                                                   [options scheme],
+                                                   [options reporters]);
+
+  [xcodeSubjectInfo.actionScripts postArchiveWithOptions:options];
+
+  return ret;
 }
 
 + (NSArray *)options

--- a/xctool/xctool/BuildAction.m
+++ b/xctool/xctool/BuildAction.m
@@ -19,6 +19,7 @@
 #import "Options.h"
 #import "TaskUtil.h"
 #import "XCToolUtil.h"
+#import "XcodeSubjectInfo.h"
 
 @implementation BuildAction
 
@@ -29,15 +30,23 @@
 
 - (BOOL)performActionWithOptions:(Options *)options xcodeSubjectInfo:(XcodeSubjectInfo *)xcodeSubjectInfo
 {
+
+  [xcodeSubjectInfo.actionScripts preBuildWithOptions:options];
+
+
   NSArray *arguments = [[[options xcodeBuildArgumentsForSubject]
                          arrayByAddingObjectsFromArray:[options commonXcodeBuildArgumentsForSchemeAction:@"LaunchAction"
                                                                                         xcodeSubjectInfo:xcodeSubjectInfo]]
                         arrayByAddingObject:@"build"];
 
-  return RunXcodebuildAndFeedEventsToReporters(arguments,
+  BOOL ret = RunXcodebuildAndFeedEventsToReporters(arguments,
                                                @"build",
                                                [options scheme],
                                                [options reporters]);
+
+  [xcodeSubjectInfo.actionScripts postBuildWithOptions:options];
+
+  return ret;
 }
 
 @end

--- a/xctool/xctool/BuildTestsAction.m
+++ b/xctool/xctool/BuildTestsAction.m
@@ -114,6 +114,8 @@
     [schemeGenerator addBuildableWithID:testable.targetID inProject:testable.projectPath];
   }
 
+  [xcodeSubjectInfo.actionScripts preBuildWithOptions:options];
+
   NSArray *xcodebuildArguments = [options commonXcodeBuildArgumentsForSchemeAction:@"TestAction"
                                                                   xcodeSubjectInfo:xcodeSubjectInfo];
   BOOL succeeded = [BuildTestsAction buildWorkspace:[schemeGenerator writeWorkspaceNamed:@"Tests"]
@@ -124,6 +126,8 @@
                                   sharedPrecompsDir:xcodeSubjectInfo.sharedPrecompsDir
                                      xcodeArguments:xcodebuildArguments
                                        xcodeCommand:command];
+
+  [xcodeSubjectInfo.actionScripts postBuildWithOptions:options];
 
   if (!succeeded) {
     return NO;

--- a/xctool/xctool/Options.h
+++ b/xctool/xctool/Options.h
@@ -50,6 +50,7 @@
 
 @property (nonatomic, assign) BOOL showBuildSettings;
 @property (nonatomic, assign) BOOL showTasks;
+@property (nonatomic, assign) BOOL actionScripts;
 
 @property (nonatomic, strong) NSMutableDictionary *buildSettings;
 @property (nonatomic, strong) NSMutableDictionary *userDefaults;

--- a/xctool/xctool/Options.m
+++ b/xctool/xctool/Options.m
@@ -148,6 +148,10 @@
                          aliases:nil
                      description:@"show all tasks being spawned by xctool"
                          setFlag:@selector(setShowTasks:)],
+    [Action actionOptionWithName:@"actionScripts"
+                         aliases:nil
+                     description:@"run pre and post action scripts defined in the scheme"
+                         setFlag:@selector(setActionScripts:)],
     [Action actionOptionWithName:@"version"
                          aliases:@[@"v"]
                      description:@"print version and exit"

--- a/xctool/xctool/RunTestsAction.m
+++ b/xctool/xctool/RunTestsAction.m
@@ -496,13 +496,7 @@ NSArray *BucketizeTestCasesByTestClass(NSArray *testCases, int bucketSize)
     testables = newTestables;
   }
 
-  if (![self runTestables:testables
-                  options:options
-         xcodeSubjectInfo:xcodeSubjectInfo]) {
-    return NO;
-  }
-
-  return YES;
+  return [self runTestables:testables options:options xcodeSubjectInfo:xcodeSubjectInfo];
 }
 
 - (Class)testRunnerClassForBuildSettings:(NSDictionary *)testableBuildSettings
@@ -726,6 +720,8 @@ typedef BOOL (^TestableBlock)(NSArray *reporters);
     return [self listTestsInTestableExecutionInfos:testableExecutionInfos options:options];
   }
 
+  [xcodeSubjectInfo.actionScripts preTestWithOptions:options];
+
   for (TestableExecutionInfo *info in testableExecutionInfos) {
     if (info.buildSettingsError) {
       TestableBlock block = [self blockToAdvertiseMessage:info.buildSettingsError
@@ -889,6 +885,8 @@ typedef BOOL (^TestableBlock)(NSArray *reporters);
   dispatch_release(group);
   dispatch_release(queueLimiter);
   dispatch_release(q);
+
+  [xcodeSubjectInfo.actionScripts postTestWithOptions:options];
 
   return succeeded;
 }

--- a/xctool/xctool/XcodeSubjectInfo.h
+++ b/xctool/xctool/XcodeSubjectInfo.h
@@ -16,6 +16,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import "ActionScripts.h"
+
 @class Testable;
 @class XcodeTargetMatch;
 
@@ -36,6 +38,8 @@
 @property (nonatomic, copy) NSString *effectivePlatformName;
 @property (nonatomic, copy) NSString *targetedDeviceFamily;
 @property (nonatomic, copy) NSArray *testables;
+@property (nonatomic, strong) ActionScripts *actionScripts;
+@property (nonatomic, copy) NSDictionary *environmentForScripts;
 // Everything in the scheme marked as Build for Test
 @property (nonatomic, copy) NSArray *buildablesForTest;
 @property (nonatomic, assign) BOOL parallelizeBuildables;


### PR DESCRIPTION
Fixes Issue #313 
Feature is enabled by using `-actionScripts`

All comments welcome, especially on file placement, naming conventions, and hook placement.
Signed-off-by: Jimi Xenidis <jimix@pobox.com>