### PR TITLE
Fixes #632, in which an exception is raised on invalid destinations

### DIFF
--- a/xctool/Headers/CoreSimulator/SimDeviceType.h
+++ b/xctool/Headers/CoreSimulator/SimDeviceType.h
@@ -9,7 +9,6 @@
 + (id)supportedDeviceTypes;
 + (id)supportedDeviceTypesByAlias;
 + (id)supportedDeviceTypesByIdentifier;
-+ (id)supportedDeviceTypesByName;
 + (id)supportedDevices;
 
 - (instancetype)init;

--- a/xctool/xctool/SimulatorWrapper/SimulatorInfo.m
+++ b/xctool/xctool/SimulatorWrapper/SimulatorInfo.m
@@ -361,7 +361,11 @@ static const NSInteger KProductTypeIpad = 2;
 
 + (NSArray *)availableDevices
 {
-  return [[SimDeviceType supportedDeviceTypesByName] allKeys];
+  NSMutableArray *deviceNames = [NSMutableArray array];
+  for (SimDeviceType *deviceType in [SimDeviceType supportedDeviceTypes]) {
+    [deviceNames addObject:deviceType.name];
+  }
+  return deviceNames;
 }
 
 + (BOOL)isDeviceAvailableWithAlias:(NSString *)deviceName

--- a/xctool/xctool/SimulatorWrapper/SimulatorInfo.m
+++ b/xctool/xctool/SimulatorWrapper/SimulatorInfo.m
@@ -361,11 +361,7 @@ static const NSInteger KProductTypeIpad = 2;
 
 + (NSArray *)availableDevices
 {
-  NSMutableArray *deviceNames = [NSMutableArray array];
-  for (SimDeviceType *deviceType in [SimDeviceType supportedDeviceTypes]) {
-    [deviceNames addObject:deviceType.name];
-  }
-  return deviceNames;
+  return [[SimDeviceType supportedDeviceTypes] valueForKeyPath:@"name"];
 }
 
 + (BOOL)isDeviceAvailableWithAlias:(NSString *)deviceName


### PR DESCRIPTION
Problem was SimDeviceType removed the +supportedDeviceTypesByName method.