### PR TITLE
Add an omit option for tests

### DIFF
--- a/xctool/xctool-tests/BuildTestsActionTests.m
+++ b/xctool/xctool-tests/BuildTestsActionTests.m
@@ -48,6 +48,23 @@ static NSString *kTestWorkspaceTestProjectOtherLibTargetID      = @"28ADB45F16E4
   [super setUp];
 }
 
+- (void)testOnlyListAndOmitListCannotBothBeSpecified
+{
+  [[Options optionsFrom:@[
+    @"-project", TEST_DATA @"TestProject-Library/TestProject-Library.xcodeproj",
+    @"-scheme", @"TestProject-Library",
+    @"-sdk", @"iphonesimulator6.1",
+    @"build-tests",
+    @"-only", @"TestProject-LibraryTests",
+    @"-omit", @"TestProject-LibraryTests",
+    ]]
+   assertOptionsFailToValidateWithError:
+   @"build-tests: -only and -omit cannot both be specified."
+   withBuildSettingsFromFile:
+   TEST_DATA @"TestProject-Library-TestProject-Library-showBuildSettings.txt"
+   ];
+}
+
 - (void)testOnlyListIsCollected
 {
   Options *options = [[Options optionsFrom:@[
@@ -62,6 +79,19 @@ static NSString *kTestWorkspaceTestProjectOtherLibTargetID      = @"28ADB45F16E4
   assertThat((action.onlyList), equalTo(@[@"TestProject-LibraryTests"]));
 }
 
+- (void)testOmitListIsCollected
+{
+  Options *options = [[Options optionsFrom:@[
+                       @"-project", TEST_DATA @"TestProject-Library/TestProject-Library.xcodeproj",
+                       @"-scheme", @"TestProject-Library",
+                       @"-sdk", @"iphonesimulator6.1",
+                       @"build-tests", @"-omit", @"TestProject-LibraryTests",
+                       ]] assertOptionsValidateWithBuildSettingsFromFile:
+                      TEST_DATA @"TestProject-Library-TestProject-Library-showBuildSettings.txt"
+                      ];
+  BuildTestsAction *action = options.actions[0];
+  assertThat((action.omitList), equalTo(@[@"TestProject-LibraryTests"]));
+}
 
 - (void)testSkipDependenciesIsCollected
 {

--- a/xctool/xctool-tests/RunTestsActionTests.m
+++ b/xctool/xctool-tests/RunTestsActionTests.m
@@ -84,6 +84,23 @@ static BOOL areEqualJsonOutputsIgnoringKeys(NSString *output1, NSString *output2
   assertThat((action.testSDK), equalTo(@"iphonesimulator6.0"));
 }
 
+- (void)testOnlyListAndOmitListCannotBothBeSpecified
+{
+  [[Options optionsFrom:@[
+    @"-project", TEST_DATA @"TestProject-Library/TestProject-Library.xcodeproj",
+    @"-scheme", @"TestProject-Library",
+    @"-sdk", @"iphonesimulator6.1",
+    @"run-tests",
+    @"-only", @"TestProject-LibraryTests",
+    @"-omit", @"TestProject-LibraryTests",
+    ]]
+   assertOptionsFailToValidateWithError:
+   @"run-tests: -only and -omit cannot both be specified."
+   withBuildSettingsFromFile:
+   TEST_DATA @"TestProject-Library-TestProject-Library-showBuildSettings.txt"
+   ];
+}
+
 - (void)testOnlyListIsCollected
 {
   Options *options = [[Options optionsFrom:@[
@@ -96,6 +113,20 @@ static BOOL areEqualJsonOutputsIgnoringKeys(NSString *output1, NSString *output2
                       ];
   RunTestsAction *action = options.actions[0];
   assertThat((action.onlyList), equalTo(@[@"TestProject-LibraryTests"]));
+}
+
+- (void)testOmitListIsCollected
+{
+  Options *options = [[Options optionsFrom:@[
+                       @"-project", TEST_DATA @"TestProject-Library/TestProject-Library.xcodeproj",
+                       @"-scheme", @"TestProject-Library",
+                       @"-sdk", @"iphonesimulator6.1",
+                       @"run-tests", @"-omit", @"TestProject-LibraryTests",
+                       ]] assertOptionsValidateWithBuildSettingsFromFile:
+                      TEST_DATA @"TestProject-Library-TestProject-Library-showBuildSettings.txt"
+                      ];
+  RunTestsAction *action = options.actions[0];
+  assertThat((action.omitList), equalTo(@[@"TestProject-LibraryTests"]));
 }
 
 - (void)testOnlyListRequiresValidTarget
@@ -529,7 +560,7 @@ static BOOL areEqualJsonOutputsIgnoringKeys(NSString *output1, NSString *output2
   }];
 }
 
-- (void)testCanSelectSpecificTestClassOrTestMethodWithOnly
+- (void)testCanSelectSpecificTestClassOrTestMethodsWithOnlyAndOmit
 {
   if (ToolchainIsXcode7OrBetter()) {
     // octest isn't supported in Xcode 7
@@ -545,7 +576,7 @@ static BOOL areEqualJsonOutputsIgnoringKeys(NSString *output1, NSString *output2
                         @"SomeTests/testWillFail",
                         @"SomeTests/testWillPass"];
 
-  void (^runWithOnlyArgumentAndExpectSenTestToBe)(NSString *, NSString *) = ^(NSString *onlyArgument, NSString *expectedSenTest) {
+  void (^runWithArguments)(NSString *, NSArray *, BOOL) = ^(NSString *argument, NSArray *values, BOOL skipTarget) {
     [[FakeTaskManager sharedManager] runBlockWithFakeTasks:^{
       [[FakeTaskManager sharedManager] addLaunchHandlerBlocks:@[
         // Make sure -showBuildSettings returns some data
@@ -570,58 +601,62 @@ static BOOL areEqualJsonOutputsIgnoringKeys(NSString *output1, NSString *output2
                                                                 ]];
 
       XCTool *tool = [[XCTool alloc] init];
-
-      tool.arguments = @[@"-project", TEST_DATA @"TestProject-Library/TestProject-Library.xcodeproj",
-                         @"-scheme", @"TestProject-Library",
-                         @"-configuration", @"Debug",
-                         @"-sdk", @"iphonesimulator6.0",
-                         @"-destination", @"arch=i386",
-                         @"run-tests", @"-only", onlyArgument,
-                         @"-reporter", @"plain",
-                         ];
+      NSMutableArray *args = [@[@"-project", TEST_DATA @"TestProject-Library/TestProject-Library.xcodeproj",
+                                @"-scheme", @"TestProject-Library",
+                                @"-configuration", @"Debug",
+                                @"-sdk", @"iphonesimulator6.0",
+                                @"-destination", @"arch=i386",
+                                @"run-tests"] mutableCopy];
+      for (NSString *value in values) {
+        [args addObject:argument];
+        [args addObject:value];
+      }
+      [args addObjectsFromArray:@[@"-reporter", @"plain"]];
+      tool.arguments = args;
 
       [TestUtil runWithFakeStreams:tool];
 
       NSArray *launchedTasks = [[FakeTaskManager sharedManager] launchedTasks];
-      assertThatInteger([launchedTasks count], equalToInteger(2));
-      NSArray *arguments = [launchedTasks[1] arguments];
-      assertThat(arguments, containsArray(@[
-        @"-NSTreatUnknownArgumentsAsOpen", @"NO",
-        @"-ApplePersistenceIgnoreState", @"YES",
-        @"-SenTestInvertScope", @"YES"]));
-      assertThat(arguments, containsArray(@[@"-OTEST_TESTLIST_FILE"]));
-      assertThat(arguments, containsArray(@[
-        @"-OTEST_FILTER_TEST_ARGS_KEY", @"SenTest",
-        @"-SenTest", @"XCTOOL_FAKE_LIST_OF_TESTS",
-      ]));
-
-      assertThat(arguments, containsArray(@[
-        @"/Users/nekto/Library/Developer/Xcode/DerivedData/TestProject-Library-frruszglismbfoceinskphldzhci/Build/Products/Debug-iphonesimulator/TestProject-LibraryTests.octest",
-      ]));
+      if (skipTarget) {
+        assertThatInteger([launchedTasks count], equalToInteger(0));
+      } else {
+        assertThatInteger([launchedTasks count], equalToInteger(2));
+        NSArray *arguments = [launchedTasks[1] arguments];
+        assertThat(arguments, containsArray(@[
+                                              @"-NSTreatUnknownArgumentsAsOpen", @"NO",
+                                              @"-ApplePersistenceIgnoreState", @"YES",
+                                              @"-SenTestInvertScope", @"YES"]));
+        assertThat(arguments, containsArray(@[@"-OTEST_TESTLIST_FILE"]));
+        assertThat(arguments, containsArray(@[
+                                              @"-OTEST_FILTER_TEST_ARGS_KEY", @"SenTest",
+                                              @"-SenTest", @"XCTOOL_FAKE_LIST_OF_TESTS",
+                                              ]));
+        
+        assertThat(arguments, containsArray(@[
+                                              @"/Users/nekto/Library/Developer/Xcode/DerivedData/TestProject-Library-frruszglismbfoceinskphldzhci/Build/Products/Debug-iphonesimulator/TestProject-LibraryTests.octest",
+                                              ]));
+      }
     }];
   };
 
-  runWithOnlyArgumentAndExpectSenTestToBe(@"TestProject-LibraryTests:SomeTests/testOutputMerging",
-                                          @"OtherTests/testSomething,"
-                                          @"SomeTests/testBacktraceOutputIsCaptured,"
-                                          @"SomeTests/testPrintSDK,"
-                                          @"SomeTests/testStream,"
-                                          @"SomeTests/testWillFail,"
-                                          @"SomeTests/testWillPass");
-  runWithOnlyArgumentAndExpectSenTestToBe(@"TestProject-LibraryTests:SomeTests/testWillPass",
-                                          @"OtherTests/testSomething,"
-                                          @"SomeTests/testBacktraceOutputIsCaptured,"
-                                          @"SomeTests/testOutputMerging,"
-                                          @"SomeTests/testPrintSDK,"
-                                          @"SomeTests/testStream,"
-                                          @"SomeTests/testWillFail");
-  runWithOnlyArgumentAndExpectSenTestToBe(@"TestProject-LibraryTests:SomeTests/testWillPass,OtherTests/testSomething",
-                                          // The ordering will be alphabetized.
-                                          @"SomeTests/testBacktraceOutputIsCaptured,"
-                                          @"SomeTests/testOutputMerging,"
-                                          @"SomeTests/testPrintSDK,"
-                                          @"SomeTests/testStream,"
-                                          @"SomeTests/testWillFail");
+  runWithArguments(@"-only", @[@"TestProject-LibraryTests:SomeTests/testOutputMerging"], NO);
+  runWithArguments(@"-only", @[@"TestProject-LibraryTests:SomeTests/testWillPass"], NO);
+  runWithArguments(@"-only", @[@"TestProject-LibraryTests:SomeTests/testWillPass,OtherTests/testSomething"], NO);
+  runWithArguments(@"-only", @[@"TestProject-LibraryTests:SomeTests/testWillPass",
+                               @"TestProject-LibraryTests:SomeTests/testWillFail"], NO);
+  runWithArguments(@"-only", @[@"TestProject-LibraryTests",
+                               @"TestProject-LibraryTests:SomeTests/testWillFail"], NO);
+  runWithArguments(@"-only", @[@"TestProject-LibraryTests:SomeTests/testWillPass",
+                               @"TestProject-LibraryTests"], NO);
+  runWithArguments(@"-omit", @[@"TestProject-LibraryTests:SomeTests/testOutputMerging"], NO);
+  runWithArguments(@"-omit", @[@"TestProject-LibraryTests:SomeTests/testWillPass"], NO);
+  runWithArguments(@"-omit", @[@"TestProject-LibraryTests:SomeTests/testWillPass,OtherTests/testSomething"], NO);
+  runWithArguments(@"-omit", @[@"TestProject-LibraryTests:SomeTests/testWillPass",
+                               @"TestProject-LibraryTests:SomeTests/testWillFail,SomeTests/testOutputMerging"], NO);
+  runWithArguments(@"-omit", @[@"TestProject-LibraryTests",
+                               @"TestProject-LibraryTests:SomeTests/testWillFail,SomeTests/testOutputMerging"], YES);
+  runWithArguments(@"-omit", @[@"TestProject-LibraryTests:SomeTests/testWillPass",
+                               @"TestProject-LibraryTests"], YES);
 }
 
 /**

--- a/xctool/xctool-tests/TestActionTests.m
+++ b/xctool/xctool-tests/TestActionTests.m
@@ -54,6 +54,20 @@
   assertThat(([action onlyList]), equalTo(@[@"TestProject-LibraryTests"]));
 }
 
+- (void)testOmitListIsCollected
+{
+  Options *options = [[Options optionsFrom:@[
+                       @"-project", TEST_DATA @"TestProject-Library/TestProject-Library.xcodeproj",
+                       @"-scheme", @"TestProject-Library",
+                       @"-sdk", @"iphonesimulator6.1",
+                       @"test", @"-omit", @"TestProject-LibraryTests",
+                       ]] assertOptionsValidateWithBuildSettingsFromFile:
+                      TEST_DATA @"TestProject-Library-TestProject-Library-showBuildSettings.txt"
+                      ];
+  TestAction *action = options.actions[0];
+  assertThat(([action omitList]), equalTo(@[@"TestProject-LibraryTests"]));
+}
+
 - (void)testOnlyListRequiresValidTarget
 {
   [[Options optionsFrom:@[
@@ -95,6 +109,19 @@
                       ];
   assertThat([options.actions[0] buildTestsAction].onlyList, equalTo(@[@"TestProject-LibraryTests"]));
   assertThat([options.actions[0] runTestsAction].onlyList, equalTo(@[@"TestProject-LibraryTests:ClassName/methodName"]));
+}
+
+- (void)testOmitParsing
+{
+  Options *options = [[Options optionsFrom:@[
+                       @"-project", TEST_DATA @"TestProject-Library/TestProject-Library.xcodeproj",
+                       @"-scheme", @"TestProject-Library",
+                       @"test", @"-omit", @"TestProject-LibraryTests:ClassName/methodName"
+                       ]] assertOptionsValidateWithBuildSettingsFromFile:
+                      TEST_DATA @"TestProject-Library-TestProject-Library-showBuildSettings.txt"
+                      ];
+  assertThat([options.actions[0] buildTestsAction].omitList, equalTo(@[@"TestProject-LibraryTests"]));
+  assertThat([options.actions[0] runTestsAction].omitList, equalTo(@[@"TestProject-LibraryTests:ClassName/methodName"]));
 }
 
 @end

--- a/xctool/xctool/BuildTestsAction.h
+++ b/xctool/xctool/BuildTestsAction.h
@@ -19,6 +19,7 @@
 @interface BuildTestsAction : Action
 
 @property (nonatomic, strong) NSMutableArray *onlyList;
+@property (nonatomic, strong) NSMutableArray *omitList;
 @property (nonatomic, assign) BOOL skipDependencies;
 
 + (BOOL)buildWorkspace:(NSString *)path

--- a/xctool/xctool/RunTestsAction.h
+++ b/xctool/xctool/RunTestsAction.h
@@ -60,6 +60,7 @@ typedef NS_ENUM(NSInteger, BucketBy) {
 @property (nonatomic, assign) BOOL listTestsOnly;
 @property (nonatomic, copy) NSString *testSDK;
 @property (nonatomic, strong) NSMutableArray *onlyList;
+@property (nonatomic, strong) NSMutableArray *omitList;
 @property (nonatomic, strong) NSMutableArray *logicTests;
 @property (nonatomic, strong) NSMutableDictionary *appTests;
 @property (nonatomic, copy) NSString *targetedDeviceFamily;

--- a/xctool/xctool/TestAction.m
+++ b/xctool/xctool/TestAction.m
@@ -49,6 +49,12 @@
      @"SPEC is TARGET[:Class/case[,Class2/case2]]; use * when specifying class or case prefix."
                        paramName:@"SPEC"
                            mapTo:@selector(addOnly:)],
+    [Action actionOptionWithName:@"omit"
+                         aliases:nil
+                     description:
+     @"SPEC is TARGET[:Class/case[,Class2/case2]]; use * when specifying class or case prefix."
+                       paramName:@"SPEC"
+                           mapTo:@selector(addOmit:)],
     [Action actionOptionWithName:@"skip-deps"
                          aliases:nil
                      description:@"Only build the target, not its dependencies"
@@ -181,9 +187,22 @@
   [_runTestsAction.onlyList addObject:argument];
 }
 
+- (void)addOmit:(NSString *)argument
+{
+  // build-tests takes only a target argument, where run-tests takes Target:Class/method.
+  NSString *buildTestsOmitArg = [argument componentsSeparatedByString:@":"][0];
+  [_buildTestsAction.omitList addObject:buildTestsOmitArg];
+  [_runTestsAction.omitList addObject:argument];
+}
+
 - (NSArray *)onlyList
 {
   return _buildTestsAction.onlyList;
+}
+
+- (NSArray *)omitList
+{
+  return _buildTestsAction.omitList;
 }
 
 - (BOOL)skipDependencies

--- a/xctool/xctool/TestActionInternal.h
+++ b/xctool/xctool/TestActionInternal.h
@@ -21,6 +21,7 @@
 @interface TestAction (Internal)
 
 - (NSArray *)onlyList;
+- (NSArray *)omitList;
 - (BuildTestsAction *)buildTestsAction;
 - (RunTestsAction *)runTestsAction;
 - (BOOL)skipDependencies;


### PR DESCRIPTION
Add a command line option to omit particular tests using the same format as the -only flag.  Add omitted targets/tests to the skipped targets/tests from the scheme.

In "testCanSelectSpecificTestClassOrTestMethodWithOnly", "runWithOnlyArgumentAndExpectSenTestToBe" was taking in a list of expected tests, but it was doing absolutely nothing with them.  So, stop sending them in since they're ignored anyway.

Generalize "onlyListAsTargetsAndSenTestList" and make it return a dictionary rather than an array of key value pairs so that we can query whether a given target is in it or not easily. 