### PR TITLE
Test passthrough for process environment variables named XCTOOL_TEST_ENV_*

### DIFF
--- a/xctool/xctool-tests/OTestShimTests.m
+++ b/xctool/xctool-tests/OTestShimTests.m
@@ -118,7 +118,8 @@ static NSTask *OtestShimTask(NSString *platformName,
                                                           noResetSimulatorOnFailure:NO
                                                                        freshInstall:NO
                                                                         testTimeout:1
-                                                                          reporters:@[]];
+                                                                          reporters:@[]
+                                                                 processEnvironment:@{}];
   NSTask *task = [runner otestTaskWithTestBundle: bundlePath];
 
   // Make sure launch path is accessible.

--- a/xctool/xctool/OCUnitTestRunner.h
+++ b/xctool/xctool/OCUnitTestRunner.h
@@ -64,7 +64,8 @@
             noResetSimulatorOnFailure:(BOOL)noResetSimulatorOnFailure
                          freshInstall:(BOOL)freshInstall
                           testTimeout:(NSInteger)testTimeout
-                            reporters:(NSArray *)reporters;
+                            reporters:(NSArray *)reporters
+                   processEnvironment:(NSDictionary *)processEnvironment;
 
 - (BOOL)runTests;
 

--- a/xctool/xctool/RunTestsAction.m
+++ b/xctool/xctool/RunTestsAction.m
@@ -680,7 +680,8 @@ typedef BOOL (^TestableBlock)(NSArray *reporters);
                                                         noResetSimulatorOnFailure:_noResetSimulatorOnFailure
                                                                      freshInstall:_freshInstall
                                                                       testTimeout:_testTimeout
-                                                                        reporters:reporters];
+                                                                        reporters:reporters
+                                                               processEnvironment:[[NSProcessInfo processInfo] environment]];
 
     PublishEventToReporters(reporters,
                             [[self class] eventForBeginOCUnitFromTestableExecutionInfo:testableExecutionInfo action:self]);


### PR DESCRIPTION
We'd like to pass through environment variables from Buck when running iOS / OS X tests. (For example, we'd like to set an environment variable telling the test where to write its log files).

This adds the ability to set environment variables named `XCTOOL_TEST_ENV_FOO` when running tests via `xctool`. It will pass through any such environment variable after stripping the `XCTOOL_TEST_ENV_` prefix.

Added unit tests and confirmed they passed by running `./scripts/make_release.sh`. Also integrated with Buck and confirmed via simulator logs that environment variables were passed through.