### PR TITLE
Wait for CoreSimulator responses only a particular amount of time.

### DIFF
--- a/Common/XCToolUtil.m
+++ b/Common/XCToolUtil.m
@@ -344,9 +344,14 @@ BOOL IsRunningOnCISystem()
 
 BOOL IsRunningUnderTest()
 {
-  NSString *processName = [[NSProcessInfo processInfo] processName];
-  return ([processName isEqualToString:@"xctest"] ||
-          [processName isEqualToString:@"xctest-x86_64"]);
+  static BOOL isRunningUnderTest;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    NSString *processName = [[NSProcessInfo processInfo] processName];
+    isRunningUnderTest = [processName isEqualToString:@"xctest"] ||
+                         [processName isEqualToString:@"xctest-x86_64"];
+  });
+  return isRunningUnderTest;
 }
 
 BOOL LaunchXcodebuildTaskAndFeedEventsToReporters(NSTask *task,

--- a/otest-query/otest-query.xcodeproj/project.pbxproj
+++ b/otest-query/otest-query.xcodeproj/project.pbxproj
@@ -353,7 +353,7 @@
 		CD9048F61756C5B1006CF16D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = Facebook;
 			};
 			buildConfigurationList = CD9048F91756C5B1006CF16D /* Build configuration list for PBXProject "otest-query" */;

--- a/otest-shim/otest-shim.xcodeproj/project.pbxproj
+++ b/otest-shim/otest-shim.xcodeproj/project.pbxproj
@@ -287,7 +287,7 @@
 		283CCA8416C2EE4C00F2E343 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0630;
+				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = "Facebook, Inc.";
 			};
 			buildConfigurationList = 283CCA8716C2EE4C00F2E343 /* Build configuration list for PBXProject "otest-shim" */;

--- a/reporters/reporters-tests/reporters-tests-Info.plist
+++ b/reporters/reporters-tests/reporters-tests-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.facebook.xctool.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>

--- a/reporters/reporters.xcodeproj/project.pbxproj
+++ b/reporters/reporters.xcodeproj/project.pbxproj
@@ -712,7 +712,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastTestingUpgradeCheck = 0700;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0710;
 			};
 			buildConfigurationList = 2893A94117960CAD00EFBD28 /* Build configuration list for PBXProject "reporters" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -962,6 +962,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = "reporters-tests/reporters-tests-Info.plist";
 				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.xctool.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -996,6 +997,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = "reporters-tests/reporters-tests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.xctool.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -1365,6 +1367,7 @@
 					__info_plist,
 					"$(INFOPLIST_FILE)",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.xctool;
 				PRODUCT_NAME = "user-notifications";
 				SDKROOT = macosx;
 			};
@@ -1396,6 +1399,7 @@
 					__info_plist,
 					"$(INFOPLIST_FILE)",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.facebook.xctool;
 				PRODUCT_NAME = "user-notifications";
 				SDKROOT = macosx;
 			};

--- a/reporters/user-notifications/user-notifications-Info.plist
+++ b/reporters/user-notifications/user-notifications-Info.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleIdentifier</key>
-	<string>com.facebook.xctool</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 </dict>
 </plist>

--- a/xcodebuild-shim/xcodebuild-shim.xcodeproj/project.pbxproj
+++ b/xcodebuild-shim/xcodebuild-shim.xcodeproj/project.pbxproj
@@ -221,7 +221,7 @@
 		283CCAA116C2EE7200F2E343 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = "Facebook, Inc.";
 			};
 			buildConfigurationList = 283CCAA416C2EE7200F2E343 /* Build configuration list for PBXProject "xcodebuild-shim" */;

--- a/xctool/xctool-tests/FakeSimDevice.h
+++ b/xctool/xctool-tests/FakeSimDevice.h
@@ -1,0 +1,34 @@
+//
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "SimDevice.h"
+
+@interface FakeSimDevice : SimDevice
+
+@property (nonatomic, assign) BOOL fakeAvailable;
+@property (nonatomic, assign) unsigned long long fakeState;
+@property (nonatomic, strong) NSUUID *fakeUDID;
+
+@property (nonatomic, assign) BOOL fakeInstallFailure;
+@property (nonatomic, assign) BOOL fakeUninstallFailure;
+
+@property (nonatomic, assign) int fakeIsInstalledTimeout;
+@property (nonatomic, assign) int fakeInstallTimeout;
+@property (nonatomic, assign) int fakeUninstallTimeout;
+
+- (void)addFakeInstalledApp:(NSString *)testHostBundleID;
+
+@end

--- a/xctool/xctool-tests/FakeSimDevice.m
+++ b/xctool/xctool-tests/FakeSimDevice.m
@@ -1,0 +1,82 @@
+//
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "FakeSimDevice.h"
+
+@interface FakeSimDevice ()
+@property (nonatomic, strong) NSMutableSet *fakeInstalledApps;
+@end
+
+@implementation FakeSimDevice
+
+- (instancetype)init
+{
+  self = [super init];
+  if (self) {
+    _fakeInstalledApps = [NSMutableSet set];
+    _fakeInstallFailure = NO;
+    _fakeUninstallFailure = NO;
+    _fakeInstallTimeout = 0;
+    _fakeUninstallTimeout = 0;
+    _fakeIsInstalledTimeout = 0;
+  }
+  return self;
+}
+
+- (BOOL)available
+{
+  return _fakeAvailable;
+}
+
+- (NSString *)name
+{
+  return @"Test Device";
+}
+
+- (unsigned long long)state
+{
+  return _fakeState;
+}
+
+- (NSUUID *)UDID
+{
+  return _fakeUDID;
+}
+
+- (void)addFakeInstalledApp:(NSString *)testHostBundleID
+{
+  [_fakeInstalledApps addObject:testHostBundleID];
+}
+
+- (BOOL)applicationIsInstalled:(NSString *)bundleId type:(NSString **)arg2 error:(NSError **)error
+{
+  sleep(_fakeIsInstalledTimeout);
+  return [_fakeInstalledApps containsObject:bundleId];
+}
+
+- (BOOL)uninstallApplication:(NSString *)bundleId withOptions:(NSDictionary *)options error:(NSError **)error
+{
+  sleep(_fakeUninstallTimeout);
+  return !_fakeUninstallFailure;
+}
+
+- (BOOL)installApplication:(NSURL *)appURL withOptions:(NSDictionary *)options error:(NSError **)error
+{
+  sleep(_fakeInstallTimeout);
+  return !_fakeInstallFailure;
+}
+
+@end

--- a/xctool/xctool-tests/SimulatorWrapperTests.m
+++ b/xctool/xctool-tests/SimulatorWrapperTests.m
@@ -1,0 +1,287 @@
+//
+// Copyright 2004-present Facebook. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "EventBuffer.h"
+#import "FakeSimDevice.h"
+#import "ReporterEvents.h"
+#import "SimDevice.h"
+#import "SimulatorWrapper.h"
+#import "SimulatorWrapperXcode6.h"
+#import "Swizzler.h"
+
+@interface SimulatorWrapperTests : XCTestCase
+{
+  FakeSimDevice *_simDevice;
+
+  NSWorkspace *_nsWorkspaceMock;
+  id _runningApp;
+
+  EventBuffer *_eventBuffer;
+}
+@end
+
+@implementation SimulatorWrapperTests
+
+- (void)setUp
+{
+  [super setUp];
+
+  _simDevice = [FakeSimDevice new];
+  _simDevice.fakeAvailable = YES;
+  _simDevice.fakeUDID = [[NSUUID alloc] initWithUUIDString:@"E621E1F8-C36C-495A-93FC-0C247A3E6E5F"];;
+  _simDevice.fakeState = SimDeviceStateShutdown;
+
+  _nsWorkspaceMock = mock([NSWorkspace class]);
+  [[[given([_nsWorkspaceMock launchApplicationAtURL:anything() options:0 configuration:anything() error:nil])
+    withMatcher:anything() forArgument:1]
+    withMatcher:anything() forArgument:3]
+    willDo:^id(NSInvocation *inv) {
+    return _runningApp;
+  }];
+
+  _eventBuffer = [[EventBuffer alloc] init];
+}
+
+- (void)tearDown
+{
+
+  [super tearDown];
+}
+
+#pragma mark - Prepare
+
+- (void)testPrepareSimulator
+{
+  SwizzleReceipt *swizzle = [Swizzler swizzleSelector:@selector(sharedWorkspace) forClass:[NSWorkspace class] withBlock:^(){
+    return _nsWorkspaceMock;
+  }];
+  _runningApp = @0;
+  _simDevice.fakeState = SimDeviceStateBooted;
+
+  NSString *error = nil;
+  BOOL result = [SimulatorWrapper prepareSimulator:_simDevice
+                                         reporters:@[_eventBuffer]
+                                             error:&error];
+  assertThatBool(result, isTrue());
+  assertThat(error, nilValue());
+  [Swizzler unswizzleFromReceipt:swizzle];
+
+  NSArray *events = [_eventBuffer events];
+  assertThatUnsignedInteger([events count], equalToUnsignedInt(2));
+  assertThat(events[0][kReporter_BeginStatus_MessageKey], equalTo(@"Preparing 'Test Device' simulator to run tests ..."));
+  assertThat(events[1][kReporter_EndStatus_MessageKey], equalTo(@"Prepared 'Test Device' simulator to run tests."));
+}
+
+- (void)testPrepareSimulatorFailsWithNoAppLaunched
+{
+  SwizzleReceipt *swizzle = [Swizzler swizzleSelector:@selector(sharedWorkspace) forClass:[NSWorkspace class] withBlock:^(){
+    return _nsWorkspaceMock;
+  }];
+
+  NSString *error = nil;
+  BOOL result = [SimulatorWrapper prepareSimulator:_simDevice
+                                         reporters:@[_eventBuffer]
+                                             error:&error];
+  assertThatBool(result, isFalse());
+  assertThat(error, startsWith(@"iOS Simulator app wasn't launched at path"));
+  [Swizzler unswizzleFromReceipt:swizzle];
+
+  NSArray *events = [_eventBuffer events];
+  assertThatUnsignedInteger([events count], equalToUnsignedInt(2));
+  assertThat(events[0][kReporter_BeginStatus_MessageKey], equalTo(@"Preparing 'Test Device' simulator to run tests ..."));
+  assertThat(events[1][kReporter_EndStatus_MessageKey], equalTo(@"Failed to prepare 'Test Device' simulator to run tests."));
+}
+
+- (void)testPrepareSimulatorTimesOut
+{
+  SwizzleReceipt *swizzle = [Swizzler swizzleSelector:@selector(sharedWorkspace) forClass:[NSWorkspace class] withBlock:^(){
+    return _nsWorkspaceMock;
+  }];
+  _runningApp = @0;
+
+  NSString *error = nil;
+  BOOL result = [SimulatorWrapper prepareSimulator:_simDevice
+                                         reporters:@[_eventBuffer]
+                                             error:&error];
+  assertThatBool(result, isFalse());
+  assertThat(error, startsWith(@"Timed out while waiting simulator to boot."));
+  [Swizzler unswizzleFromReceipt:swizzle];
+
+  NSArray *events = [_eventBuffer events];
+  assertThatUnsignedInteger([events count], equalToUnsignedInt(2));
+  assertThat(events[0][kReporter_BeginStatus_MessageKey], equalTo(@"Preparing 'Test Device' simulator to run tests ..."));
+  assertThat(events[1][kReporter_EndStatus_MessageKey], equalTo(@"Failed to prepare 'Test Device' simulator to run tests."));
+}
+
+#pragma mark - Uninstall
+
+- (void)testUninstallTestHostBundleID
+{
+  NSString *testHostBundleID = @"com.facebook.xctool-test-app";
+  NSString *error = nil;
+  [_simDevice addFakeInstalledApp:testHostBundleID];
+  BOOL result = [SimulatorWrapper uninstallTestHostBundleID:testHostBundleID
+                                                     device:_simDevice
+                                                  reporters:@[_eventBuffer]
+                                                      error:&error];
+  assertThatBool(result, isTrue());
+  assertThat(error, nilValue());
+
+  NSArray *events = [_eventBuffer events];
+  assertThatUnsignedInteger([events count], equalToUnsignedInt(2));
+  assertThat(events[0][kReporter_BeginStatus_MessageKey], equalTo(@"Uninstalling 'com.facebook.xctool-test-app' to get a fresh install ..."));
+  assertThat(events[1][kReporter_EndStatus_MessageKey], equalTo(@"Uninstalled 'com.facebook.xctool-test-app' to get a fresh install."));
+}
+
+- (void)testUninstallTestHostBundleIDAppNotInstalled
+{
+  NSString *testHostBundleID = @"com.facebook.xctool-test-app";
+  NSString *error = nil;
+  BOOL result = [SimulatorWrapper uninstallTestHostBundleID:testHostBundleID
+                                                     device:_simDevice
+                                                  reporters:@[_eventBuffer]
+                                                      error:&error];
+  assertThatBool(result, isTrue());
+  assertThat(error, nilValue());
+
+  NSArray *events = [_eventBuffer events];
+  assertThatUnsignedInteger([events count], equalToUnsignedInt(2));
+  assertThat(events[0][kReporter_BeginStatus_MessageKey], equalTo(@"Uninstalling 'com.facebook.xctool-test-app' to get a fresh install ..."));
+  assertThat(events[1][kReporter_EndStatus_MessageKey], equalTo(@"Uninstalled 'com.facebook.xctool-test-app' to get a fresh install."));
+}
+
+- (void)testUninstallTestHostBundleIDFailure
+{
+  NSString *testHostBundleID = @"com.facebook.xctool-test-app";
+  NSString *error = nil;
+  [_simDevice addFakeInstalledApp:testHostBundleID];
+  _simDevice.fakeUninstallFailure = YES;
+  BOOL result = [SimulatorWrapper uninstallTestHostBundleID:testHostBundleID
+                                                     device:_simDevice
+                                                  reporters:@[_eventBuffer]
+                                                      error:&error];
+  assertThatBool(result, isFalse());
+  assertThat(error, equalTo(@"Failed to uninstall the test host app 'com.facebook.xctool-test-app': Failed for unknown reason."));
+
+  NSArray *events = [_eventBuffer events];
+  assertThatUnsignedInteger([events count], equalToUnsignedInt(2));
+  assertThat(events[0][kReporter_BeginStatus_MessageKey], equalTo(@"Uninstalling 'com.facebook.xctool-test-app' to get a fresh install ..."));
+  assertThat(events[1][kReporter_EndStatus_MessageKey], equalTo(@"Failed to uninstall the test host app 'com.facebook.xctool-test-app'."));
+}
+
+- (void)testUninstallTestHostBundleIDTimesOut
+{
+  NSString *testHostBundleID = @"com.facebook.xctool-test-app";
+  NSString *error = nil;
+  [_simDevice addFakeInstalledApp:testHostBundleID];
+  _simDevice.fakeUninstallTimeout = 20;
+  BOOL result = [SimulatorWrapper uninstallTestHostBundleID:testHostBundleID
+                                                     device:_simDevice
+                                                  reporters:@[_eventBuffer]
+                                                      error:&error];
+  assertThatBool(result, isFalse());
+  assertThat(error, equalTo(@"Failed to uninstall the test host app 'com.facebook.xctool-test-app': Timed out."));
+
+  NSArray *events = [_eventBuffer events];
+  assertThatUnsignedInteger([events count], equalToUnsignedInt(2));
+  assertThat(events[0][kReporter_BeginStatus_MessageKey], equalTo(@"Uninstalling 'com.facebook.xctool-test-app' to get a fresh install ..."));
+  assertThat(events[1][kReporter_EndStatus_MessageKey], equalTo(@"Failed to uninstall the test host app 'com.facebook.xctool-test-app'."));
+}
+
+- (void)testUninstallTestHostBundleIDTimesOutOnIsInstallCheck
+{
+  NSString *testHostBundleID = @"com.facebook.xctool-test-app";
+  NSString *error = nil;
+  [_simDevice addFakeInstalledApp:testHostBundleID];
+  _simDevice.fakeIsInstalledTimeout = 20;
+  BOOL result = [SimulatorWrapper uninstallTestHostBundleID:testHostBundleID
+                                                     device:_simDevice
+                                                  reporters:@[_eventBuffer]
+                                                      error:&error];
+  assertThatBool(result, isTrue());
+  assertThat(error, nilValue());
+
+  NSArray *events = [_eventBuffer events];
+  assertThatUnsignedInteger([events count], equalToUnsignedInt(2));
+  assertThat(events[0][kReporter_BeginStatus_MessageKey], equalTo(@"Uninstalling 'com.facebook.xctool-test-app' to get a fresh install ..."));
+  assertThat(events[1][kReporter_EndStatus_MessageKey], equalTo(@"Uninstalled 'com.facebook.xctool-test-app' to get a fresh install."));
+}
+
+#pragma mark - Install
+
+- (void)testInstallTestHostBundleID
+{
+  NSString *testHostBundleID = @"com.facebook.xctool-test-app";
+  NSString *error = nil;
+  BOOL result = [SimulatorWrapper installTestHostBundleID:testHostBundleID
+                                           fromBundlePath:@"/tmp"
+                                                   device:_simDevice
+                                                reporters:@[_eventBuffer]
+                                                    error:&error];
+  assertThatBool(result, isTrue());
+  assertThat(error, nilValue());
+
+
+  NSArray *events = [_eventBuffer events];
+  assertThatUnsignedInteger([events count], equalToUnsignedInt(2));
+  assertThat(events[0][kReporter_BeginStatus_MessageKey], equalTo(@"Installing 'com.facebook.xctool-test-app' ..."));
+  assertThat(events[1][kReporter_EndStatus_MessageKey], equalTo(@"Installed 'com.facebook.xctool-test-app'."));
+}
+
+- (void)testInstallTestHostBundleIDFailure
+{
+  NSString *testHostBundleID = @"com.facebook.xctool-test-app";
+  NSString *error = nil;
+  _simDevice.fakeInstallFailure = YES;
+  BOOL result = [SimulatorWrapper installTestHostBundleID:testHostBundleID
+                                           fromBundlePath:@"/tmp"
+                                                   device:_simDevice
+                                                reporters:@[_eventBuffer]
+                                                    error:&error];
+  assertThatBool(result, isFalse());
+  assertThat(error, equalTo(@"Failed to install the test host app 'com.facebook.xctool-test-app': Failed for unknown reason."));
+
+
+  NSArray *events = [_eventBuffer events];
+  assertThatUnsignedInteger([events count], equalToUnsignedInt(2));
+  assertThat(events[0][kReporter_BeginStatus_MessageKey], equalTo(@"Installing 'com.facebook.xctool-test-app' ..."));
+  assertThat(events[1][kReporter_EndStatus_MessageKey], equalTo(@"Failed to install the test host app 'com.facebook.xctool-test-app'."));
+}
+
+- (void)testInstallTestHostBundleIDTimesOut
+{
+  NSString *testHostBundleID = @"com.facebook.xctool-test-app";
+  NSString *error = nil;
+  _simDevice.fakeInstallFailure = YES;
+  _simDevice.fakeInstallTimeout = 20;
+  BOOL result = [SimulatorWrapper installTestHostBundleID:testHostBundleID
+                                           fromBundlePath:@"/tmp"
+                                                   device:_simDevice
+                                                reporters:@[_eventBuffer]
+                                                    error:&error];
+  assertThatBool(result, isFalse());
+  assertThat(error, equalTo(@"Failed to install the test host app 'com.facebook.xctool-test-app': Timed out."));
+
+
+  NSArray *events = [_eventBuffer events];
+  assertThatUnsignedInteger([events count], equalToUnsignedInt(2));
+  assertThat(events[0][kReporter_BeginStatus_MessageKey], equalTo(@"Installing 'com.facebook.xctool-test-app' ..."));
+  assertThat(events[1][kReporter_EndStatus_MessageKey], equalTo(@"Failed to install the test host app 'com.facebook.xctool-test-app'."));
+}
+
+@end

--- a/xctool/xctool-tests/xctool-tests-Info.plist
+++ b/xctool/xctool-tests/xctool-tests-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.facebook.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>

--- a/xctool/xctool.xcodeproj/project.pbxproj
+++ b/xctool/xctool.xcodeproj/project.pbxproj
@@ -133,6 +133,8 @@
 		CCA8F74D1BD2280A0084E131 /* libiconv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = CCA8F74B1BD225F90084E131 /* libiconv.dylib */; };
 		CCC55AD2195BCD7D0051A50B /* SimulatorWrapperXcode6.m in Sources */ = {isa = PBXBuildFile; fileRef = CCC55AD1195BCD7D0051A50B /* SimulatorWrapperXcode6.m */; };
 		CCC55AD6195BCDD90051A50B /* SimulatorWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = CCC55AD5195BCDD90051A50B /* SimulatorWrapper.m */; };
+		CCCF099A1C126D23006F08C4 /* SimulatorWrapperTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CCCF09991C126D23006F08C4 /* SimulatorWrapperTests.m */; };
+		CCCF099D1C1286B4006F08C4 /* FakeSimDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = CCCF099C1C1286B4006F08C4 /* FakeSimDevice.m */; };
 		CCE14EA11ACB5B8100B76996 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CCE14EA01ACB5B8100B76996 /* AppKit.framework */; };
 		CCE14EA21ACB5BB100B76996 /* AppKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CCE14EA01ACB5B8100B76996 /* AppKit.framework */; };
 		CCEB0F26195F2D9E00878E25 /* SimulatorInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = CCF6EE48195BA918005BA335 /* SimulatorInfo.m */; };
@@ -352,6 +354,9 @@
 		CCC55AD4195BCDA30051A50B /* SimulatorWrapperXcode6.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SimulatorWrapperXcode6.h; path = xctool/SimulatorWrapper/SimulatorWrapperXcode6.h; sourceTree = "<group>"; };
 		CCC55AD5195BCDD90051A50B /* SimulatorWrapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SimulatorWrapper.m; path = xctool/SimulatorWrapper/SimulatorWrapper.m; sourceTree = "<group>"; };
 		CCC647DD1B2F8F4C006609FC /* XCTestConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XCTestConfiguration.h; sourceTree = "<group>"; };
+		CCCF09991C126D23006F08C4 /* SimulatorWrapperTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SimulatorWrapperTests.m; sourceTree = "<group>"; };
+		CCCF099B1C1286B4006F08C4 /* FakeSimDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FakeSimDevice.h; sourceTree = "<group>"; };
+		CCCF099C1C1286B4006F08C4 /* FakeSimDevice.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FakeSimDevice.m; sourceTree = "<group>"; };
 		CCE14EA01ACB5B8100B76996 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
 		CCF50B5519DC9E8C00A1044E /* SimVerifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SimVerifier.h; sourceTree = "<group>"; };
 		CCF6EE48195BA918005BA335 /* SimulatorInfo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SimulatorInfo.m; path = xctool/SimulatorWrapper/SimulatorInfo.m; sourceTree = "<group>"; };
@@ -567,6 +572,8 @@
 				28D9C5B01828D5CA0032FEA8 /* ContainsAssertionFailure.m */,
 				CC84C94A18ECE161001F6094 /* FakeOCUnitTestRunner.h */,
 				CC84C94B18ECE161001F6094 /* FakeOCUnitTestRunner.m */,
+				CCCF099B1C1286B4006F08C4 /* FakeSimDevice.h */,
+				CCCF099C1C1286B4006F08C4 /* FakeSimDevice.m */,
 				28E9B99016C3037E00A52E4D /* FakeTask.h */,
 				28E9B99116C3037E00A52E4D /* FakeTask.m */,
 				2889805E1742B675004BA024 /* FakeTaskManager.h */,
@@ -587,6 +594,7 @@
 				28E28FBF1797193F0072376C /* ReporterTaskTests.m */,
 				28C81A62175562050072DDB8 /* ReportStatusTests.m */,
 				283479A416E1B242003C3B77 /* RunTestsActionTests.m */,
+				CCCF09991C126D23006F08C4 /* SimulatorWrapperTests.m */,
 				283CCAC616C2EE9900F2E343 /* Supporting Files */,
 				28A5A8EB1746D2AA001733A9 /* Swizzler.h */,
 				28A5A8EC1746D2AA001733A9 /* Swizzler.m */,
@@ -946,6 +954,7 @@
 				28E9B9DA16C3275200A52E4D /* OCUnitIOSLogicTestRunner.m in Sources */,
 				28E9B9DC16C3275200A52E4D /* OCUnitTestRunner.m in Sources */,
 				28046D2D16D7603B000AA15C /* Action.m in Sources */,
+				CCCF099A1C126D23006F08C4 /* SimulatorWrapperTests.m in Sources */,
 				2862C1B6180DE7BA00E5F58B /* XCToolUtilTests.m in Sources */,
 				AAC1E0C218121AC6005A4FD5 /* OCUnitIOSAppTestQueryRunner.m in Sources */,
 				28046D3016D76665000AA15C /* ActionTests.m in Sources */,
@@ -980,6 +989,7 @@
 				28A5A8F01746D2B9001733A9 /* SwizzlerTests.m in Sources */,
 				CDD81F2F174ABA2700F42111 /* SchemeGenerator.m in Sources */,
 				AAF334481806A46F00928A00 /* LaunchHandlers.m in Sources */,
+				CCCF099D1C1286B4006F08C4 /* FakeSimDevice.m in Sources */,
 				CDD81F52174EAFDC00F42111 /* EventBuffer.m in Sources */,
 				AAC1E0BE18121071005A4FD5 /* OCUnitIOSLogicTestQueryRunner.m in Sources */,
 				CC4AB1FB1B82C57F00543A42 /* TestableExecutionInfoTests.m in Sources */,

--- a/xctool/xctool.xcodeproj/project.pbxproj
+++ b/xctool/xctool.xcodeproj/project.pbxproj
@@ -816,7 +816,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastTestingUpgradeCheck = 0700;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = "Facebook, Inc.";
 			};
 			buildConfigurationList = 283CCA3D16C2EA3700F2E343 /* Build configuration list for PBXProject "xctool" */;
@@ -1108,6 +1108,7 @@
 				);
 				GCC_PREFIX_HEADER = "xctool-tests/xctool-tests-Prefix.pch";
 				INFOPLIST_FILE = "xctool-tests/xctool-tests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "xctool-tests";
 				SKIP_INSTALL = YES;
 			};
@@ -1125,6 +1126,7 @@
 				);
 				GCC_PREFIX_HEADER = "xctool-tests/xctool-tests-Prefix.pch";
 				INFOPLIST_FILE = "xctool-tests/xctool-tests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.facebook.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "xctool-tests";
 				SKIP_INSTALL = YES;
 			};

--- a/xctool/xctool.xcodeproj/xcshareddata/xcschemes/xctool.xcscheme
+++ b/xctool/xctool.xcodeproj/xcshareddata/xcschemes/xctool.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0710"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/xctool/xctool/OCUnitIOSAppTestRunner.m
+++ b/xctool/xctool/OCUnitIOSAppTestRunner.m
@@ -202,10 +202,6 @@ static const NSInteger kMaxRunTestsAttempts = 3;
     [NSThread sleepForTimeInterval:1];
   }
 
-  ReportStatusMessage(_reporters,
-                      REPORTER_MESSAGE_INFO,
-                      @"Launching test host and running tests ...");
-
   NSArray *appLaunchArgs = nil;
   NSMutableDictionary *appLaunchEnvironment = [_simulatorInfo simulatorLaunchEnvironment];
   if (ToolchainIsXcode7OrBetter()) {
@@ -226,6 +222,7 @@ static const NSInteger kMaxRunTestsAttempts = 3;
                                                   arguments:appLaunchArgs
                                                 environment:appLaunchEnvironment
                                           feedOutputToBlock:outputLineBlock
+                                                  reporters:_reporters
                                                       error:&error];
 
     if (infraSucceeded) {

--- a/xctool/xctool/SimulatorWrapper/SimulatorUtils.h
+++ b/xctool/xctool/SimulatorWrapper/SimulatorUtils.h
@@ -22,3 +22,4 @@ void KillSimulatorJobs();
 BOOL RemoveSimulatorContentAndSettings(SimulatorInfo *simulatorInfo, NSString **removedPath, NSString **errorMessage);
 BOOL ShutdownSimulator(SimulatorInfo *simulatorInfo, NSString **errorMessage);
 BOOL VerifySimulators(NSString **errorMessage);
+BOOL RunSimulatorBlockWithTimeout(dispatch_block_t block);

--- a/xctool/xctool/SimulatorWrapper/SimulatorUtils.m
+++ b/xctool/xctool/SimulatorWrapper/SimulatorUtils.m
@@ -23,7 +23,7 @@
 #import "SimVerifier.h"
 #import "XCToolUtil.h"
 
-static const dispatch_time_t kDefaultSimulatorBlockTimeout = 15;
+static const dispatch_time_t kDefaultSimulatorBlockTimeout = 30;
 
 static void GetJobsIterator(const launch_data_t launch_data, const char *key, void *context) {
   void (^block)(const launch_data_t, const char *) = (__bridge void (^)(const launch_data_t, const char *))(context);
@@ -224,7 +224,8 @@ BOOL ShutdownSimulator(SimulatorInfo *simulatorInfo, NSString **errorMessage)
 
 BOOL RunSimulatorBlockWithTimeout(dispatch_block_t block)
 {
-  dispatch_time_t timer = dispatch_time(DISPATCH_TIME_NOW, kDefaultSimulatorBlockTimeout * NSEC_PER_SEC);
+  dispatch_time_t timeout = IsRunningUnderTest() ? 5 : kDefaultSimulatorBlockTimeout;
+  dispatch_time_t timer = dispatch_time(DISPATCH_TIME_NOW, timeout * NSEC_PER_SEC);
   dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
     block();

--- a/xctool/xctool/SimulatorWrapper/SimulatorUtils.m
+++ b/xctool/xctool/SimulatorWrapper/SimulatorUtils.m
@@ -23,6 +23,8 @@
 #import "SimVerifier.h"
 #import "XCToolUtil.h"
 
+static const dispatch_time_t kDefaultSimulatorBlockTimeout = 15;
+
 static void GetJobsIterator(const launch_data_t launch_data, const char *key, void *context) {
   void (^block)(const launch_data_t, const char *) = (__bridge void (^)(const launch_data_t, const char *))(context);
   block(launch_data, key);
@@ -139,16 +141,25 @@ BOOL RemoveSimulatorContentAndSettingsFolder(NSString *simulatorVersion, cpu_typ
 BOOL RemoveSimulatorContentAndSettings(SimulatorInfo *simulatorInfo, NSString **removedPath, NSString **errorMessage)
 {
   SimDevice *simulatedDevice = [simulatorInfo simulatedDevice];
-  NSError *error = nil;
+  __block NSError *error = nil;
+  __block BOOL erased = NO;
   *removedPath = [simulatedDevice dataPath];
-  if ([simulatedDevice eraseContentsAndSettingsWithError:&error]) {
-    return YES;
-  } else {
+  if (!RunSimulatorBlockWithTimeout(^{
+    erased = [simulatedDevice eraseContentsAndSettingsWithError:&error];
+  })) {
+    error = [NSError errorWithDomain:@"com.facebook.xctool.sim.erase.timeout"
+                                code:0
+                            userInfo:@{
+      NSLocalizedDescriptionKey: @"Timed out while erasing contents and settings of a simulator.",
+    }];
+  }
+
+  if (!erased) {
     *errorMessage = [NSString stringWithFormat:@"%@; %@.",
                      error.localizedDescription ?: @"Unknown error.",
                      [error.userInfo[NSUnderlyingErrorKey] localizedDescription] ?: @""];
-    return NO;
   }
+  return erased;
 }
 
 BOOL VerifySimulators(NSString **errorMessage)
@@ -171,7 +182,6 @@ BOOL VerifySimulators(NSString **errorMessage)
 BOOL ShutdownSimulator(SimulatorInfo *simulatorInfo, NSString **errorMessage)
 {
   SimDevice *simulatedDevice = [simulatorInfo simulatedDevice];
-  NSError *error = nil;
 
   /*
    * In Xcode 6 there is a `simBridgeDistantObject` property
@@ -191,7 +201,18 @@ BOOL ShutdownSimulator(SimulatorInfo *simulatorInfo, NSString **errorMessage)
   }
 
   if (simulatedDevice.state != SimDeviceStateShutdown) {
-    if (![simulatedDevice shutdownWithError:&error]) {
+    __block NSError *error = nil;
+    __block BOOL shutdown = NO;
+    if (!RunSimulatorBlockWithTimeout(^{
+      shutdown = [simulatedDevice shutdownWithError:&error];
+    })) {
+      error = [NSError errorWithDomain:@"com.facebook.xctool.sim.shutdown.timeout"
+                                  code:0
+                              userInfo:@{
+        NSLocalizedDescriptionKey: @"Timed out.",
+      }];
+    }
+    if (!shutdown) {
       *errorMessage = [NSString stringWithFormat:@"Tried to shutdown the simulator but failed: %@; %@.",
                        error.localizedDescription ?: @"Unknown error.",
                        [error.userInfo[NSUnderlyingErrorKey] localizedDescription] ?: @""];
@@ -199,4 +220,15 @@ BOOL ShutdownSimulator(SimulatorInfo *simulatorInfo, NSString **errorMessage)
     }
   }
   return YES;
+}
+
+BOOL RunSimulatorBlockWithTimeout(dispatch_block_t block)
+{
+  dispatch_time_t timer = dispatch_time(DISPATCH_TIME_NOW, kDefaultSimulatorBlockTimeout * NSEC_PER_SEC);
+  dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0), ^{
+    block();
+    dispatch_semaphore_signal(semaphore);
+  });
+  return dispatch_semaphore_wait(semaphore, timer) == 0;
 }

--- a/xctool/xctool/SimulatorWrapper/SimulatorWrapper.h
+++ b/xctool/xctool/SimulatorWrapper/SimulatorWrapper.h
@@ -42,6 +42,7 @@
               arguments:(NSArray *)arguments
             environment:(NSDictionary *)environment
       feedOutputToBlock:(FdOutputLineFeedBlock)feedOutputToBlock
+              reporters:(NSArray *)reporters
                   error:(NSError **)error;
 
 + (BOOL)prepareSimulator:(SimDevice *)device

--- a/xctool/xctool/SimulatorWrapper/SimulatorWrapper.h
+++ b/xctool/xctool/SimulatorWrapper/SimulatorWrapper.h
@@ -44,6 +44,10 @@
       feedOutputToBlock:(FdOutputLineFeedBlock)feedOutputToBlock
                   error:(NSError **)error;
 
++ (BOOL)prepareSimulator:(SimDevice *)device
+               reporters:(NSArray *)reporters
+                   error:(NSString **)error;
+
 + (BOOL)uninstallTestHostBundleID:(NSString *)testHostBundleID
                            device:(SimDevice *)device
                         reporters:(NSArray *)reporters

--- a/xctool/xctool/SimulatorWrapper/SimulatorWrapper.m
+++ b/xctool/xctool/SimulatorWrapper/SimulatorWrapper.m
@@ -211,7 +211,7 @@ static const NSString * kOptionsWaitForDebuggerKey = @"wait_for_debugger";
   } else {
     ReportStatusMessageEnd(reporters,
                            REPORTER_MESSAGE_WARNING,
-                           @"Tried to uninstall the test host app '%@' but failed.",
+                           @"Failed to uninstall the test host app '%@'.",
                            testHostBundleID);
   }
   return uninstalled;
@@ -241,7 +241,7 @@ static const NSString * kOptionsWaitForDebuggerKey = @"wait_for_debugger";
   } else {
     ReportStatusMessageEnd(reporters,
                            REPORTER_MESSAGE_WARNING,
-                           @"Tried to install the test host app '%@' but failed.",
+                           @"Failed to install the test host app '%@'.",
                            testHostBundleID);
   }
   return installed;

--- a/xctool/xctool/SimulatorWrapper/SimulatorWrapper.m
+++ b/xctool/xctool/SimulatorWrapper/SimulatorWrapper.m
@@ -135,6 +135,32 @@ static const NSString * kOptionsWaitForDebuggerKey = @"wait_for_debugger";
 
 #pragma mark Installation Methods
 
++ (BOOL)prepareSimulator:(SimDevice *)device
+               reporters:(NSArray *)reporters
+                   error:(NSString **)error
+{
+  ReportStatusMessageBegin(reporters,
+                           REPORTER_MESSAGE_INFO,
+                           @"Preparing '%@' simulator to run tests ...",
+                           device.name);
+
+  BOOL prepared = [[self classBasedOnCurrentVersionOfXcode] prepareSimulator:device
+                                                                   reporters:reporters
+                                                                       error:error];
+  if (prepared) {
+    ReportStatusMessageEnd(reporters,
+                           REPORTER_MESSAGE_INFO,
+                           @"Prepared '%@' simulator to run tests.",
+                           device.name);
+  } else {
+    ReportStatusMessageEnd(reporters,
+                           REPORTER_MESSAGE_WARNING,
+                           @"Failed to prepare '%@' simulator to run tests.",
+                           device.name);
+  }
+  return prepared;
+}
+
 + (BOOL)uninstallTestHostBundleID:(NSString *)testHostBundleID
                            device:(SimDevice *)device
                         reporters:(NSArray *)reporters


### PR DESCRIPTION
Next CoreSimulator methods could stuck forever in Xcode 7.1 and Xcode 7.2 beta:
```
- (BOOL)applicationIsInstalled:(NSString *)bundleId type:(NSString **)arg2 error:(NSError **)error;
- (BOOL)installApplication:(NSURL *)appURL withOptions:(NSDictionary *)options error:(NSError **)error;
- (BOOL)uninstallApplication:(NSString *)bundleId withOptions:(NSDictionary *)options error:(NSError **)error;
- (int)launchApplicationWithID:(id)arg1 options:(NSDictionary *)options error:(NSError **)error;
- (BOOL)eraseContentsAndSettingsWithError:(id *)arg1;
- (BOOL)shutdownWithError:(id *)arg1;
```
Since xctool executes them on the main thread it can put the tool into a deadlock. To avoid that we will wait for CoreSimulator responses only a particular amount of time and then "forget" about them and try to remediate by killing all simulator related processes.

xctool already have retry mechanism around these calls so we don't need to do that in this PR.

Current default timeout was chosen to be 15 seconds.