### PR TITLE
Allow pretty reporting without overwrite when TTY not detected.

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,11 +318,11 @@ Started](http://about.travis-ci.org/docs/user/getting-started/) page.
 xctool has reporters that output build and test results in different
 formats.  If you do not specify any reporters yourself, xctool uses
 the `pretty` and `user-notifications` reporters by default.
-The `plain` reporter is used in place of the `pretty` reporter
-when xctool does not detect a TTY. This can be overridden by
-setting `XCTOOL_FORCE_TTY` in the environment. The `user-notifications`
-reporter will not be used if xctool detects that the build is 
-being run by Travis CI, i.e. `TRAVIS=true` in the environment.
+Overwrite is disabled on the `pretty` reporter when xctool does not
+detect a TTY. This can be overridden by setting `XCTOOL_FORCE_TTY` in
+the environment. The `user-notifications` reporter will not be used
+if xctool detects that the build is being run by Travis CI,
+i.e. `TRAVIS=true` in the environment.
 
 You can choose your own reporters with the `-reporter` option:
 

--- a/reporters/text/TextReporter.h
+++ b/reporters/text/TextReporter.h
@@ -38,5 +38,8 @@
 @interface PrettyTextReporter : TextReporter
 @end
 
+@interface NoOverwritePrettyTextReporter : TextReporter
+@end
+
 @interface PlainTextReporter : TextReporter
 @end

--- a/reporters/text/TextReporter.m
+++ b/reporters/text/TextReporter.m
@@ -45,6 +45,7 @@ static NSString *abbreviatePath(NSString *string) {
 @property (nonatomic, assign) NSInteger indent;
 @property (nonatomic, assign) NSInteger savedIndent;
 @property (nonatomic, assign) BOOL useColorOutput;
+@property (nonatomic, assign) BOOL useOverwrite;
 @property (nonatomic, strong) NSFileHandle *outputHandle;
 @property (nonatomic, copy) NSString *lastLineUpdate;
 
@@ -128,7 +129,7 @@ static NSString *abbreviatePath(NSString *string) {
 
 - (void)printNewline
 {
-  if (_lastLineUpdate != nil && !_useColorOutput) {
+  if (_lastLineUpdate != nil && !(_useColorOutput && _useOverwrite)) {
     [_outputHandle writeData:[_lastLineUpdate dataUsingEncoding:NSUTF8StringEncoding]];
     _lastLineUpdate = nil;
   }
@@ -139,7 +140,7 @@ static NSString *abbreviatePath(NSString *string) {
 {
   NSString *line = [self formattedStringWithFormat:format arguments:argList];;
 
-  if (_useColorOutput) {
+  if (_useColorOutput && _useOverwrite) {
     [_outputHandle writeData:[@"\r" dataUsingEncoding:NSUTF8StringEncoding]];
     [_outputHandle writeData:[line dataUsingEncoding:NSUTF8StringEncoding]];
   } else {
@@ -168,6 +169,7 @@ static NSString *abbreviatePath(NSString *string) {
 
 @interface TextReporter ()
 @property (nonatomic, assign) BOOL isPretty;
+@property (nonatomic, assign) BOOL canOverwrite;
 @property (nonatomic, strong) TestResultCounter *resultCounter;
 @property (nonatomic, copy) NSDictionary *currentStatusEvent;
 @property (nonatomic, copy) NSDictionary *currentBuildCommandEvent;
@@ -199,6 +201,7 @@ static NSString *abbreviatePath(NSString *string) {
 {
   _reportWriter = [[ReportWriter alloc] initWithOutputHandle:_outputHandle];
   _reportWriter.useColorOutput = _isPretty;
+  _reportWriter.useOverwrite = _canOverwrite;
 }
 
 - (void)didFinishReporting
@@ -912,6 +915,19 @@ static NSString *abbreviatePath(NSString *string) {
 @end
 
 @implementation PrettyTextReporter
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    self.isPretty = YES;
+    self.canOverwrite = YES;
+  }
+  return self;
+}
+
+@end
+
+@implementation NoOverwritePrettyTextReporter
 
 - (instancetype)init
 {

--- a/reporters/text/main.m
+++ b/reporters/text/main.m
@@ -27,7 +27,7 @@ int main(int argc, const char * argv[])
       if (isatty(STDOUT_FILENO) || NSProcessInfo.processInfo.environment[@"XCTOOL_FORCE_TTY"]) {
         cls = [PrettyTextReporter class];
       } else {
-        cls = [PlainTextReporter class];
+        cls = [NoOverwritePrettyTextReporter class];
       }
     } else {
       cls = [PlainTextReporter class];


### PR DESCRIPTION
This implements #512. I'm not sure if this is how you would like the
feature implemented, happy to iterate.