### PR TITLE
Improve `-only` and `-omit` options behavior.

### DIFF
--- a/otest-query/otest-query.xcodeproj/project.pbxproj
+++ b/otest-query/otest-query.xcodeproj/project.pbxproj
@@ -353,7 +353,7 @@
 		CD9048F61756C5B1006CF16D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0710;
+				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = Facebook;
 			};
 			buildConfigurationList = CD9048F91756C5B1006CF16D /* Build configuration list for PBXProject "otest-query" */;

--- a/otest-shim/otest-shim.xcodeproj/project.pbxproj
+++ b/otest-shim/otest-shim.xcodeproj/project.pbxproj
@@ -287,7 +287,7 @@
 		283CCA8416C2EE4C00F2E343 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0710;
+				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = "Facebook, Inc.";
 			};
 			buildConfigurationList = 283CCA8716C2EE4C00F2E343 /* Build configuration list for PBXProject "otest-shim" */;

--- a/reporters/reporters.xcodeproj/project.pbxproj
+++ b/reporters/reporters.xcodeproj/project.pbxproj
@@ -712,7 +712,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastTestingUpgradeCheck = 0700;
-				LastUpgradeCheck = 0710;
+				LastUpgradeCheck = 0720;
 			};
 			buildConfigurationList = 2893A94117960CAD00EFBD28 /* Build configuration list for PBXProject "reporters" */;
 			compatibilityVersion = "Xcode 3.2";

--- a/xcodebuild-shim/xcodebuild-shim.xcodeproj/project.pbxproj
+++ b/xcodebuild-shim/xcodebuild-shim.xcodeproj/project.pbxproj
@@ -221,7 +221,7 @@
 		283CCAA116C2EE7200F2E343 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0710;
+				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = "Facebook, Inc.";
 			};
 			buildConfigurationList = 283CCAA416C2EE7200F2E343 /* Build configuration list for PBXProject "xcodebuild-shim" */;

--- a/xctool/xctool-tests/OCUnitTestRunnerTests.m
+++ b/xctool/xctool-tests/OCUnitTestRunnerTests.m
@@ -576,139 +576,247 @@ static int NumberOfEntries(NSArray *array, NSObject *target)
 - (void)testClassNameDiscoveryFiltering
 {
   NSArray *testCases = @[
-                         @"Cls1/test1",
-                         @"Cls1/test2",
-                         @"Cls1/test3",
-                         @"Cls2/test1",
-                         @"Cls2/test2",
-                         @"Cls3/test1",
-                         @"OtherClass1/test1",
-                         @"OtherClass2/test1",
-                         @"OtherClass2/test2",
-                         @"OtherNonmatching/testOne",
-                         @"OtherNonmatching/testThree",
-                         @"OtherNonmatching/testTwo",
-                         ];
+    @"Cls1/test1",
+    @"Cls1/test2",
+    @"Cls1/test3",
+    @"Cls2/test1",
+    @"Cls2/test2",
+    @"Cls3/test1",
+    @"OtherClass1/test1",
+    @"OtherClass2/test1",
+    @"OtherClass2/test2",
+    @"OtherNonmatching/testOne",
+    @"OtherNonmatching/testThree",
+    @"OtherNonmatching/testTwo",
+  ];
   NSString *error = nil;
-  assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"All" senTestInvertScope:NO error:&error],
-             equalTo(testCases));
-  assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"None" senTestInvertScope:NO error:&error],
-             equalTo(@[]));
-  XCTAssertNil(error, @"Error shouldn't be set");
-  assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"Cls1" senTestInvertScope:NO error:&error],
-             equalTo(@[
-                     @"Cls1/test1",
-                     @"Cls1/test2",
-                     @"Cls1/test3",
-                     ]));
-  XCTAssertNil(error, @"Error shouldn't be set");
-  assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"Cls1" senTestInvertScope:YES error:&error],
-             equalTo(@[
-                     @"Cls2/test1",
-                     @"Cls2/test2",
-                     @"Cls3/test1",
-                     @"OtherClass1/test1",
-                     @"OtherClass2/test1",
-                     @"OtherClass2/test2",
-                     @"OtherNonmatching/testOne",
-                     @"OtherNonmatching/testThree",
-                     @"OtherNonmatching/testTwo",
-                     ]));
-  XCTAssertNil(error, @"Error shouldn't be set");
-  assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"Cls1,Cls2/test1,Cls3" senTestInvertScope:NO error:&error],
-             equalTo(@[
-                     @"Cls1/test1",
-                     @"Cls1/test2",
-                     @"Cls1/test3",
-                     @"Cls2/test1",
-                     @"Cls3/test1"
-                     ]));
-  XCTAssertNil(error, @"Error shouldn't be set");
-  assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"Cls1,Cls2/test1,Cls3" senTestInvertScope:YES error:&error],
-             equalTo(@[
-                     @"Cls2/test2",
-                     @"OtherClass1/test1",
-                     @"OtherClass2/test1",
-                     @"OtherClass2/test2",
-                     @"OtherNonmatching/testOne",
-                     @"OtherNonmatching/testThree",
-                     @"OtherNonmatching/testTwo",
-                     ]));
-  XCTAssertNil(error, @"Error shouldn't be set");
+  NSArray *onlyTestCases = nil;
+  NSArray *skipTestCases = nil;
 
-  // Class prefix cases
-  assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"Other*" senTestInvertScope:NO error:&error],
-             equalTo(@[
-                       @"OtherClass1/test1",
-                       @"OtherClass2/test1",
-                       @"OtherClass2/test2",
-                       @"OtherNonmatching/testOne",
-                       @"OtherNonmatching/testThree",
-                       @"OtherNonmatching/testTwo",
-                       ]));
-  XCTAssertNil(error, @"Error shouldn't be set");
+  // all test cases
+  assertThat([OCUnitTestRunner filterTestCases:testCases onlyTestCases:nil skippedTestCases:nil error:&error], equalTo(testCases));
+  assertThat(error, nilValue());
 
-  assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"Cls*" senTestInvertScope:NO error:&error],
-             equalTo(@[
-                       @"Cls1/test1",
-                       @"Cls1/test2",
-                       @"Cls1/test3",
-                       @"Cls2/test1",
-                       @"Cls2/test2",
-                       @"Cls3/test1"
-                       ]));
-  XCTAssertNil(error, @"Error shouldn't be set");
+  // no test cases, skip all
+  assertThat([OCUnitTestRunner filterTestCases:testCases onlyTestCases:nil skippedTestCases:testCases error:&error], equalTo(@[]));
+  assertThat(error, nilValue());
 
-  assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"OtherC*" senTestInvertScope:NO error:&error],
-             equalTo(@[
-                       @"OtherClass1/test1",
-                       @"OtherClass2/test1",
-                       @"OtherClass2/test2"
-                       ]));
-  XCTAssertNil(error, @"Error shouldn't be set");
+  // skip specified test cases
+  skipTestCases = @[
+    @"Cls2/test1",
+    @"Cls2/test2",
+    @"Cls3/test1",
+    @"OtherClass1/test1",
+    @"OtherClass2/test1",
+    @"OtherClass2/test2",
+    @"OtherNonmatching/testOne",
+    @"OtherNonmatching/testThree",
+    @"OtherNonmatching/testTwo",
+  ];
+  assertThat([OCUnitTestRunner filterTestCases:testCases onlyTestCases:nil skippedTestCases:skipTestCases error:&error], equalTo(@[
+    @"Cls1/test1",
+    @"Cls1/test2",
+    @"Cls1/test3",
+  ]));
+  assertThat(error, nilValue());
 
-  // Test prefix cases
-  assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"OtherClass1/test*" senTestInvertScope:NO error:&error],
-             equalTo(@[
-                       @"OtherClass1/test1",
-                       ]));
-  XCTAssertNil(error, @"Error shouldn't be set");
+  // skip specified class and test cases
+  skipTestCases = @[
+    @"Cls1",
+    @"Cls2/test1",
+    @"Cls3",
+  ];
+  assertThat([OCUnitTestRunner filterTestCases:testCases onlyTestCases:nil skippedTestCases:skipTestCases error:&error], equalTo(@[
+    @"Cls2/test2",
+    @"OtherClass1/test1",
+    @"OtherClass2/test1",
+    @"OtherClass2/test2",
+    @"OtherNonmatching/testOne",
+    @"OtherNonmatching/testThree",
+    @"OtherNonmatching/testTwo",
+  ]));
+  assertThat(error, nilValue());
 
-  assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"OtherClass2/test*" senTestInvertScope:NO error:&error],
-             equalTo(@[
-                       @"OtherClass2/test1",
-                       @"OtherClass2/test2",
-                       ]));
-  XCTAssertNil(error, @"Error shouldn't be set");
+  // class prefix cases (skip)
+  assertThat([OCUnitTestRunner filterTestCases:testCases onlyTestCases:nil skippedTestCases:@[@"Other*"] error:&error], equalTo(@[
+    @"Cls1/test1",
+    @"Cls1/test2",
+    @"Cls1/test3",
+    @"Cls2/test1",
+    @"Cls2/test2",
+    @"Cls3/test1",
+  ]));
+  assertThat(error, nilValue());
 
-  assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"Cls1/t*" senTestInvertScope:NO error:&error],
-             equalTo(@[
-                       @"Cls1/test1",
-                       @"Cls1/test2",
-                       @"Cls1/test3",
-                       ]));
-  XCTAssertNil(error, @"Error shouldn't be set");
+  // test prefix cases (skip)
+  assertThat([OCUnitTestRunner filterTestCases:testCases onlyTestCases:nil skippedTestCases:@[@"OtherNonmatching/testT*"] error:&error], equalTo(@[
+    @"Cls1/test1",
+    @"Cls1/test2",
+    @"Cls1/test3",
+    @"Cls2/test1",
+    @"Cls2/test2",
+    @"Cls3/test1",
+    @"OtherClass1/test1",
+    @"OtherClass2/test1",
+    @"OtherClass2/test2",
+    @"OtherNonmatching/testOne",
+  ]));
+  assertThat(error, nilValue());
 
-  assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"OtherNonmatching/*" senTestInvertScope:NO error:&error],
-             equalTo(@[
-                       @"OtherNonmatching/testOne",
-                       @"OtherNonmatching/testThree",
-                       @"OtherNonmatching/testTwo",
-                       ]));
-  XCTAssertNil(error, @"Error shouldn't be set");
+  // only specified class test cases
+  assertThat([OCUnitTestRunner filterTestCases:testCases onlyTestCases:@[@"Cls1"] skippedTestCases:nil error:&error], equalTo(@[
+    @"Cls1/test1",
+    @"Cls1/test2",
+    @"Cls1/test3",
+  ]));
+  assertThat(error, nilValue());
 
-  assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"OtherNonmatching/testO*" senTestInvertScope:NO error:&error],
-             equalTo(@[
-                       @"OtherNonmatching/testOne",
-                       ]));
-  XCTAssertNil(error, @"Error shouldn't be set");
+  // only specified classes and test case
+  onlyTestCases = @[
+    @"Cls1",
+    @"Cls2/test1",
+    @"Cls3",
+  ];
+  assertThat([OCUnitTestRunner filterTestCases:testCases onlyTestCases:onlyTestCases skippedTestCases:nil error:&error], equalTo(@[
+    @"Cls1/test1",
+    @"Cls1/test2",
+    @"Cls1/test3",
+    @"Cls2/test1",
+    @"Cls3/test1"
+  ]));
+  assertThat(error, nilValue());
 
-  assertThat([OCUnitTestRunner filterTestCases:testCases withSenTestList:@"OtherNonmatching/testT*" senTestInvertScope:NO error:&error],
-             equalTo(@[
-                       @"OtherNonmatching/testThree",
-                       @"OtherNonmatching/testTwo",
-                       ]));
-  XCTAssertNil(error, @"Error shouldn't be set");
+  // class prefix cases (only)
+  assertThat([OCUnitTestRunner filterTestCases:testCases onlyTestCases:@[@"Other*"] skippedTestCases:nil error:&error], equalTo(@[
+    @"OtherClass1/test1",
+    @"OtherClass2/test1",
+    @"OtherClass2/test2",
+    @"OtherNonmatching/testOne",
+    @"OtherNonmatching/testThree",
+    @"OtherNonmatching/testTwo",
+  ]));
+  assertThat(error, nilValue());
+
+  assertThat([OCUnitTestRunner filterTestCases:testCases onlyTestCases:@[@"Cls*"] skippedTestCases:nil error:&error], equalTo(@[
+    @"Cls1/test1",
+    @"Cls1/test2",
+    @"Cls1/test3",
+    @"Cls2/test1",
+    @"Cls2/test2",
+    @"Cls3/test1",
+  ]));
+  assertThat(error, nilValue());
+
+  assertThat([OCUnitTestRunner filterTestCases:testCases onlyTestCases:@[@"OtherC*"] skippedTestCases:nil error:&error], equalTo(@[
+    @"OtherClass1/test1",
+    @"OtherClass2/test1",
+    @"OtherClass2/test2",
+  ]));
+  assertThat(error, nilValue());
+
+  // test prefix cases (only)
+  assertThat([OCUnitTestRunner filterTestCases:testCases onlyTestCases:@[@"OtherClass1/test*"] skippedTestCases:nil error:&error], equalTo(@[
+    @"OtherClass1/test1",
+  ]));
+  assertThat(error, nilValue());
+
+  assertThat([OCUnitTestRunner filterTestCases:testCases onlyTestCases:@[@"OtherClass2/test*"] skippedTestCases:nil error:&error], equalTo(@[
+    @"OtherClass2/test1",
+    @"OtherClass2/test2",
+  ]));
+  assertThat(error, nilValue());
+
+  assertThat([OCUnitTestRunner filterTestCases:testCases onlyTestCases:@[@"Cls1/t*"] skippedTestCases:nil error:&error], equalTo(@[
+    @"Cls1/test1",
+    @"Cls1/test2",
+    @"Cls1/test3",
+  ]));
+  assertThat(error, nilValue());
+
+  assertThat([OCUnitTestRunner filterTestCases:testCases onlyTestCases:@[@"OtherNonmatching/*"] skippedTestCases:nil error:&error], equalTo(@[
+    @"OtherNonmatching/testOne",
+    @"OtherNonmatching/testThree",
+    @"OtherNonmatching/testTwo",
+  ]));
+  assertThat(error, nilValue());
+
+  assertThat([OCUnitTestRunner filterTestCases:testCases onlyTestCases:@[@"OtherNonmatching/testO*"] skippedTestCases:nil error:&error], equalTo(@[
+    @"OtherNonmatching/testOne",
+  ]));
+  assertThat(error, nilValue());
+
+  assertThat([OCUnitTestRunner filterTestCases:testCases onlyTestCases:@[@"OtherNonmatching/testT*"] skippedTestCases:nil error:&error], equalTo(@[
+    @"OtherNonmatching/testThree",
+    @"OtherNonmatching/testTwo",
+  ]));
+  assertThat(error, nilValue());
+
+  // test only non-existing test case/class
+  assertThat([OCUnitTestRunner filterTestCases:testCases onlyTestCases:@[@"OtherClassR"] skippedTestCases:nil error:&error], nilValue());
+  assertThat(error, equalTo(@"Test cases for the following test specifiers weren't found: OtherClassR."));
+  error = nil;
+
+  assertThat([OCUnitTestRunner filterTestCases:testCases onlyTestCases:@[@"OtherClass1/testR"] skippedTestCases:nil error:&error], nilValue());
+  assertThat(error, equalTo(@"Test cases for the following test specifiers weren't found: OtherClass1/testR."));
+  error = nil;
+
+  assertThat([OCUnitTestRunner filterTestCases:testCases onlyTestCases:@[@"OtherClassR*"] skippedTestCases:nil error:&error], nilValue());
+  assertThat(error, equalTo(@"Test cases for the following test specifiers weren't found: OtherClassR*."));
+  error = nil;
+
+  assertThat([OCUnitTestRunner filterTestCases:testCases onlyTestCases:@[@"OtherClass1/testR*"] skippedTestCases:nil error:&error], nilValue());
+  assertThat(error, equalTo(@"Test cases for the following test specifiers weren't found: OtherClass1/testR*."));
+  error = nil;
+
+  // test only and skip test cases at the same time
+  onlyTestCases = @[
+    @"Cls1",
+    @"Cls2/test1",
+    @"Cls3",
+  ];
+  skipTestCases = @[
+    @"Cls1",
+  ];
+  assertThat([OCUnitTestRunner filterTestCases:testCases onlyTestCases:onlyTestCases skippedTestCases:skipTestCases error:&error], equalTo(@[
+    @"Cls2/test1",
+    @"Cls3/test1",
+  ]));
+  assertThat(error, nilValue());
+
+  onlyTestCases = @[
+    @"Cls1",
+    @"Cls2/test1",
+  ];
+  skipTestCases = @[
+    @"Cls3",
+  ];
+  assertThat([OCUnitTestRunner filterTestCases:testCases onlyTestCases:onlyTestCases skippedTestCases:skipTestCases error:&error], equalTo(@[
+    @"Cls1/test1",
+    @"Cls1/test2",
+    @"Cls1/test3",
+    @"Cls2/test1",
+  ]));
+  assertThat(error, nilValue());
+
+  onlyTestCases = @[
+    @"OtherNonmatching/test*",
+  ];
+  skipTestCases = @[
+    @"OtherNonmatching/testT*",
+  ];
+  assertThat([OCUnitTestRunner filterTestCases:testCases onlyTestCases:onlyTestCases skippedTestCases:skipTestCases error:&error], equalTo(@[
+    @"OtherNonmatching/testOne",
+  ]));
+  assertThat(error, nilValue());
+
+  onlyTestCases = @[
+    @"OtherNonmatching/test*",
+  ];
+  skipTestCases = @[
+    @"OtherNonmatching/test*",
+  ];
+  assertThat([OCUnitTestRunner filterTestCases:testCases onlyTestCases:onlyTestCases skippedTestCases:skipTestCases error:&error], equalTo(@[]));
+  assertThat(error, nilValue());
 }
 
 @end

--- a/xctool/xctool-tests/XcodeSubjectInfoTests.m
+++ b/xctool/xctool-tests/XcodeSubjectInfoTests.m
@@ -353,8 +353,7 @@
   assertThat(testable.environment, equalTo(@{}));
   assertThat(testable.executable, equalTo(@"TestProject-LibraryTests.octest"));
   assertThat(testable.projectPath, endsWith(@"xctool-tests/TestData/TestProject-Library/TestProject-Library.xcodeproj"));
-  assertThatBool(testable.senTestInvertScope, isTrue());
-  assertThat(testable.senTestList, equalTo(@"DisabledTests"));
+  assertThat(testable.skippedTests, equalTo(@[@"DisabledTests"]));
   assertThatBool(testable.skipped, isFalse());
   assertThat(testable.target, equalTo(@"TestProject-LibraryTests"));
   assertThat(testable.targetID, equalTo(@"2828293016B11F0F00426B92"));
@@ -382,8 +381,7 @@
   assertThat(testable.macroExpansionTarget, equalTo(nil));
   assertThat(testable.executable, equalTo(@"TestsWithArgAndEnvSettingsTests.octest"));
   assertThat(testable.projectPath, endsWith(@"xctool-tests/TestData/TestsWithArgAndEnvSettingsInRunAction/TestsWithArgAndEnvSettings.xcodeproj"));
-  assertThatBool(testable.senTestInvertScope, isFalse());
-  assertThat(testable.senTestList, equalTo(@"All"));
+  assertThat(testable.skippedTests, equalTo(@[]));
   assertThatBool(testable.skipped, isFalse());
   assertThat(testable.target, equalTo(@"TestsWithArgAndEnvSettingsTests"));
   assertThat(testable.targetID, equalTo(@"288DD482173B7C9800F1093C"));
@@ -412,8 +410,7 @@
   assertThat(testable.macroExpansionTarget, equalTo(nil));
   assertThat(testable.executable, equalTo(@"TestsWithArgAndEnvSettingsTests.octest"));
   assertThat(testable.projectPath, endsWith(@"xctool-tests/TestData/TestsWithArgAndEnvSettingsInTestAction/TestsWithArgAndEnvSettings.xcodeproj"));
-  assertThatBool(testable.senTestInvertScope, isFalse());
-  assertThat(testable.senTestList, equalTo(@"All"));
+  assertThat(testable.skippedTests, equalTo(@[]));
   assertThatBool(testable.skipped, isFalse());
   assertThat(testable.target, equalTo(@"TestsWithArgAndEnvSettingsTests"));
   assertThat(testable.targetID, equalTo(@"288DD482173B7C9800F1093C"));
@@ -445,8 +442,7 @@
   assertThat(testable.macroExpansionTarget, equalTo(@"TestsWithArgAndEnvSettings"));
   assertThat(testable.executable, equalTo(@"TestsWithArgAndEnvSettingsTests.octest"));
   assertThat(testable.projectPath, endsWith(@"xctool-tests/TestData/TestsWithArgAndEnvSettingsWithMacroExpansion/TestsWithArgAndEnvSettings.xcodeproj"));
-  assertThatBool(testable.senTestInvertScope, isFalse());
-  assertThat(testable.senTestList, equalTo(@"All"));
+  assertThat(testable.skippedTests, equalTo(@[]));
   assertThatBool(testable.skipped, isFalse());
   assertThat(testable.target, equalTo(@"TestsWithArgAndEnvSettingsTests"));
   assertThat(testable.targetID, equalTo(@"288DD482173B7C9800F1093C"));

--- a/xctool/xctool.xcodeproj/project.pbxproj
+++ b/xctool/xctool.xcodeproj/project.pbxproj
@@ -824,7 +824,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastTestingUpgradeCheck = 0700;
-				LastUpgradeCheck = 0710;
+				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = "Facebook, Inc.";
 			};
 			buildConfigurationList = 283CCA3D16C2EA3700F2E343 /* Build configuration list for PBXProject "xctool" */;

--- a/xctool/xctool.xcodeproj/xcshareddata/xcschemes/xctool.xcscheme
+++ b/xctool/xctool.xcodeproj/xcshareddata/xcschemes/xctool.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"

--- a/xctool/xctool/OCUnitTestRunner.h
+++ b/xctool/xctool/OCUnitTestRunner.h
@@ -42,16 +42,20 @@
 @property (nonatomic, copy, readonly) NSArray *reporters;
 
 /**
- * Filters a list of test class names to only those that match the
- * senTestList and senTestInvertScope constraints.
+ * Filters a list of test cases by removing test cases with names matching
+ * `skippedTestCases` constraints and, if set, all tests cases not matching
+ * `onlyTestCases` ones.
  *
- * @param testCases An array of test cases ('ClassA/test1', 'ClassB/test2', 'Class*', 'Class', 'ClassA/test*')
- * @param senTestList SenTestList string.  e.g. "All", "None", "ClsA,ClsB"
- * @param senTestInvertScope YES if scope should be inverted.
+ * @param allTestCases An array of test cases ('ClassA/test1', 'ClassB/test2', 'Class')
+ * @param onlyTestCases An array of test case name constraints defining what test
+ *                      cases should only be included ('Class*', 'Class1', 'ClassA/test*', 'ClassB/test2')
+ * @param skippedTestCases An array of test case name constraints defining what test 
+ *                         cases should be removed ('Class*', 'Class1', 'ClassA/test*', 'ClassB/test2')
+ * @param error An output parameter which is set if error occures during filtering.
  */
-+ (NSArray *)filterTestCases:(NSArray *)testCases
-             withSenTestList:(NSString *)senTestList
-          senTestInvertScope:(BOOL)senTestInvertScope
++ (NSArray *)filterTestCases:(NSArray *)allTestCases
+               onlyTestCases:(NSArray *)onlyTestCases
+            skippedTestCases:(NSArray *)skippedTestCases
                        error:(NSString **)error;
 
 - (instancetype)initWithBuildSettings:(NSDictionary *)buildSettings

--- a/xctool/xctool/Testable.h
+++ b/xctool/xctool/Testable.h
@@ -21,18 +21,18 @@
 @interface Testable : Buildable <NSCopying>
 
 /**
- * If no tests are set to be skipped in the Xcode scheme, then `senTestList`
- * will be 'All', and `senTestInvertScope` will be NO.
- *
- * Otherwise, `senTestList` will be a comma seperated list of classes and tests
- * that should be skipped, and the `senTestInvertScope` will be YES.
+ * Tests that are set to be skipped in the Xcode scheme.
  */
-@property (nonatomic, copy) NSString *senTestList;
-@property (nonatomic, assign) BOOL senTestInvertScope;
+@property (nonatomic, copy) NSArray *skippedTests;
+
+/**
+ * The only tests that should be run (i.e. set by user via `-only` option).
+ */
+@property (nonatomic, copy) NSArray *onlyTests;
 
 /**
  * YES if this testable was deselected in the Xcode scheme
- * (i.e. it gets skipped)
+ * (i.e. it gets skipped).
  */
 @property (nonatomic, assign) BOOL skipped;
 

--- a/xctool/xctool/Testable.m
+++ b/xctool/xctool/Testable.m
@@ -23,8 +23,8 @@
   Testable *copy = [super copyWithZone:zone];
 
   if (copy) {
-    copy.senTestList = _senTestList;
-    copy.senTestInvertScope = _senTestInvertScope;
+    copy.skippedTests = _skippedTests;
+    copy.onlyTests = _onlyTests;
     copy.skipped = _skipped;
     copy.arguments = _arguments;
     copy.environment = _environment;
@@ -47,8 +47,8 @@
 
   return ([super isEqual:other] &&
           [other isKindOfClass:[Testable class]] &&
-          bothNilOrEqual(_senTestList, other.senTestList) &&
-          _senTestInvertScope == other.senTestInvertScope &&
+          bothNilOrEqual(_skippedTests, other.skippedTests) &&
+          bothNilOrEqual(_onlyTests, other.onlyTests) &&
           _skipped == other.skipped &&
           bothNilOrEqual(_arguments, other.arguments) &&
           bothNilOrEqual(_environment, other.environment) &&

--- a/xctool/xctool/XcodeSubjectInfo.m
+++ b/xctool/xctool/XcodeSubjectInfo.m
@@ -700,23 +700,12 @@ containsFilesModifiedSince:(NSDate *)sinceDate
       [testsToSkip addObject:test];
     }
 
-    NSString *senTestList = nil;
-    BOOL senTestInvertScope = NO;
-    if (testsToSkip.count > 0) {
-      senTestList = [testsToSkip componentsJoinedByString:@","];
-      senTestInvertScope = YES;
-    } else {
-      senTestList = @"All";
-      senTestInvertScope = NO;
-    }
-
     Testable *testable = [[Testable alloc] init];
     testable.projectPath = projectPath;
     testable.target = target;
     testable.targetID = targetID;
     testable.executable = executable;
-    testable.senTestInvertScope = senTestInvertScope;
-    testable.senTestList = senTestList;
+    testable.skippedTests = testsToSkip;
     testable.skipped = skipped;
     testable.arguments = argumentsAndEnvironment[@"arguments"];
     testable.environment = argumentsAndEnvironment[@"environment"];


### PR DESCRIPTION
This PR addresses a bug described in https://github.com/facebook/xctool/issues/657. But also improves  wordings and data flow in xctool.