### PR TITLE
Check for empty error outputText in TeamCity reporter

### DIFF
--- a/reporters/teamcity/TeamCityReporter.m
+++ b/reporters/teamcity/TeamCityReporter.m
@@ -71,7 +71,7 @@
   if (!succeeded) {
     NSString *outputText = [event[kReporter_EndBuildCommand_EmittedOutputTextKey]
                             stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-    if (outputText) {
+    if (outputText.length > 0) {
       NSLog(@"##teamcity[buildStatus status='FAILURE' text='%@']",[TeamCityStatusMessageGenerator escapeCharacter:[self condensedBuildCommandOutput:outputText]]);
     }
     else {


### PR DESCRIPTION
I reported Issue #540 with a stack trace I was getting on build errors (instead of the error)