### PR TITLE
Pass derivedDataPath to BuildTestsAction

### DIFF
--- a/xctool/xctool/BuildTestsAction.h
+++ b/xctool/xctool/BuildTestsAction.h
@@ -29,7 +29,8 @@
                symRoot:(NSString *)symRoot
      sharedPrecompsDir:(NSString *)sharedPrecompsDir
         xcodeArguments:(NSArray *)xcodeArguments
-          xcodeCommand:(NSString *)xcodeCommand;
+          xcodeCommand:(NSString *)xcodeCommand
+       derivedDataPath:(NSString *)derivedDataPath;
 
 + (BOOL)buildTestables:(NSArray *)testables
                command:(NSString *)command

--- a/xctool/xctool/BuildTestsAction.h
+++ b/xctool/xctool/BuildTestsAction.h
@@ -28,9 +28,9 @@
                objRoot:(NSString *)objRoot
                symRoot:(NSString *)symRoot
      sharedPrecompsDir:(NSString *)sharedPrecompsDir
+       derivedDataPath:(NSString *)derivedDataPath
         xcodeArguments:(NSArray *)xcodeArguments
-          xcodeCommand:(NSString *)xcodeCommand
-       derivedDataPath:(NSString *)derivedDataPath;
+          xcodeCommand:(NSString *)xcodeCommand;
 
 + (BOOL)buildTestables:(NSArray *)testables
                command:(NSString *)command

--- a/xctool/xctool/BuildTestsAction.m
+++ b/xctool/xctool/BuildTestsAction.m
@@ -58,9 +58,9 @@
                objRoot:(NSString *)objRoot
                symRoot:(NSString *)symRoot
      sharedPrecompsDir:(NSString *)sharedPrecompsDir
+       derivedDataPath:(NSString *)derivedDataPath
         xcodeArguments:(NSArray *)xcodeArguments
           xcodeCommand:(NSString *)xcodeCommand
-       derivedDataPath:(NSString *)derivedDataPath
 {
   NSString *customDerivedDataLocation = derivedDataPath ? derivedDataPath : [TemporaryDirectoryForAction() stringByAppendingPathComponent:@"DerivedData"];
   NSArray *taskArguments =
@@ -130,9 +130,9 @@
                                             objRoot:xcodeSubjectInfo.objRoot
                                             symRoot:xcodeSubjectInfo.symRoot
                                   sharedPrecompsDir:xcodeSubjectInfo.sharedPrecompsDir
+                                    derivedDataPath:options.derivedDataPath
                                      xcodeArguments:xcodebuildArguments
-                                       xcodeCommand:command
-                                    derivedDataPath:options.derivedDataPath];
+                                       xcodeCommand:command];
 
   [xcodeSubjectInfo.actionScripts postBuildWithOptions:options];
 

--- a/xctool/xctool/BuildTestsAction.m
+++ b/xctool/xctool/BuildTestsAction.m
@@ -60,7 +60,9 @@
      sharedPrecompsDir:(NSString *)sharedPrecompsDir
         xcodeArguments:(NSArray *)xcodeArguments
           xcodeCommand:(NSString *)xcodeCommand
+       derivedDataPath:(NSString *)derivedDataPath
 {
+  NSString *customDerivedDataLocation = derivedDataPath ? derivedDataPath : [TemporaryDirectoryForAction() stringByAppendingPathComponent:@"DerivedData"];
   NSArray *taskArguments =
   [xcodeArguments arrayByAddingObjectsFromArray:@[
    @"-workspace", path,
@@ -82,8 +84,7 @@
    // we're overriding OBJROOT/SYMROOM/SHARED_PRECOMPS_DIR, no build output ends
    // up here so the directory serves no purpose.  It's empty except for one
    // 'info.plist' file.
-   [@"-IDECustomDerivedDataLocation=" stringByAppendingString:
-    [TemporaryDirectoryForAction() stringByAppendingPathComponent:@"DerivedData"]],
+   [@"-IDECustomDerivedDataLocation=" stringByAppendingString:customDerivedDataLocation],
    xcodeCommand,
    ]];
 
@@ -130,7 +131,8 @@
                                             symRoot:xcodeSubjectInfo.symRoot
                                   sharedPrecompsDir:xcodeSubjectInfo.sharedPrecompsDir
                                      xcodeArguments:xcodebuildArguments
-                                       xcodeCommand:command];
+                                       xcodeCommand:command
+                                    derivedDataPath:options.derivedDataPath];
 
   [xcodeSubjectInfo.actionScripts postBuildWithOptions:options];
 

--- a/xctool/xctool/BuildTestsAction.m
+++ b/xctool/xctool/BuildTestsAction.m
@@ -62,7 +62,7 @@
         xcodeArguments:(NSArray *)xcodeArguments
           xcodeCommand:(NSString *)xcodeCommand
 {
-  NSString *customDerivedDataLocation = derivedDataPath ? derivedDataPath : [TemporaryDirectoryForAction() stringByAppendingPathComponent:@"DerivedData"];
+  NSString *customDerivedDataLocation = derivedDataPath ?: [TemporaryDirectoryForAction() stringByAppendingPathComponent:@"DerivedData"];
   NSArray *taskArguments =
   [xcodeArguments arrayByAddingObjectsFromArray:@[
    @"-workspace", path,


### PR DESCRIPTION
This might help people working around #248 by passing `-derivedDataPath` to `build-tests` (which was ignored before):

1st run:
```
$ ~/Development/xctool/scripts/xctool.sh -scheme 'eBay Kleinanzeigen' -derivedDataPath /tmp/foo build-tests -only 'Unit Tests' -sdk iphonesimulator
...
** BUILD-TESTS SUCCEEDED ** (138066 ms)
```

2nd run:
```
$ ~/Development/xctool/scripts/xctool.sh -scheme 'eBay Kleinanzeigen' -derivedDataPath /tmp/foo build-tests -only 'Unit Tests' -sdk iphonesimulator
...
** BUILD-TESTS SUCCEEDED ** (39262 ms)
```