### PR TITLE
Open new instance of Simulator to allow parallelizing UI tests

### DIFF
--- a/xctool/xctool-tests/OCUnitTestRunnerTests.m
+++ b/xctool/xctool-tests/OCUnitTestRunnerTests.m
@@ -55,6 +55,7 @@ static id TestRunnerWithTestListsAndProcessEnv(Class cls, NSDictionary *settings
                                 environment:environment
                              freshSimulator:NO
                              resetSimulator:NO
+                       newSimulatorInstance:NO
                   noResetSimulatorOnFailure:NO
                                freshInstall:NO
                                 testTimeout:30

--- a/xctool/xctool-tests/OTestShimTests.m
+++ b/xctool/xctool-tests/OTestShimTests.m
@@ -116,6 +116,7 @@ static NSTask *OtestShimTask(NSString *platformName,
                                                                         environment:@{}
                                                                      freshSimulator:NO
                                                                      resetSimulator:NO
+                                                               newSimulatorInstance:NO
                                                           noResetSimulatorOnFailure:NO
                                                                        freshInstall:NO
                                                                         testTimeout:1

--- a/xctool/xctool/OCUnitIOSAppTestRunner.m
+++ b/xctool/xctool/OCUnitIOSAppTestRunner.m
@@ -132,6 +132,7 @@ static const NSInteger kMaxRunTestsAttempts = 3;
     if (_freshInstall) {
       if (![SimulatorWrapper uninstallTestHostBundleID:testHostBundleID
                                                 device:[_simulatorInfo simulatedDevice]
+                                  newSimulatorInstance:_newSimulatorInstance
                                              reporters:_reporters
                                                  error:startupError]) {
         return NO;
@@ -151,6 +152,7 @@ static const NSInteger kMaxRunTestsAttempts = 3;
     if (![SimulatorWrapper installTestHostBundleID:testHostBundleID
                                     fromBundlePath:testHostAppPath
                                             device:[_simulatorInfo simulatedDevice]
+                              newSimulatorInstance:_newSimulatorInstance
                                          reporters:_reporters
                                              error:startupError]) {
       return NO;

--- a/xctool/xctool/OCUnitTestRunner.h
+++ b/xctool/xctool/OCUnitTestRunner.h
@@ -31,6 +31,7 @@
   BOOL _garbageCollection;
   BOOL _freshSimulator;
   BOOL _resetSimulator;
+  BOOL _newSimulatorInstance;
   BOOL _noResetSimulatorOnFailure;
   BOOL _freshInstall;
   NSInteger _testTimeout;
@@ -61,6 +62,7 @@
                           environment:(NSDictionary *)environment
                        freshSimulator:(BOOL)freshSimulator
                        resetSimulator:(BOOL)resetSimulator
+                 newSimulatorInstance:(BOOL)newSimulatorInstance
             noResetSimulatorOnFailure:(BOOL)noResetSimulatorOnFailure
                          freshInstall:(BOOL)freshInstall
                           testTimeout:(NSInteger)testTimeout

--- a/xctool/xctool/OCUnitTestRunner.m
+++ b/xctool/xctool/OCUnitTestRunner.m
@@ -36,6 +36,7 @@ static NSString * const kEnvVarPassThroughPrefix = @"XCTOOL_TEST_ENV_";
 @property (nonatomic, assign) BOOL garbageCollection;
 @property (nonatomic, assign) BOOL freshSimulator;
 @property (nonatomic, assign) BOOL resetSimulator;
+@property (nonatomic, assign) BOOL newSimulatorInstance;
 @property (nonatomic, assign) BOOL noResetSimulatorOnFailure;
 @property (nonatomic, assign) BOOL freshInstall;
 @property (nonatomic, copy, readwrite) NSArray *reporters;
@@ -139,6 +140,7 @@ static NSString * const kEnvVarPassThroughPrefix = @"XCTOOL_TEST_ENV_";
                           environment:(NSDictionary *)environment
                        freshSimulator:(BOOL)freshSimulator
                        resetSimulator:(BOOL)resetSimulator
+                 newSimulatorInstance:(BOOL)newSimulatorInstance
             noResetSimulatorOnFailure:(BOOL)noResetSimulatorOnFailure
                          freshInstall:(BOOL)freshInstall
                           testTimeout:(NSInteger)testTimeout
@@ -155,6 +157,7 @@ static NSString * const kEnvVarPassThroughPrefix = @"XCTOOL_TEST_ENV_";
     _environment = [environment copy];
     _freshSimulator = freshSimulator;
     _resetSimulator = resetSimulator;
+    _newSimulatorInstance = newSimulatorInstance;
     _noResetSimulatorOnFailure = noResetSimulatorOnFailure;
     _freshInstall = freshInstall;
     _testTimeout = testTimeout;

--- a/xctool/xctool/RunTestsAction.h
+++ b/xctool/xctool/RunTestsAction.h
@@ -54,6 +54,7 @@ typedef NS_ENUM(NSInteger, BucketBy) {
 
 @property (nonatomic, assign) BOOL freshSimulator;
 @property (nonatomic, assign) BOOL resetSimulator;
+@property (nonatomic, assign) BOOL newSimulatorInstance;
 @property (nonatomic, assign) BOOL noResetSimulatorOnFailure;
 @property (nonatomic, assign) BOOL freshInstall;
 @property (nonatomic, assign) BOOL parallelize;

--- a/xctool/xctool/RunTestsAction.m
+++ b/xctool/xctool/RunTestsAction.m
@@ -141,6 +141,11 @@ NSArray *BucketizeTestCasesByTestClass(NSArray *testCases, int bucketSize)
                      description:
      @"Reset simulator content and settings and restart it before running every app test run."
                          setFlag:@selector(setResetSimulator:)],
+    [Action actionOptionWithName:@"newSimulatorInstance"
+                         aliases:nil
+                     description:
+     @"Start new instance of simulator for each application test target."
+                         setFlag:@selector(setNewSimulatorInstance:)],
     [Action actionOptionWithName:@"noResetSimulatorOnFailure"
                          aliases:nil
                      description:
@@ -677,6 +682,7 @@ typedef BOOL (^TestableBlock)(NSArray *reporters);
                                                                       environment:environment
                                                                    freshSimulator:_freshSimulator
                                                                    resetSimulator:_resetSimulator
+                                                             newSimulatorInstance:_newSimulatorInstance
                                                         noResetSimulatorOnFailure:_noResetSimulatorOnFailure
                                                                      freshInstall:_freshInstall
                                                                       testTimeout:_testTimeout

--- a/xctool/xctool/SimulatorWrapper/SimulatorWrapper.h
+++ b/xctool/xctool/SimulatorWrapper/SimulatorWrapper.h
@@ -46,12 +46,14 @@
 
 + (BOOL)uninstallTestHostBundleID:(NSString *)testHostBundleID
                            device:(SimDevice *)device
+             newSimulatorInstance:(BOOL)newSimulatorInstance
                         reporters:(NSArray *)reporters
                             error:(NSString **)error;
 
 + (BOOL)installTestHostBundleID:(NSString *)testHostBundleID
                  fromBundlePath:(NSString *)testHostBundlePath
                          device:(SimDevice *)device
+           newSimulatorInstance:(BOOL)newSimulatorInstance
                       reporters:(NSArray *)reporters
                           error:(NSString **)error;
 

--- a/xctool/xctool/SimulatorWrapper/SimulatorWrapper.m
+++ b/xctool/xctool/SimulatorWrapper/SimulatorWrapper.m
@@ -137,6 +137,7 @@ static const NSString * kOptionsWaitForDebuggerKey = @"wait_for_debugger";
 
 + (BOOL)uninstallTestHostBundleID:(NSString *)testHostBundleID
                            device:(SimDevice *)device
+                        newSimulatorInstance:(BOOL)newSimulatorInstance
                         reporters:(NSArray *)reporters
                             error:(NSString **)error
 {
@@ -147,6 +148,7 @@ static const NSString * kOptionsWaitForDebuggerKey = @"wait_for_debugger";
 
   BOOL uninstalled = [[self classBasedOnCurrentVersionOfXcode] uninstallTestHostBundleID:testHostBundleID
                                                                                   device:device
+                                                                    newSimulatorInstance:newSimulatorInstance
                                                                                reporters:reporters
                                                                                    error:error];
   if (uninstalled) {
@@ -166,6 +168,7 @@ static const NSString * kOptionsWaitForDebuggerKey = @"wait_for_debugger";
 + (BOOL)installTestHostBundleID:(NSString *)testHostBundleID
                  fromBundlePath:(NSString *)testHostBundlePath
                          device:(SimDevice *)device
+           newSimulatorInstance:(BOOL)newSimulatorInstance
                       reporters:(NSArray *)reporters
                           error:(NSString **)error
 {
@@ -177,6 +180,7 @@ static const NSString * kOptionsWaitForDebuggerKey = @"wait_for_debugger";
   BOOL installed = [[self classBasedOnCurrentVersionOfXcode] installTestHostBundleID:testHostBundleID
                                                                       fromBundlePath:testHostBundlePath
                                                                               device:device
+                                                                newSimulatorInstance:newSimulatorInstance
                                                                            reporters:reporters
                                                                                error:error];
   if (installed) {

--- a/xctool/xctool/SimulatorWrapper/SimulatorWrapperXcode6.m
+++ b/xctool/xctool/SimulatorWrapper/SimulatorWrapperXcode6.m
@@ -50,7 +50,7 @@
   NSDictionary *configuration = @{NSWorkspaceLaunchConfigurationArguments: @[@"-CurrentDeviceUDID", [device.UDID UUIDString]]};
   NSError *launchError = nil;
   NSRunningApplication *app = [[NSWorkspace sharedWorkspace] launchApplicationAtURL:iOSSimulatorURL
-                                                                            options:NSWorkspaceLaunchAsync | NSWorkspaceLaunchWithoutActivation | NSWorkspaceLaunchAndHide
+                                                                            options:NSWorkspaceLaunchNewInstance | NSWorkspaceLaunchAsync | NSWorkspaceLaunchWithoutActivation | NSWorkspaceLaunchAndHide
                                                                       configuration:configuration
                                                                               error:&launchError];
   if (!app) {

--- a/xctool/xctool/SimulatorWrapper/SimulatorWrapperXcode6.m
+++ b/xctool/xctool/SimulatorWrapper/SimulatorWrapperXcode6.m
@@ -29,7 +29,7 @@
 #pragma mark -
 #pragma mark Helpers
 
-+ (BOOL)prepareSimulator:(SimDevice *)device error:(NSError **)error
++ (BOOL)prepareSimulator:(SimDevice *)device newSimulatorInstance:(BOOL)newSimulatorInstance error:(NSError **)error
 {
   if (!device.available) {
     NSString *errorDesc = [NSString stringWithFormat: @"Simulator '%@' is not available", device.name];
@@ -49,8 +49,14 @@
   }
   NSDictionary *configuration = @{NSWorkspaceLaunchConfigurationArguments: @[@"-CurrentDeviceUDID", [device.UDID UUIDString]]};
   NSError *launchError = nil;
+  
+  NSWorkspaceLaunchOptions launchOptions = NSWorkspaceLaunchAsync | NSWorkspaceLaunchWithoutActivation | NSWorkspaceLaunchAndHide;
+  if (newSimulatorInstance) {
+    launchOptions = launchOptions | NSWorkspaceLaunchNewInstance;
+  }
+
   NSRunningApplication *app = [[NSWorkspace sharedWorkspace] launchApplicationAtURL:iOSSimulatorURL
-                                                                            options:NSWorkspaceLaunchNewInstance | NSWorkspaceLaunchAsync | NSWorkspaceLaunchWithoutActivation | NSWorkspaceLaunchAndHide
+                                                                            options:launchOptions
                                                                       configuration:configuration
                                                                               error:&launchError];
   if (!app) {
@@ -77,12 +83,13 @@
 
 + (BOOL)uninstallTestHostBundleID:(NSString *)testHostBundleID
                            device:(SimDevice *)device
+             newSimulatorInstance:(BOOL)newSimulatorInstance
                         reporters:(NSArray *)reporters
                             error:(NSString **)error
 {
   NSError *localError = nil;
 
-  if (![self prepareSimulator:device error:&localError]) {
+  if (![self prepareSimulator:device newSimulatorInstance:newSimulatorInstance error:&localError]) {
     *error = [NSString stringWithFormat:
               @"Simulator '%@' was not prepared: %@",
               device.name, localError.localizedDescription ?: @"Failed for unknown reason."];
@@ -108,13 +115,14 @@
 + (BOOL)installTestHostBundleID:(NSString *)testHostBundleID
                  fromBundlePath:(NSString *)testHostBundlePath
                          device:(SimDevice *)device
+           newSimulatorInstance:(BOOL)newSimulatorInstance
                       reporters:(NSArray *)reporters
                           error:(NSString **)error
 {
   NSError *localError = nil;
   NSURL *appURL = [NSURL fileURLWithPath:testHostBundlePath];
 
-  if (![self prepareSimulator:device error:&localError]) {
+  if (![self prepareSimulator:device newSimulatorInstance:newSimulatorInstance error:&localError]) {
     *error = [NSString stringWithFormat:
               @"Simulator '%@' was not prepared: %@",
               device.name, localError.localizedDescription ?: @"Failed for unknown reason."];

--- a/xctool/xctool/TestAction.m
+++ b/xctool/xctool/TestAction.m
@@ -69,6 +69,11 @@
                      description:
      @"Reset simulator content and settings and restart it before running every app test run."
                          setFlag:@selector(setResetSimulator:)],
+    [Action actionOptionWithName:@"newSimulatorInstance"
+                         aliases:nil
+                     description:
+     @"Create new simulator instance for each application test target"
+                         setFlag:@selector(setNewSimulatorInstance:)],
     [Action actionOptionWithName:@"noResetSimulatorOnFailure"
                          aliases:nil
                      description:
@@ -137,6 +142,11 @@
 - (void)setResetSimulator:(BOOL)resetSimulator
 {
   [_runTestsAction setResetSimulator:resetSimulator];
+}
+
+- (void)setNewSimulatorInstance:(BOOL)newSimulatorInstance
+{
+  [_runTestsAction setNewSimulatorInstance:newSimulatorInstance];
 }
 
 - (void)setNoResetSimulatorOnFailure:(BOOL)noResetSimulatorOnFailure


### PR DESCRIPTION
Adding the `NSWorkspaceLaunchNewInstance` launch option to the NSRunningApplication allows multiple simulators instances to be run concurrently on a single machine.