### PR TITLE
Ensure XML is within allowed character ranges

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -21,12 +21,14 @@ COMMON_OTEST_HEADERS = [
 COMMON_REPORTERS_SRCS = [
     'Common/EventGenerator.m',
     'Common/NSFileHandle+Print.m',
+    'Common/NSCharacterSet+XML.m',
     'Common/Reporter.m',
 ]
 
 COMMON_REPORTERS_HEADERS = [
     'Common/EventGenerator.h',
     'Common/NSFileHandle+Print.h',
+    'Common/NSCharacterSet+XML.h',
     'Common/Reporter.h',
     'Common/ReporterEvents.h',
 ]

--- a/Common/NSCharacterSet+XML.h
+++ b/Common/NSCharacterSet+XML.h
@@ -1,0 +1,20 @@
+//
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import <Foundation/Foundation.h>
+
+@interface NSCharacterSet (XML)
++ (NSCharacterSet *)fb_xmlCharacterSet;
+@end

--- a/Common/NSCharacterSet+XML.m
+++ b/Common/NSCharacterSet+XML.m
@@ -1,0 +1,36 @@
+//
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "NSCharacterSet+XML.h"
+
+@implementation NSCharacterSet (XML)
++ (NSCharacterSet *)fb_xmlCharacterSet
+{
+    static NSCharacterSet *_xmlCharacterSet;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        // Valid XML characters reference: http://www.w3.org/TR/REC-xml/#charsets
+        NSString *xmlCharacters = [NSString stringWithFormat:@"%C%C%C", 0x9, 0xA, 0xD];
+        NSMutableCharacterSet *xmlCharacterSet = [NSMutableCharacterSet characterSetWithCharactersInString:xmlCharacters];
+        [xmlCharacterSet addCharactersInRange:NSMakeRange(0x20, 0xD7FF - 0x20)];
+        [xmlCharacterSet addCharactersInRange:NSMakeRange(0xE000, 0xFFFD - 0xE000)];
+        // XML also allows characters in the range 0x10000 - 0x10FFFF, but since unichar (unsigned short) has a size of 2 bytes
+        // no character can be in this range: 2^16 = 65535 (not 65536, since we're starting from 0) < 0x10000 = 65536
+        _xmlCharacterSet = [xmlCharacterSet copy];
+    });
+    
+    return _xmlCharacterSet;
+}
+@end

--- a/reporters/junit/JUnitReporter.m
+++ b/reporters/junit/JUnitReporter.m
@@ -17,6 +17,7 @@
 #import "JUnitReporter.h"
 
 #import "ReporterEvents.h"
+#import "NSCharacterSet+XML.h"
 
 #pragma mark Constants
 #define kJUnitReporter_Suite_Event @"event"
@@ -190,10 +191,11 @@
 
       NSString *output = testResult[kReporter_EndTest_OutputKey];
       if (output && output.length > 0) {
-        // make sure we don't create an invalid junit.xml when stdout contains invalid UTF-8
-        NSData *outputData = [output dataUsingEncoding:NSUTF8StringEncoding allowLossyConversion:YES];
+        // Ensure XML is within allowed character ranges
+        NSString *sanitizedOutput = [[output componentsSeparatedByCharactersInSet:[[NSCharacterSet fb_xmlCharacterSet] invertedSet]]
+                                                            componentsJoinedByString:@""];
         [testcaseElement addChild:[NSXMLElement elementWithName:@"system-out"
-                                                    stringValue:[[NSString alloc] initWithData:outputData encoding:NSUTF8StringEncoding]]];
+                                                    stringValue:sanitizedOutput]];
       }
 
       // Adding NSXMLElement testcase to NSXMLElement testsuite

--- a/reporters/reporters.xcodeproj/project.pbxproj
+++ b/reporters/reporters.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		3892D7541815A13400E68652 /* EventGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 3892D74F1815A13400E68652 /* EventGenerator.m */; };
 		3892D7551815A13400E68652 /* EventGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 3892D74F1815A13400E68652 /* EventGenerator.m */; };
 		3892D7561815A13400E68652 /* EventGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 3892D74F1815A13400E68652 /* EventGenerator.m */; };
+		B9A01C221BF101CC004D0C1A /* NSCharacterSet+XML.m in Sources */ = {isa = PBXBuildFile; fileRef = B9A01C211BF101CC004D0C1A /* NSCharacterSet+XML.m */; };
+		B9DE31BE1BF227E400368FA9 /* NSCharacterSet+XML.m in Sources */ = {isa = PBXBuildFile; fileRef = B9A01C211BF101CC004D0C1A /* NSCharacterSet+XML.m */; };
 		CC8AA20618F368EE00D9F322 /* user-notifications-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = CC8AA20518F368EE00D9F322 /* user-notifications-Info.plist */; };
 		CCC0AAF418EC8A92004FD861 /* UserNotificationsReporter.m in Sources */ = {isa = PBXBuildFile; fileRef = CCC0AAF318EC8A92004FD861 /* UserNotificationsReporter.m */; };
 		CCC0AAF818EC8AC4004FD861 /* Reporter.m in Sources */ = {isa = PBXBuildFile; fileRef = EE61734617E284DD00F02C91 /* Reporter.m */; };
@@ -210,6 +212,8 @@
 		28F48A56179750A600068E00 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		3892D74E1815A13400E68652 /* EventGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = EventGenerator.h; path = ../Common/EventGenerator.h; sourceTree = "<group>"; };
 		3892D74F1815A13400E68652 /* EventGenerator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = EventGenerator.m; path = ../Common/EventGenerator.m; sourceTree = "<group>"; };
+		B9A01C201BF101CC004D0C1A /* NSCharacterSet+XML.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSCharacterSet+XML.h"; path = "../Common/NSCharacterSet+XML.h"; sourceTree = "<group>"; };
+		B9A01C211BF101CC004D0C1A /* NSCharacterSet+XML.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSCharacterSet+XML.m"; path = "../Common/NSCharacterSet+XML.m"; sourceTree = "<group>"; };
 		CC43C4711B79725500AEDFB5 /* reporters-tests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "reporters-tests.xcconfig"; sourceTree = "<group>"; };
 		CC8AA20518F368EE00D9F322 /* user-notifications-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "user-notifications-Info.plist"; path = "user-notifications/user-notifications-Info.plist"; sourceTree = "<group>"; };
 		CCC0AAED18EC8A1F004FD861 /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = "user-notifications/main.m"; sourceTree = "<group>"; };
@@ -395,6 +399,8 @@
 				28F489F717973B7100068E00 /* FakeFileHandle.m */,
 				28F489F417973B7100068E00 /* NSFileHandle+Print.h */,
 				28F489F517973B7100068E00 /* NSFileHandle+Print.m */,
+				B9A01C201BF101CC004D0C1A /* NSCharacterSet+XML.h */,
+				B9A01C211BF101CC004D0C1A /* NSCharacterSet+XML.m */,
 				EE61734517E2785F00F02C91 /* Reporter.h */,
 				EE61734617E284DD00F02C91 /* Reporter.m */,
 				28F489CE179725BB00068E00 /* ReporterEvents.h */,
@@ -701,6 +707,7 @@
 				28F48A0017973CF600068E00 /* Reporter+Testing.m in Sources */,
 				28F48A17179743C600068E00 /* PhabricatorReporter.m in Sources */,
 				FD3D4AD01959C0D10099B717 /* TeamCityStatusMessageGenerator.m in Sources */,
+				B9DE31BE1BF227E400368FA9 /* NSCharacterSet+XML.m in Sources */,
 				28F48A1C1797462400068E00 /* PhabricatorReporterTests.m in Sources */,
 				28F48A3217974E3900068E00 /* JUnitReporter.m in Sources */,
 				FD023B2E1959ADFC00947C28 /* TeamCityReporter.m in Sources */,
@@ -756,6 +763,7 @@
 				EE61734B17E284DD00F02C91 /* Reporter.m in Sources */,
 				28F48A2E17974D5400068E00 /* NSFileHandle+Print.m in Sources */,
 				28F48A2617974D4100068E00 /* main.m in Sources */,
+				B9A01C221BF101CC004D0C1A /* NSCharacterSet+XML.m in Sources */,
 				3892D7541815A13400E68652 /* EventGenerator.m in Sources */,
 				28F48A3317974E3900068E00 /* JUnitReporter.m in Sources */,
 			);


### PR DESCRIPTION
Since #622 didn't really fix the XML output, here now an improved version :)

This PR ensures that no invalid characters end up in the XML output.

Let's say `testResult[kReporter_EndTest_OutputKey]` contains the following:

```
•¿ZÚøÿWÚø.
```

This PR ensures that the above will be converted into the following XML:

```xml
<system-out>•¿ZÚøÿWÚø.</system-out>
```

Looks like the same string, but it actually isn't - only the sanitized string is valid XML:

```shell
$ xmllint invalid.xml
invalid.xml:1: parser error : PCDATA invalid Char value 16
<system-out>•¿ZÚøÿWÚø.</system-out>
               ^
```

```shell
$ xmllint sanitized.xml
<?xml version="1.0"?>
<system-out>&#x2022;&#xBF;Z&#xDA;&#xF8;&#xFF;W&#xDA;&#xF8;.</system-out>
```