### PR TITLE
Fixes a crash when no key can be parsed while processing output

### DIFF
--- a/Common/XCToolUtil.m
+++ b/Common/XCToolUtil.m
@@ -100,7 +100,9 @@ NSDictionary *BuildSettingsFromOutput(NSString *output)
       [scanner scanUpToString:@"\n" intoString:&value];
       [scanner scanString:@"\n" intoString:NULL];
 
-      targetSettings[key] = (value == nil) ? @"" : value;
+      if (key) {
+        targetSettings[key] = (value == nil) ? @"" : value;
+      }
     }
 
     settings[target] = targetSettings;


### PR DESCRIPTION
Our crash looked like this:

2016-03-24 15:07:19.478 xctool[14840:96506] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** setObjectForKey: key cannot be nil'
*** First throw call stack:
(
	0   CoreFoundation                      0x00007fff9b8c3ae2 __exceptionPreprocess + 178
	1   libobjc.A.dylib                     0x00007fff95c1073c objc_exception_throw + 48
	2   CoreFoundation                      0x00007fff9b79ded4 -[__NSDictionaryM setObject:forKey:] + 1236
	3   xctool                              0x000000010847ac50 BuildSettingsFromOutput + 848
	4   xctool                              0x00000001084bd0f6 +[TestableExecutionInfo testableBuildSettingsForProject:target:objRoot:symRoot:sharedPrecompsDir:targetedDeviceFamily:xcodeArguments:testSDK:error:] + 1250
	5   xctool                              0x00000001084927ba __56-[RunTestsAction runTestables:options:xcodeSubjectInfo:]_block_invoke + 722
	6   libdispatch.dylib                   0x00007fff9f1a6871 _dispatch_call_block_and_release + 12
	7   libdispatch.dylib                   0x00007fff9f19b33f _dispatch_client_callout + 8
	8   libdispatch.dylib                   0x00007fff9f19ff6f _dispatch_queue_drain + 754
	9   libdispatch.dylib                   0x00007fff9f1a663b _dispatch_queue_invoke + 549
	10  libdispatch.dylib                   0x00007fff9f19b33f _dispatch_client_callout + 8
	11  libdispatch.dylib                   0x00007fff9f19f1cf _dispatch_root_queue_drain + 1890
	12  libdispatch.dylib                   0x00007fff9f19ea34 _dispatch_worker_thread3 + 91
	13  libsystem_pthread.dylib             0x00007fff8d03a68f _pthread_wqthread + 1129
	14  libsystem_pthread.dylib             0x00007fff8d038365 start_wqthread + 13
)
libc++abi.dylib: terminating with uncaught exception of type NSException

Not sure if I should add tests - this randomly happened in Jenkins and things got much more stable since we have the fix deployed.