### PR TITLE
Add support for -dry-run option

### DIFF
--- a/xctool/xctool-tests/BuildActionTests.m
+++ b/xctool/xctool-tests/BuildActionTests.m
@@ -263,4 +263,37 @@ void _CFAutoreleasePoolPrintPools();
   }];
 }
 
+
+- (void)testDryRunOptionSetsFlag
+{
+  [[FakeTaskManager sharedManager] runBlockWithFakeTasks:^{
+    [[FakeTaskManager sharedManager] addLaunchHandlerBlocks:@[
+     // Make sure -showBuildSettings returns some data
+     [LaunchHandlers handlerForShowBuildSettingsWithWorkspace:TEST_DATA @"ProjectsWithDifferentSDKs/ProjectsWithDifferentSDKs.xcworkspace"
+                                                       scheme:@"ProjectsWithDifferentSDKs"
+                                                 settingsPath:TEST_DATA @"ProjectsWithDifferentSDKs-ProjectsWithDifferentSDKs-showBuildSettings.txt"],
+     ]];
+
+    XCTool *tool = [[XCTool alloc] init];
+    
+    tool.arguments = @[@"-workspace", TEST_DATA @"ProjectsWithDifferentSDKs/ProjectsWithDifferentSDKs.xcworkspace",
+                       @"-scheme", @"ProjectsWithDifferentSDKs",
+                       @"build",
+                       @"-dry-run",
+                       @"-reporter", @"plain",
+                       ];
+    
+    [TestUtil runWithFakeStreams:tool];
+    
+    assertThat([[[FakeTaskManager sharedManager] launchedTasks][0] arguments],
+               equalTo(@[
+                         @"-workspace", TEST_DATA @"ProjectsWithDifferentSDKs/ProjectsWithDifferentSDKs.xcworkspace",
+                         @"-scheme", @"ProjectsWithDifferentSDKs",
+                         @"-configuration", @"Debug",
+                         @"-dry-run",
+                         @"build",
+                         ]));
+  }];
+}
+
 @end

--- a/xctool/xctool-tests/OptionsTests.m
+++ b/xctool/xctool-tests/OptionsTests.m
@@ -479,4 +479,5 @@
    [NSString stringWithFormat:@"Unable to find projects (.xcodeproj) in directory %@. Please specify with -workspace, -project, or -find-target.",
     options.findProjectPath]];
 }
+
 @end

--- a/xctool/xctool/BuildAction.h
+++ b/xctool/xctool/BuildAction.h
@@ -19,4 +19,7 @@
 #import "Action.h"
 
 @interface BuildAction : Action
+
+@property (nonatomic, assign) BOOL onlyPrintCommandNames;
+
 @end

--- a/xctool/xctool/BuildAction.m
+++ b/xctool/xctool/BuildAction.m
@@ -28,25 +28,49 @@
   return @"build";
 }
 
++ (NSArray *)options
+{
+  return
+  @[
+    [Action actionOptionWithName:@"dry-run"
+                         aliases:@[@"n"]
+                     description:@"print the commands that would be executed, but do not execute them"
+                         setFlag:@selector(setOnlyPrintCommandNames:)]
+    ];
+}
+
 - (BOOL)performActionWithOptions:(Options *)options xcodeSubjectInfo:(XcodeSubjectInfo *)xcodeSubjectInfo
 {
-
+  
   [xcodeSubjectInfo.actionScripts preBuildWithOptions:options];
-
-
-  NSArray *arguments = [[[options xcodeBuildArgumentsForSubject]
-                         arrayByAddingObjectsFromArray:[options commonXcodeBuildArgumentsForSchemeAction:@"LaunchAction"
-                                                                                        xcodeSubjectInfo:xcodeSubjectInfo]]
-                        arrayByAddingObject:@"build"];
-
+  
+  NSArray *arguments = [self xcodebuildArgumentsForActionWithOptions:options xcodeSubjectInfo:xcodeSubjectInfo];
+  
   BOOL ret = RunXcodebuildAndFeedEventsToReporters(arguments,
-                                               @"build",
-                                               [options scheme],
-                                               [options reporters]);
-
+                                                   @"build",
+                                                   [options scheme],
+                                                   [options reporters]);
+  
   [xcodeSubjectInfo.actionScripts postBuildWithOptions:options];
-
+  
   return ret;
+}
+
+- (NSArray *)xcodebuildArgumentsForActionWithOptions:(Options *)options xcodeSubjectInfo:(XcodeSubjectInfo *)xcodeSubjectInfo
+{
+  NSMutableArray *arguments = [NSMutableArray array];
+  
+  [arguments addObjectsFromArray:[options xcodeBuildArgumentsForSubject]];
+  [arguments addObjectsFromArray:[options commonXcodeBuildArgumentsForSchemeAction:@"LaunchAction"
+                                                                  xcodeSubjectInfo:xcodeSubjectInfo]];
+  
+  if (_onlyPrintCommandNames) {
+    [arguments addObject:@"-dry-run"];
+  }
+  
+  [arguments addObject:@"build"];
+  
+  return [NSArray arrayWithArray:arguments];
 }
 
 @end


### PR DESCRIPTION
`-dry-run` option is very useful in combination with json-compilation-database reporter when we need the `compile_commands.json` file but there is no need to build the project. With `-dry-run`, it only prints the commands without executing them, dramatically reducing the amount of time needed to get the `compile_commands.json` file.