### PR TITLE
disable xctest symbolication in xcode7 because it sometimes hangs

### DIFF
--- a/otest-shim/otest-shim/otest-shim.m
+++ b/otest-shim/otest-shim/otest-shim.m
@@ -427,6 +427,12 @@ static void XCTestCase_performTest(id self, SEL sel, id arg1)
   XCPerformTestWithSuppressedExpectedAssertionFailures(self, originalSelector, arg1);
 }
 
+#pragma mark - _enableSymbolication
+static BOOL XCTestCase__enableSymbolication(id self, SEL sel)
+{
+  return NO;
+}
+
 #pragma mark - Test Scope
 
 static NSString * SenTestProbe_testScope(Class cls, SEL cmd)
@@ -690,6 +696,12 @@ static const char *DyldImageStateChangeHandler(enum dyld_image_states state,
       XTSwizzleSelectorForFunction(NSClassFromString(@"XCTestCase"),
                                    @selector(performTest:),
                                    (IMP)XCTestCase_performTest);
+      if ([NSClassFromString(@"XCTestCase") respondsToSelector:@selector(_enableSymbolication)]) {
+        // Disable symbolication thing on xctest 7 because it sometimes takes forever.
+        XTSwizzleClassSelectorForFunction(NSClassFromString(@"XCTestCase"),
+                                          @selector(_enableSymbolication),
+                                          (IMP)XCTestCase__enableSymbolication);
+      }
       NSDictionary *frameworkInfo = FrameworkInfoForExtension(@"xctest");
       ApplyDuplicateTestNameFix([frameworkInfo objectForKey:kTestingFrameworkTestProbeClassName],
                                 [frameworkInfo objectForKey:kTestingFrameworkTestSuiteClassName]);


### PR DESCRIPTION
This disables some sort of symbolication feature new in xctest in xcode7. This feature hangs nondeterministically when a test throws an objc exception:

```
0   libsystem_platform.dylib      	0x030e0500 _platform_memcmp + 48
1   com.apple.CoreSymbolication   	0x25cbc703 0x25c8a000 + 206595
2   com.apple.CoreSymbolication   	0x25ca1951 0x25c8a000 + 96593
3   com.apple.CoreSymbolication   	0x25c93725 0x25c8a000 + 38693
4   com.apple.CoreSymbolication   	0x25cbb2c1 0x25c8a000 + 201409
5   com.apple.CoreSymbolication   	0x25cba12b 0x25c8a000 + 196907
6   com.apple.CoreSymbolication   	0x25cbaa06 0x25c8a000 + 199174
7   com.apple.CoreSymbolication   	0x25ca175f CSSymbolicatorCreateWithPathArchitectureFlagsAndNotification + 233
8   com.apple.CoreSymbolication   	0x25ca8772 0x25c8a000 + 124786
9   com.apple.CoreSymbolication   	0x25ca84e0 0x25c8a000 + 124128
10  com.apple.CoreSymbolication   	0x25cc3c81 0x25c8a000 + 236673
11  com.apple.CoreSymbolication   	0x25ca703f 0x25c8a000 + 118847
12  com.apple.CoreSymbolication   	0x25c90730 0x25c8a000 + 26416
13  com.apple.CoreSymbolication   	0x25c903f8 0x25c8a000 + 25592
14  com.apple.CoreSymbolication   	0x25c8fd35 0x25c8a000 + 23861
15  com.apple.CoreSymbolication   	0x25c8fcc6 0x25c8a000 + 23750
16  com.apple.CoreSymbolication   	0x25c9aa29 CSSymbolicatorGetSymbolWithAddressAtTime + 93
17  com.apple.dt.XCTest           	0x00172088 +[XCSymbolicationRecord _symbolicationRecordForSymbolicator:address:] + 92
18  com.apple.dt.XCTest           	0x00172451 +[XCSymbolicationRecord symbolicationRecordForTask:address:] + 389
19  com.apple.dt.XCTest           	0x001722c5 +[XCSymbolicationRecord symbolicationRecordForAddress:] + 61
20  com.apple.dt.XCTest           	0x0014949d -[XCTestCase _symbolicationRecordForTestCodeInAddressStack:] + 844
21  com.apple.dt.XCTest           	0x0014741a -[XCTestCase performTest:] + 1016
22  otest-shim-ios.dylib          	0x00116842 XCPerformTestWithSuppressedExpectedAssertionFailures + 584 (otest-shim.m:405)
23  otest-shim-ios.dylib          	0x00115e40 XCTestCase_performTest + 31 (otest-shim.m:428)
```