### PR TITLE
Add timeout of 30s for showBuildSettings tasks

### DIFF
--- a/Common/TaskUtil.h
+++ b/Common/TaskUtil.h
@@ -63,6 +63,13 @@ void ReadOutputsAndFeedOuputLinesToBlockOnQueue(
 NSDictionary *LaunchTaskAndCaptureOutput(NSTask *task, NSString *description);
 
 /**
+ * Launchs a task, waits for exit or timeout, retries n times, and returns a dictionary like
+ * { @"stdout": "...", @"stderr": "..." }
+ * If given timeout is 0.0f, it waits forever (and will not retry of course).
+ */
+NSDictionary *LaunchTaskAndCaptureOutputWithTimeoutAndRetry(NSTask *task, NSString *description, NSTimeInterval timeout, NSUInteger retry);
+
+/**
  * Launches a task, waits for exit, and returns a string of the combined
  * STDOUT and STDERR output.
  */

--- a/Common/TaskUtil.m
+++ b/Common/TaskUtil.m
@@ -286,6 +286,11 @@ void ReadOutputsAndFeedOuputLinesToBlockOnQueue(
 
 NSDictionary *LaunchTaskAndCaptureOutput(NSTask *task, NSString *description)
 {
+  return LaunchTaskAndCaptureOutputWithTimeoutAndRetry(task, description, 0.0f, 0);
+}
+
+NSDictionary *LaunchTaskAndCaptureOutputWithTimeoutAndRetry(NSTask *task, NSString *description, NSTimeInterval timeout, NSUInteger retry)
+{
   int stdoutPipefd[2];
   pipe(stdoutPipefd);
   NSFileHandle *stdoutHandle = [[NSFileHandle alloc] initWithFileDescriptor:stdoutPipefd[1]];
@@ -304,6 +309,8 @@ NSDictionary *LaunchTaskAndCaptureOutput(NSTask *task, NSString *description)
   NSMutableArray *stdoutArray = [NSMutableArray new];
   NSMutableArray *stderrArray = [NSMutableArray new];
 
+  __block BOOL didTimeout = NO;
+
   ReadOutputsAndFeedOuputLinesToBlockOnQueue(fildes, 2, ^(int fd, NSString *line) {
     if (fd == stdoutReadFd) {
       [stdoutArray addObject:line];
@@ -311,11 +318,27 @@ NSDictionary *LaunchTaskAndCaptureOutput(NSTask *task, NSString *description)
       [stderrArray addObject:line];
     }
   }, NULL, ^{
-    LaunchTaskAndMaybeLogCommand(task, description);
-    [task waitUntilExit];
+    dispatch_group_t taskTimeoutGroup = dispatch_group_create();
+    dispatch_group_async(taskTimeoutGroup, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        LaunchTaskAndMaybeLogCommand(task, description);
+        [task waitUntilExit];
+    });
+    dispatch_time_t waitUntil = timeout == 0.0f ? DISPATCH_TIME_FOREVER : dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout * NSEC_PER_SEC));
+    didTimeout = dispatch_group_wait(taskTimeoutGroup, waitUntil) != 0;
+    if (didTimeout) {
+      kill(task.processIdentifier, SIGKILL);
+    }
     [stdoutHandle closeFile];
     [stderrHandle closeFile];
   }, YES);
+
+  if (didTimeout && retry > 0) {
+    NSTask *retryTask = CreateTaskInSameProcessGroup();
+    retryTask.arguments = task.arguments;
+    retryTask.environment = task.environment;
+    retryTask.launchPath = task.launchPath;
+    return LaunchTaskAndCaptureOutputWithTimeoutAndRetry(retryTask, description, timeout, retry--);
+  }
 
   NSString *stdoutOutput = [stdoutArray componentsJoinedByString:@"\n"];
   NSString *stderrOutput = [stderrArray componentsJoinedByString:@"\n"];

--- a/xctool/xctool/RunTestsAction.m
+++ b/xctool/xctool/RunTestsAction.m
@@ -778,9 +778,16 @@ typedef BOOL (^TestableBlock)(NSArray *reporters);
     });
   }
 
-  dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
+  dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(30.0f * NSEC_PER_SEC));
+  long collectBuildSettingsStatus = dispatch_group_wait(group, timeout);
+
   ReportStatusMessageEnd(options.reporters, REPORTER_MESSAGE_INFO,
                          @"Collecting info for testables...");
+
+  if (collectBuildSettingsStatus != 0) {
+    ReportStatusMessage(options.reporters, REPORTER_MESSAGE_ERROR, @"Failed to collect all build settings.");
+    return NO;
+  }
 
   if (_listTestsOnly) {
     return [self listTestsInTestableExecutionInfos:testableExecutionInfos options:options];

--- a/xctool/xctool/RunTestsAction.m
+++ b/xctool/xctool/RunTestsAction.m
@@ -778,16 +778,9 @@ typedef BOOL (^TestableBlock)(NSArray *reporters);
     });
   }
 
-  dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(30.0f * NSEC_PER_SEC));
-  long collectBuildSettingsStatus = dispatch_group_wait(group, timeout);
-
+  dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
   ReportStatusMessageEnd(options.reporters, REPORTER_MESSAGE_INFO,
                          @"Collecting info for testables...");
-
-  if (collectBuildSettingsStatus != 0) {
-    ReportStatusMessage(options.reporters, REPORTER_MESSAGE_ERROR, @"Failed to collect all build settings.");
-    return NO;
-  }
 
   if (_listTestsOnly) {
     return [self listTestsInTestableExecutionInfos:testableExecutionInfos options:options];

--- a/xctool/xctool/TestableExecutionInfo.m
+++ b/xctool/xctool/TestableExecutionInfo.m
@@ -109,8 +109,8 @@
     @"SHOW_ONLY_BUILD_SETTINGS_FOR_TARGET" : target,
   }];
 
-  NSDictionary *output = LaunchTaskAndCaptureOutput(settingsTask,
-                                                    [NSString stringWithFormat:@"running xcodebuild -showBuildSettings for '%@' target", target]);
+  NSString *settingsTaskDescription = [NSString stringWithFormat:@"running xcodebuild -showBuildSettings for '%@' target", target];
+  NSDictionary *output = LaunchTaskAndCaptureOutputWithTimeoutAndRetry(settingsTask, settingsTaskDescription, 10.0f, 5);
   settingsTask = nil;
 
   NSDictionary *allSettings = BuildSettingsFromOutput(output[@"stdout"]);


### PR DESCRIPTION
On our CI (Xcode 7.3) xctool sometimes hangs forever. This happens when
xctool is trying to collect the build settings for the testables:

    |-+- 52192 plu /Users/plu/Development/ios-client/ci-dependencies/bin/xctool -derivedDataPath /tmp/ios-client -scheme eBay Kleinanzeigen UI Tests -sdk iphonesimulator run-tests -noResetSimulatorOnFailure -only UI Tests -destination id=739CFA28-CA10-4DB4-885F-58E1CA15479B -reporter pretty -reporter junit:/Users/plu/Development/ios-client/test-reports/ui/iOS 9.0/ios-client UI Tests iPad 9.0/junit.xml -reporter plain:/Users/plu/Development/ios-client/test-reports/ui/iOS 9.0/ios-client UI Tests iPad 9.0/run-tests.log
    | |--- 52203 plu /Users/plu/Development/ios-client/ci-dependencies/libexec/reporters/pretty
    | |--- 52208 plu /Users/plu/Development/ios-client/ci-dependencies/libexec/reporters/junit
    | |--- 52213 plu /Users/plu/Development/ios-client/ci-dependencies/libexec/reporters/plain
    | \--- 52274 plu /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -configuration Tests -sdk iphonesimulator9.3 -destination id=739CFA28-CA10-4DB4-885F-58E1CA15479B -destination-timeout 10 PLATFORM_NAME=iphonesimulator -project eBay Kleinanzeigen.xcodeproj -target UI Tests OBJROOT=/tmp/ios-client/Build/Intermediates SYMROOT=/tmp/ios-client/Build/Products SHARED_PRECOMPS_DIR=/tmp/ios-client/Build/Intermediates/PrecompiledHeaders TARGETED_DEVICE_FAMILY=1,2 build -showBuildSettings

Unfortunately I have not found the root cause for this yet. This commit
only makes xctool fail early instead of waiting forever. If I run the
same `xcodebuild ... -showBuildSettings` in a separate Terminal.app
while the one executed by xctool is hanging, it just works fine and prints
the build settings immediately.