### PR TITLE
Fix a few BUCK build issues

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -1,4 +1,4 @@
-COMMON_PREPROCESSOR_FLAGS = ['-fobjc-arc', '-mmacosx-version-min=10.7']
+COMMON_PREPROCESSOR_FLAGS = ['-fobjc-arc', '-mmacosx-version-min=10.7', '-Wno-deprecated-declarations']
 
 COMMON_OTEST_SRCS = [
     'Common/DuplicateTestNameFix.m',

--- a/xctool/xctool/XCToolUtil.m
+++ b/xctool/xctool/XCToolUtil.m
@@ -19,6 +19,7 @@
 #import <CommonCrypto/CommonDigest.h>
 
 #import <mach-o/dyld.h>
+#import <limits.h>
 
 #import "EventGenerator.h"
 #import "EventSink.h"
@@ -340,7 +341,7 @@ BOOL LaunchXcodebuildTaskAndFeedEventsToReporters(NSTask *task,
                                                   long long *errorCodeOut)
 {
   __block NSString *errorMessage = nil;
-  __block long long errorCode = LONG_LONG_MIN;
+  __block long long errorCode = LLONG_MIN;
   __block BOOL hadFailingBuildCommand = NO;
 
   LaunchTaskAndFeedOuputLinesToBlock(task,


### PR DESCRIPTION
This fixes the following build issues when building from Buck:

```
third-party/ios/xctool/xctool/xctool/SimulatorWrapper/SimulatorUtils.m:33:31: warning: 'launch_data_alloc' is deprecated: first deprecated in OS X 10.10 [-Wdeprecated-declarations]
  launch_data_t stopMessage = launch_data_alloc(LAUNCH_DATA_DICTIONARY);
```

and

```
third-party/ios/xctool/xctool/xctool/XCToolUtil.m:355:60: error: use of undeclared identifier 'LONG_LONG_MIN'
  __attribute__((__blocks__(byref))) long long errorCode = LONG_LONG_MIN;
```