### PR TITLE
Remove explicit deps from genrules.

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -314,23 +314,6 @@ genrule(
 
 genrule(
     name = 'xctool-zip',
-    deps = [
-      ':json-compilation-database#macosx-x86_64',
-      ':json-stream#macosx-x86_64',
-      ':junit#macosx-x86_64',
-      ':otest-query-ios',
-      ':otest-query-lib-ios',
-      ':otest-query-lib-osx',
-      ':otest-query-osx',
-      ':otest-shim-ios',
-      ':otest-shim-osx',
-      ':phabricator#macosx-x86_64',
-      ':plain#macosx-x86_64',
-      ':pretty#macosx-x86_64',
-      ':teamcity#macosx-x86_64',
-      ':user-notifications#macosx-x86_64',
-      ':xctool-bin#macosx-x86_64',
-    ],
     srcs = [
         'scripts/create_xctool_zip.sh',
     ],
@@ -363,16 +346,6 @@ genrule(
 # Minimal xctool only includes the json-stream reporter
 genrule(
     name = 'xctool-minimal-zip',
-    deps = [
-      ':json-stream#macosx-x86_64',
-      ':otest-query-ios',
-      ':otest-query-lib-ios',
-      ':otest-query-lib-osx',
-      ':otest-query-osx',
-      ':otest-shim-ios',
-      ':otest-shim-osx',
-      ':xctool-bin#macosx-x86_64',
-    ],
     srcs = [
         'scripts/create_xctool_zip.sh',
     ],


### PR DESCRIPTION
Genrules infer dependencies referenced in the command via macros automatically.