### PR TITLE
Fix the Buck build.

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -53,14 +53,18 @@ apple_binary(
     ]),
     linker_flags = [
         '-F$DEVELOPER_DIR/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks',
+        '-F$DEVELOPER_DIR/Platforms/MacOSX.platform/Developer/Library/Frameworks',
         '-F$DEVELOPER_DIR/../SharedFrameworks',
         '-F$DEVELOPER_DIR/Library/PrivateFrameworks',
+        '-F$DEVELOPER_DIR/Library/MigrationFrameworks',
         '-weak_framework',
         'DVTFoundation',
         '-weak_framework',
         'DVTiPhoneSimulatorRemoteClient',
         '-weak_framework',
         'CoreSimulator',
+        '-weak_framework',
+        'XCTest',
     ],
     preprocessor_flags = COMMON_PREPROCESSOR_FLAGS + [
         '-DXCODE_VERSION=0630',


### PR DESCRIPTION
The `BUCK` file doesn't link in XCTest, so when running xctool built by Buck you get:

```
2015-09-14 20:15:22.715 xctool[89573:7208158] *** Assertion failure in -[OCUnitIOSAppTestRunner testEnvironmentWithSpecifiedTestConfiguration], third-party/ios/xctool/xctool/xctool/OCUnitTestRunner.m:333
2015-09-14 20:15:22.787 xctool[89573:7208158] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'XCTestConfiguration isn't available'
```