### PR TITLE
Drop Xcode 5 support.

### DIFF
--- a/Common/TestingFramework.m
+++ b/Common/TestingFramework.m
@@ -52,7 +52,7 @@ NSDictionary *FrameworkInfoForExtension(NSString *extension)
           extension, [frameworks allKeys]);
     return nil;
   }
-  return [frameworks objectForKey:extension];
+  return frameworks[extension];
 }
 
 NSDictionary *FrameworkInfoForTestBundleAtPath (NSString *path)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ features and fix any bugs they may encounter without learning a new language. We
 
 ## Requirements
 
-* Xcode 5 or higher
+* Xcode 6 or higher
 * You'll need Xcode's Command Line Tools installed.  From Xcode, install
 via _Xcode &rarr; Preferences &rarr; Downloads_.
 

--- a/xctool/xctool/XCTool.m
+++ b/xctool/xctool/XCTool.m
@@ -90,8 +90,8 @@
 
 - (void)run
 {
-  if ([XcodebuildVersion() compare:@"0500"] == NSOrderedAscending) {
-    [_standardError printString:@"ERROR: This version of xctool supports only Xcode 5.0 or higher.\n"];
+  if ([XcodebuildVersion() compare:@"0600"] == NSOrderedAscending) {
+    [_standardError printString:@"ERROR: This version of xctool supports only Xcode 6.0 or higher.\n"];
     _exitStatus = 1;
     return;
   }


### PR DESCRIPTION
Why now:
- At Facebook we aren't using Xcode 5.
- Travis CI uses Xcode 6.1.1 since December 18th, 2014 ((http://docs.travis-ci.com/user/osx-ci-environment/#Xcode, http://docs.travis-ci.com/user/build-environment-updates/2014-12-18/).
- According to Apple documentation (https://developer.apple.com/support/xcode/) developers "should use the latest version of Xcode available on the Mac App Store to submit your apps, or when available, the latest GM seed release from the Xcode download page.". Latest version in the Mac App Store is 6.3.2 (https://itunes.apple.com/us/app/xcode/id497799835?mt=12).
- Latest Xcode 5 version (5.1.1) was released more then a year ago (http://en.wikipedia.org/wiki/Xcode#Xcode_5.0_-_7.x_.28with_arm64_support.29)

Benefits:
- We could switch from injecting dynamic libraries to injecting iOS frameworks.
- We could remove all hacks to support xctool built with Xcode 5 to run with Xcode 6.
- We could remove mobile-installation-helper.app because Xcode 6 gives us access to CoreSimulator API's.
- We could start adopting new versions of Xcode w/o worrying about compatibility with older versions of Xcode.

cc @fpotter, @LegNeato.