### PR TITLE
Assert that resultBundlePath does not exist

### DIFF
--- a/xctool/xctool-tests/OptionsTests.m
+++ b/xctool/xctool-tests/OptionsTests.m
@@ -207,28 +207,17 @@
    TEST_DATA @"TestWorkspace-Library-TestProject-Library-showBuildSettings.txt"];
 }
 
-- (void)testResultBundlePathMustBeADirectory
+- (void)testResultBundlePathMustNotExist
 {
-  NSString *validFilePath = TEST_DATA @"TestWorkspace-Library-TestProject-Library-showBuildSettings.txt";
+  NSString *existingFilePath = TEST_DATA @"TestWorkspace-Library-TestProject-Library-showBuildSettings.txt";
+  assertThatBool([[NSFileManager defaultManager] fileExistsAtPath:existingFilePath], isTrue());
   [[Options optionsFrom:@[
                           @"-scheme", @"TestProject-Library",
                           @"-workspace", TEST_DATA @"TestWorkspace-Library/TestWorkspace-Library.xcworkspace",
-                          @"-resultBundlePath", validFilePath,
+                          @"-resultBundlePath", existingFilePath,
                           ]]
    assertOptionsFailToValidateWithError:
-   [NSString stringWithFormat:@"Specified result bundle path must be a directory: %@", validFilePath]];
-}
-
-- (void)testResultBundlePathMustExist
-{
-  NSString *invalidResultBundlePath = @"SOME_BAD_PATH";
-  [[Options optionsFrom:@[
-                          @"-scheme", @"TestProject-Library",
-                          @"-workspace", TEST_DATA @"TestWorkspace-Library/TestWorkspace-Library.xcworkspace",
-                          @"-resultBundlePath", invalidResultBundlePath,
-                          ]]
-   assertOptionsFailToValidateWithError:
-   [NSString stringWithFormat:@"Specified result bundle path doesn't exist: %@", invalidResultBundlePath]];
+   [NSString stringWithFormat:@"Specified result bundle path already exists: %@", existingFilePath]];
 }
 
 - (void)testResultBundlePathWorks

--- a/xctool/xctool/Options.m
+++ b/xctool/xctool/Options.m
@@ -446,11 +446,9 @@
   }
 
   if (_resultBundlePath) {
-    BOOL isDirectory = NO;
-    BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:_resultBundlePath isDirectory:&isDirectory];
-    if (!isDirectory) {
-      NSString *errorReason = fileExists ? @"must be a directory" : @"doesn't exist";
-      *errorMessage = [NSString stringWithFormat:@"Specified result bundle path %@: %@", errorReason, _resultBundlePath];
+    BOOL fileExists = [[NSFileManager defaultManager] fileExistsAtPath:_resultBundlePath];
+    if (fileExists) {
+      *errorMessage = [NSString stringWithFormat:@"Specified result bundle path already exists: %@", _resultBundlePath];
       return NO;
     }
   }


### PR DESCRIPTION
xcodebuild bails if the path provided to `resultBundlePath` exists already, so the current behavior for xctool is backwards (in terms of rejecting a path that doesn't already exist). When presented with a result bundle path that already exists, xcodebulid exits with the error: `xcodebuild: error: Existing file at -resultBundlePath`.

It seems like xcodebuild has the same behavior back to Xcode 6.4, based on brief testing, so I'm kinda curious if this option ever worked?