### PR TITLE
Add option for not reseting the simulator on failure

### DIFF
--- a/xctool/xctool-tests/OCUnitTestRunnerTests.m
+++ b/xctool/xctool-tests/OCUnitTestRunnerTests.m
@@ -55,6 +55,7 @@ static id TestRunnerWithTestLists(Class cls, NSDictionary *settings, NSArray *fo
                                 environment:environment
                              freshSimulator:NO
                              resetSimulator:NO
+                  noResetSimulatorOnFailure:NO
                                freshInstall:NO
                                 testTimeout:30
                                   reporters:@[eventBuffer]];

--- a/xctool/xctool-tests/OTestShimTests.m
+++ b/xctool/xctool-tests/OTestShimTests.m
@@ -117,6 +117,7 @@ static NSTask *OtestShimTask(NSString *platformName,
                                                                         environment:@{}
                                                                      freshSimulator:NO
                                                                      resetSimulator:NO
+                                                          noResetSimulatorOnFailure:NO
                                                                        freshInstall:NO
                                                                         testTimeout:1
                                                                           reporters:@[]];

--- a/xctool/xctool/OCUnitIOSAppTestRunner.m
+++ b/xctool/xctool/OCUnitIOSAppTestRunner.m
@@ -183,7 +183,7 @@ static const NSInteger kMaxRunTestsAttempts = 3;
 
     // we will reset iOS simulator contents and settings now if it is not done in `prepTestEnv`
     if (!_resetSimulator) {
-      prepareSimulator(YES, YES);
+      prepareSimulator(YES, !_noResetSimulatorOnFailure);
     }
 
     // Sometimes, the test host app installation retries are starting and

--- a/xctool/xctool/OCUnitTestRunner.h
+++ b/xctool/xctool/OCUnitTestRunner.h
@@ -31,6 +31,7 @@
   BOOL _garbageCollection;
   BOOL _freshSimulator;
   BOOL _resetSimulator;
+  BOOL _noResetSimulatorOnFailure;
   BOOL _freshInstall;
   NSInteger _testTimeout;
   NSArray *_reporters;
@@ -60,6 +61,7 @@
                           environment:(NSDictionary *)environment
                        freshSimulator:(BOOL)freshSimulator
                        resetSimulator:(BOOL)resetSimulator
+            noResetSimulatorOnFailure:(BOOL)noResetSimulatorOnFailure
                          freshInstall:(BOOL)freshInstall
                           testTimeout:(NSInteger)testTimeout
                             reporters:(NSArray *)reporters;

--- a/xctool/xctool/OCUnitTestRunner.m
+++ b/xctool/xctool/OCUnitTestRunner.m
@@ -34,6 +34,7 @@
 @property (nonatomic, assign) BOOL garbageCollection;
 @property (nonatomic, assign) BOOL freshSimulator;
 @property (nonatomic, assign) BOOL resetSimulator;
+@property (nonatomic, assign) BOOL noResetSimulatorOnFailure;
 @property (nonatomic, assign) BOOL freshInstall;
 @property (nonatomic, copy, readwrite) NSArray *reporters;
 @property (nonatomic, copy) NSDictionary *framework;
@@ -135,6 +136,7 @@
                           environment:(NSDictionary *)environment
                        freshSimulator:(BOOL)freshSimulator
                        resetSimulator:(BOOL)resetSimulator
+            noResetSimulatorOnFailure:(BOOL)noResetSimulatorOnFailure
                          freshInstall:(BOOL)freshInstall
                           testTimeout:(NSInteger)testTimeout
                             reporters:(NSArray *)reporters
@@ -149,6 +151,7 @@
     _environment = [environment copy];
     _freshSimulator = freshSimulator;
     _resetSimulator = resetSimulator;
+    _noResetSimulatorOnFailure = noResetSimulatorOnFailure;
     _freshInstall = freshInstall;
     _testTimeout = testTimeout;
     _reporters = [reporters copy];

--- a/xctool/xctool/RunTestsAction.h
+++ b/xctool/xctool/RunTestsAction.h
@@ -54,6 +54,7 @@ typedef NS_ENUM(NSInteger, BucketBy) {
 
 @property (nonatomic, assign) BOOL freshSimulator;
 @property (nonatomic, assign) BOOL resetSimulator;
+@property (nonatomic, assign) BOOL noResetSimulatorOnFailure;
 @property (nonatomic, assign) BOOL freshInstall;
 @property (nonatomic, assign) BOOL parallelize;
 @property (nonatomic, assign) BOOL failOnEmptyTestBundles;

--- a/xctool/xctool/RunTestsAction.m
+++ b/xctool/xctool/RunTestsAction.m
@@ -141,6 +141,11 @@ NSArray *BucketizeTestCasesByTestClass(NSArray *testCases, int bucketSize)
                      description:
      @"Reset simulator content and settings and restart it before running every app test run."
                          setFlag:@selector(setResetSimulator:)],
+    [Action actionOptionWithName:@"noResetSimulatorOnFailure"
+                         aliases:nil
+                     description:
+     @"Do not reset simulator content and settings if running failed."
+                         setFlag:@selector(setNoResetSimulatorOnFailure:)],
     [Action actionOptionWithName:@"freshInstall"
                          aliases:nil
                      description:
@@ -668,6 +673,7 @@ typedef BOOL (^TestableBlock)(NSArray *reporters);
                                                                       environment:environment
                                                                    freshSimulator:_freshSimulator
                                                                    resetSimulator:_resetSimulator
+                                                        noResetSimulatorOnFailure:_noResetSimulatorOnFailure
                                                                      freshInstall:_freshInstall
                                                                       testTimeout:_testTimeout
                                                                         reporters:reporters];

--- a/xctool/xctool/TestAction.m
+++ b/xctool/xctool/TestAction.m
@@ -69,6 +69,11 @@
                      description:
      @"Reset simulator content and settings and restart it before running every app test run."
                          setFlag:@selector(setResetSimulator:)],
+    [Action actionOptionWithName:@"noResetSimulatorOnFailure"
+                         aliases:nil
+                     description:
+     @"Do not reset simulator content and settings if running failed."
+                         setFlag:@selector(setNoResetSimulatorOnFailure:)],
     [Action actionOptionWithName:@"freshInstall"
                          aliases:nil
                      description:
@@ -132,6 +137,11 @@
 - (void)setResetSimulator:(BOOL)resetSimulator
 {
   [_runTestsAction setResetSimulator:resetSimulator];
+}
+
+- (void)setNoResetSimulatorOnFailure:(BOOL)noResetSimulatorOnFailure
+{
+  [_runTestsAction setNoResetSimulatorOnFailure:noResetSimulatorOnFailure];
 }
 
 - (void)setFreshInstall:(BOOL)freshInstall


### PR DESCRIPTION
I added a option for disabling the reseting of the simulator if the install failed 3 times.