### PR TITLE
Make junit reporter output valid UTF8 to not break Jenkins' junit plugin.

### DIFF
--- a/reporters/junit/JUnitReporter.m
+++ b/reporters/junit/JUnitReporter.m
@@ -190,8 +190,10 @@
 
       NSString *output = testResult[kReporter_EndTest_OutputKey];
       if (output && output.length > 0) {
+        // make sure we don't create an invalid junit.xml when stdout contains invalid UTF-8
+        NSData *outputData = [output dataUsingEncoding:NSUTF8StringEncoding allowLossyConversion:YES];
         [testcaseElement addChild:[NSXMLElement elementWithName:@"system-out"
-                                                    stringValue:output]];
+                                                    stringValue:[[NSString alloc] initWithData:outputData encoding:NSUTF8StringEncoding]]];
       }
 
       // Adding NSXMLElement testcase to NSXMLElement testsuite


### PR DESCRIPTION
The junit reporter sometimes generates a `junit.xml` that's not valid xml. This is an attempt to make sure the created `junit.xml` is always valid.