### PR TITLE
Don't unzip output of apple_bundle rule

### DIFF
--- a/scripts/create_xctool_zip.sh
+++ b/scripts/create_xctool_zip.sh
@@ -41,7 +41,7 @@ for libexec in ${libexecs//:/ }; do
 done
 
 if [[ "$mobile_installation_helper_app" ]]; then
-    pushd out/libexec/mobile-installation-helper.app && unzip "$mobile_installation_helper_app" && popd
+    cp -a "$mobile_installation_helper_app" out/libexec
 fi
 
 for reporter in ${reporters//:/ }; do


### PR DESCRIPTION
The build is currently broken with Buck master:

https://travis-ci.org/facebook/xctool/builds/65782394

This is because Buck commit c83489ea543ce164d43dd93a1af53c76ea45e139 changed the behavior of the `apple_bundle` rule to no longer output a ZIP archive, but instead place its output directly in a directory.

This updates `scripts/create_xctool/zip.sh` to work with the new behavior.

Tested with `buck build //:xctool-zip`.