### PR TITLE
Add support for '-skipUnavailableActions' option

### DIFF
--- a/xctool/xctool-tests/BuildActionTests.m
+++ b/xctool/xctool-tests/BuildActionTests.m
@@ -263,7 +263,6 @@ void _CFAutoreleasePoolPrintPools();
   }];
 }
 
-
 - (void)testDryRunOptionSetsFlag
 {
   [[FakeTaskManager sharedManager] runBlockWithFakeTasks:^{
@@ -291,6 +290,38 @@ void _CFAutoreleasePoolPrintPools();
                          @"-scheme", @"ProjectsWithDifferentSDKs",
                          @"-configuration", @"Debug",
                          @"-dry-run",
+                         @"build",
+                         ]));
+  }];
+}
+
+- (void)testSkipUnavailableActionsOptionSetsFlag
+{
+  [[FakeTaskManager sharedManager] runBlockWithFakeTasks:^{
+    [[FakeTaskManager sharedManager] addLaunchHandlerBlocks:@[
+     // Make sure -showBuildSettings returns some data
+     [LaunchHandlers handlerForShowBuildSettingsWithWorkspace:TEST_DATA @"ProjectsWithDifferentSDKs/ProjectsWithDifferentSDKs.xcworkspace"
+                                                       scheme:@"ProjectsWithDifferentSDKs"
+                                                 settingsPath:TEST_DATA @"ProjectsWithDifferentSDKs-ProjectsWithDifferentSDKs-showBuildSettings.txt"],
+     ]];
+
+    XCTool *tool = [[XCTool alloc] init];
+    
+    tool.arguments = @[@"-workspace", TEST_DATA @"ProjectsWithDifferentSDKs/ProjectsWithDifferentSDKs.xcworkspace",
+                       @"-scheme", @"ProjectsWithDifferentSDKs",
+                       @"build",
+                       @"-skipUnavailableActions",
+                       @"-reporter", @"plain",
+                       ];
+    
+    [TestUtil runWithFakeStreams:tool];
+    
+    assertThat([[[FakeTaskManager sharedManager] launchedTasks][0] arguments],
+               equalTo(@[
+                         @"-workspace", TEST_DATA @"ProjectsWithDifferentSDKs/ProjectsWithDifferentSDKs.xcworkspace",
+                         @"-scheme", @"ProjectsWithDifferentSDKs",
+                         @"-configuration", @"Debug",
+                         @"-skipUnavailableActions",
                          @"build",
                          ]));
   }];

--- a/xctool/xctool/BuildAction.h
+++ b/xctool/xctool/BuildAction.h
@@ -21,5 +21,6 @@
 @interface BuildAction : Action
 
 @property (nonatomic, assign) BOOL onlyPrintCommandNames;
+@property (nonatomic, assign) BOOL skipUnavailableActions;
 
 @end

--- a/xctool/xctool/BuildAction.m
+++ b/xctool/xctool/BuildAction.m
@@ -23,6 +23,7 @@
 
 @implementation BuildAction
 
+
 + (NSString *)name
 {
   return @"build";
@@ -35,7 +36,11 @@
     [Action actionOptionWithName:@"dry-run"
                          aliases:@[@"n"]
                      description:@"print the commands that would be executed, but do not execute them"
-                         setFlag:@selector(setOnlyPrintCommandNames:)]
+                         setFlag:@selector(setOnlyPrintCommandNames:)],
+    [Action actionOptionWithName:@"skipUnavailableActions"
+                         aliases:nil
+                     description:@"skip build actions that cannot be performed instead of failing. This option is only honored if -scheme is passed"
+                         setFlag:@selector(setSkipUnavailableActions:)],
     ];
 }
 
@@ -66,6 +71,9 @@
   
   if (_onlyPrintCommandNames) {
     [arguments addObject:@"-dry-run"];
+  }
+  if (_skipUnavailableActions) {
+    [arguments addObject:@"-skipUnavailableActions"];
   }
   
   [arguments addObject:@"build"];


### PR DESCRIPTION
`skipUnavailableActions` is a useful option when you want to obtain the `compile_commands.json` file no matter if all the build actions can be performed or not. One can find other useful use cases.