### PR TITLE
Allow prefix matching for test class names

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,15 @@ path/to/xctool.sh \
   test -only SomeTestTarget:SomeTestClass/testSomeMethod
 ```
 
+You can also specify prefix matching for classes or test methods:
+
+```bash
+path/to/xctool.sh \
+  -workspace YourWorkspace.xcworkspace \
+  -scheme YourScheme \
+  test -only SomeTestTarget:SomeTestClassPrefix*,SomeTestClass/testSomeMethodPrefix*
+```
+
 You can also run tests against a different SDK:
 
 ```bash

--- a/xctool/xctool-tests/OCUnitTestRunnerTests.m
+++ b/xctool/xctool-tests/OCUnitTestRunnerTests.m
@@ -512,6 +512,10 @@ static int NumberOfEntries(NSArray *array, NSObject *target)
                          @"Cls2/test1",
                          @"Cls2/test2",
                          @"Cls3/test1",
+                         @"OtherClass1/test1",
+                         @"OtherClass2/test1",
+                         @"OtherClass2/test2",
+                         @"OtherNonmatching/test1",
                          ];
   NSString *error = nil;
   assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"All" senTestInvertScope:NO error:&error],
@@ -529,6 +533,10 @@ static int NumberOfEntries(NSArray *array, NSObject *target)
                      @"Cls2/test1",
                      @"Cls2/test2",
                      @"Cls3/test1",
+                     @"OtherClass1/test1",
+                     @"OtherClass2/test1",
+                     @"OtherClass2/test2",
+                     @"OtherNonmatching/test1",
                      ]));
   XCTAssertNil(error, @"Error shouldn't be set");
   assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"Cls1,Cls2/test1,Cls3" senTestInvertScope:NO error:&error],
@@ -543,7 +551,40 @@ static int NumberOfEntries(NSArray *array, NSObject *target)
   assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"Cls1,Cls2/test1,Cls3" senTestInvertScope:YES error:&error],
              equalTo(@[
                      @"Cls2/test2",
+                     @"OtherClass1/test1",
+                     @"OtherClass2/test1",
+                     @"OtherClass2/test2",
+                     @"OtherNonmatching/test1",
                      ]));
+  XCTAssertNil(error, @"Error shouldn't be set");
+  
+  // Prefix cases
+  assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"Other*" senTestInvertScope:NO error:&error],
+             equalTo(@[
+                       @"OtherClass1/test1",
+                       @"OtherClass2/test1",
+                       @"OtherClass2/test2",
+                       @"OtherNonmatching/test1"
+                       ]));
+  XCTAssertNil(error, @"Error shouldn't be set");
+
+  assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"Cls*" senTestInvertScope:NO error:&error],
+             equalTo(@[
+                       @"Cls1/test1",
+                       @"Cls1/test2",
+                       @"Cls1/test3",
+                       @"Cls2/test1",
+                       @"Cls2/test2",
+                       @"Cls3/test1"
+                       ]));
+  XCTAssertNil(error, @"Error shouldn't be set");
+
+  assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"OtherC*" senTestInvertScope:NO error:&error],
+             equalTo(@[
+                       @"OtherClass1/test1",
+                       @"OtherClass2/test1",
+                       @"OtherClass2/test2"
+                       ]));
   XCTAssertNil(error, @"Error shouldn't be set");
 }
 

--- a/xctool/xctool-tests/OCUnitTestRunnerTests.m
+++ b/xctool/xctool-tests/OCUnitTestRunnerTests.m
@@ -515,11 +515,15 @@ static int NumberOfEntries(NSArray *array, NSObject *target)
                          @"OtherClass1/test1",
                          @"OtherClass2/test1",
                          @"OtherClass2/test2",
-                         @"OtherNonmatching/test1",
+                         @"OtherNonmatching/testOne",
+                         @"OtherNonmatching/testThree",
+                         @"OtherNonmatching/testTwo",
                          ];
   NSString *error = nil;
   assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"All" senTestInvertScope:NO error:&error],
              equalTo(testCases));
+  assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"None" senTestInvertScope:NO error:&error],
+             equalTo(@[]));
   XCTAssertNil(error, @"Error shouldn't be set");
   assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"Cls1" senTestInvertScope:NO error:&error],
              equalTo(@[
@@ -536,7 +540,9 @@ static int NumberOfEntries(NSArray *array, NSObject *target)
                      @"OtherClass1/test1",
                      @"OtherClass2/test1",
                      @"OtherClass2/test2",
-                     @"OtherNonmatching/test1",
+                     @"OtherNonmatching/testOne",
+                     @"OtherNonmatching/testThree",
+                     @"OtherNonmatching/testTwo",
                      ]));
   XCTAssertNil(error, @"Error shouldn't be set");
   assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"Cls1,Cls2/test1,Cls3" senTestInvertScope:NO error:&error],
@@ -554,17 +560,21 @@ static int NumberOfEntries(NSArray *array, NSObject *target)
                      @"OtherClass1/test1",
                      @"OtherClass2/test1",
                      @"OtherClass2/test2",
-                     @"OtherNonmatching/test1",
+                     @"OtherNonmatching/testOne",
+                     @"OtherNonmatching/testThree",
+                     @"OtherNonmatching/testTwo",
                      ]));
   XCTAssertNil(error, @"Error shouldn't be set");
   
-  // Prefix cases
+  // Class prefix cases
   assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"Other*" senTestInvertScope:NO error:&error],
              equalTo(@[
                        @"OtherClass1/test1",
                        @"OtherClass2/test1",
                        @"OtherClass2/test2",
-                       @"OtherNonmatching/test1"
+                       @"OtherNonmatching/testOne",
+                       @"OtherNonmatching/testThree",
+                       @"OtherNonmatching/testTwo",
                        ]));
   XCTAssertNil(error, @"Error shouldn't be set");
 
@@ -584,6 +594,49 @@ static int NumberOfEntries(NSArray *array, NSObject *target)
                        @"OtherClass1/test1",
                        @"OtherClass2/test1",
                        @"OtherClass2/test2"
+                       ]));
+  XCTAssertNil(error, @"Error shouldn't be set");
+  
+  // Test prefix cases
+  assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"OtherClass1/test*" senTestInvertScope:NO error:&error],
+             equalTo(@[
+                       @"OtherClass1/test1",
+                       ]));
+  XCTAssertNil(error, @"Error shouldn't be set");
+
+  assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"OtherClass2/test*" senTestInvertScope:NO error:&error],
+             equalTo(@[
+                       @"OtherClass2/test1",
+                       @"OtherClass2/test2",
+                       ]));
+  XCTAssertNil(error, @"Error shouldn't be set");
+
+  assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"Cls1/t*" senTestInvertScope:NO error:&error],
+             equalTo(@[
+                       @"Cls1/test1",
+                       @"Cls1/test2",
+                       @"Cls1/test3",
+                       ]));
+  XCTAssertNil(error, @"Error shouldn't be set");
+  
+  assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"OtherNonmatching/*" senTestInvertScope:NO error:&error],
+             equalTo(@[
+                       @"OtherNonmatching/testOne",
+                       @"OtherNonmatching/testThree",
+                       @"OtherNonmatching/testTwo",
+                       ]));
+  XCTAssertNil(error, @"Error shouldn't be set");
+
+  assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"OtherNonmatching/testO*" senTestInvertScope:NO error:&error],
+             equalTo(@[
+                       @"OtherNonmatching/testOne",
+                       ]));
+  XCTAssertNil(error, @"Error shouldn't be set");
+
+  assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"OtherNonmatching/testT*" senTestInvertScope:NO error:&error],
+             equalTo(@[
+                       @"OtherNonmatching/testThree",
+                       @"OtherNonmatching/testTwo",
                        ]));
   XCTAssertNil(error, @"Error shouldn't be set");
 }

--- a/xctool/xctool/OCUnitTestRunner.h
+++ b/xctool/xctool/OCUnitTestRunner.h
@@ -43,7 +43,7 @@
  * Filters a list of test class names to only those that match the
  * senTestList and senTestInvertScope constraints.
  *
- * @param testCases An array of test cases ('ClassA/test1', 'ClassB/test2')
+ * @param testCases An array of test cases ('ClassA/test1', 'ClassB/test2', 'Class*', 'Class', 'ClassA/test*')
  * @param senTestList SenTestList string.  e.g. "All", "None", "ClsA,ClsB"
  * @param senTestInvertScope YES if scope should be inverted.
  */

--- a/xctool/xctool/OCUnitTestRunner.m
+++ b/xctool/xctool/OCUnitTestRunner.m
@@ -69,7 +69,16 @@
           matched = YES;
         }
       } else {
-        NSString *matchingPrefix = [specifier stringByAppendingString:@"/"];
+        NSString *matchingPrefix = nil;
+        if ([specifier length] > 0 &&
+            [specifier characterAtIndex:specifier.length-1] == '*') {
+          // Wild card prefix - remove * and do not append /
+          matchingPrefix = [specifier substringToIndex:specifier.length-1];
+        } else {
+          // Regular case - strict matching
+          matchingPrefix = [specifier stringByAppendingString:@"/"];
+        }
+        
         for (NSString *testCase in testCases) {
           if ([testCase hasPrefix:matchingPrefix]) {
             [matchingSet addObject:testCase];

--- a/xctool/xctool/OCUnitTestRunner.m
+++ b/xctool/xctool/OCUnitTestRunner.m
@@ -48,7 +48,7 @@
  *
  * @param specifier The string to check
  */
-+ (NSString*)wildcardPrefixFrom:(NSString*)specifier {
++ (NSString *)wildcardPrefixFrom:(NSString *)specifier {
   NSString *resultPrefix = nil;
   if ([specifier length] > 0 &&
       [specifier characterAtIndex:specifier.length-1] == '*') {

--- a/xctool/xctool/RunTestsAction.m
+++ b/xctool/xctool/RunTestsAction.m
@@ -122,7 +122,7 @@ NSArray *BucketizeTestCasesByTestClass(NSArray *testCases, int bucketSize)
     [Action actionOptionWithName:@"only"
                          aliases:nil
                      description:
-     @"SPEC is TARGET[:Class/case[,Class2/case2]], or TARGET:ClassPrefix*, or TARGET:Class/casePrefix*"
+     @"SPEC is TARGET[:Class/case[,Class2/case2]]; use * when specifying class or case prefix."
                        paramName:@"SPEC"
                            mapTo:@selector(addOnly:)],
     [Action actionOptionWithName:@"freshSimulator"

--- a/xctool/xctool/RunTestsAction.m
+++ b/xctool/xctool/RunTestsAction.m
@@ -121,7 +121,7 @@ NSArray *BucketizeTestCasesByTestClass(NSArray *testCases, int bucketSize)
                            mapTo:@selector(setTestSDK:)],
     [Action actionOptionWithName:@"only"
                          aliases:nil
-                     description:@"SPEC is TARGET[:Class/case[,Class2/case2]]"
+                     description:@"SPEC is TARGET[:Class/case[,Class2/case2]], or TEST:ClassPrefix*"
                        paramName:@"SPEC"
                            mapTo:@selector(addOnly:)],
     [Action actionOptionWithName:@"freshSimulator"

--- a/xctool/xctool/RunTestsAction.m
+++ b/xctool/xctool/RunTestsAction.m
@@ -121,7 +121,8 @@ NSArray *BucketizeTestCasesByTestClass(NSArray *testCases, int bucketSize)
                            mapTo:@selector(setTestSDK:)],
     [Action actionOptionWithName:@"only"
                          aliases:nil
-                     description:@"SPEC is TARGET[:Class/case[,Class2/case2]], or TEST:ClassPrefix*"
+                     description:
+     @"SPEC is TARGET[:Class/case[,Class2/case2]], or TARGET:ClassPrefix*, or TARGET:Class/casePrefix*"
                        paramName:@"SPEC"
                            mapTo:@selector(addOnly:)],
     [Action actionOptionWithName:@"freshSimulator"

--- a/xctool/xctool/TestAction.m
+++ b/xctool/xctool/TestAction.m
@@ -45,7 +45,8 @@
                            mapTo:@selector(setTestSDK:)],
     [Action actionOptionWithName:@"only"
                          aliases:nil
-                     description:@"SPEC is TARGET[:Class/case[,Class2/case2]], or TEST:ClassPrefix*"
+                     description:
+     @"SPEC is TARGET[:Class/case[,Class2/case2]], or TARGET:ClassPrefix*, or TARGET:Class/casePrefix*"
                        paramName:@"SPEC"
                            mapTo:@selector(addOnly:)],
     [Action actionOptionWithName:@"skip-deps"

--- a/xctool/xctool/TestAction.m
+++ b/xctool/xctool/TestAction.m
@@ -46,7 +46,7 @@
     [Action actionOptionWithName:@"only"
                          aliases:nil
                      description:
-     @"SPEC is TARGET[:Class/case[,Class2/case2]], or TARGET:ClassPrefix*, or TARGET:Class/casePrefix*"
+     @"SPEC is TARGET[:Class/case[,Class2/case2]]; use * when specifying class or case prefix."
                        paramName:@"SPEC"
                            mapTo:@selector(addOnly:)],
     [Action actionOptionWithName:@"skip-deps"

--- a/xctool/xctool/TestAction.m
+++ b/xctool/xctool/TestAction.m
@@ -45,7 +45,7 @@
                            mapTo:@selector(setTestSDK:)],
     [Action actionOptionWithName:@"only"
                          aliases:nil
-                     description:@"SPEC is TARGET[:Class/case[,Class2/case2]]"
+                     description:@"SPEC is TARGET[:Class/case[,Class2/case2]], or TEST:ClassPrefix*"
                        paramName:@"SPEC"
                            mapTo:@selector(addOnly:)],
     [Action actionOptionWithName:@"skip-deps"


### PR DESCRIPTION
In addition to specifying specific test classes with `only` argument, this change allows you to specify a class prefix, which is useful if you want to run a number of test classes that are logically connected, which share the same prefix.

For example if you have test cases
```
WesterosNorthTestClass
WesterosEastTestClass
WesterosSouthTestClass
```

instead of specifying the 3 classes explicitly, you can just do `-only SomeTarget:Westeros*`