### PR TITLE
Option to wait for debugger on launch

### DIFF
--- a/xctool/xctool-tests/OCUnitTestRunnerTests.m
+++ b/xctool/xctool-tests/OCUnitTestRunnerTests.m
@@ -58,6 +58,7 @@ static id TestRunnerWithTestListsAndProcessEnv(Class cls, NSDictionary *settings
                        newSimulatorInstance:NO
                   noResetSimulatorOnFailure:NO
                                freshInstall:NO
+                            waitForDebugger:NO
                                 testTimeout:30
                                   reporters:@[eventBuffer]
                          processEnvironment:processEnvironment];

--- a/xctool/xctool-tests/OTestShimTests.m
+++ b/xctool/xctool-tests/OTestShimTests.m
@@ -121,6 +121,7 @@ static NSTask *OtestShimTask(NSString *platformName,
                                                                newSimulatorInstance:NO
                                                           noResetSimulatorOnFailure:NO
                                                                        freshInstall:NO
+                                                                    waitForDebugger:NO
                                                                         testTimeout:1
                                                                           reporters:@[]
                                                                  processEnvironment:@{}];

--- a/xctool/xctool-tests/TestRunStateTests.m
+++ b/xctool/xctool-tests/TestRunStateTests.m
@@ -97,7 +97,7 @@ static TestRunState *TestRunStateForFakeRun(id<EventSink> sink)
                 toReporter:state];
   [state didFinishRunWithStartupError:nil otherErrors:nil];
 
-  assertThat(eventBuffer.events, hasCountOf(88));
+  assertThat(eventBuffer.events, hasCountOf(92));
   assertThat(SelectEventFields(eventBuffer.events, kReporter_Events_BeginTest, @"event"), hasCountOf(7));
   assertThat(SelectEventFields(eventBuffer.events, kReporter_Events_EndTest, @"event"), hasCountOf(7));
 }

--- a/xctool/xctool/OCUnitTestRunner.h
+++ b/xctool/xctool/OCUnitTestRunner.h
@@ -34,6 +34,7 @@
   BOOL _newSimulatorInstance;
   BOOL _noResetSimulatorOnFailure;
   BOOL _freshInstall;
+  BOOL _waitForDebugger;
   NSInteger _testTimeout;
   NSArray *_reporters;
   NSDictionary *_framework;
@@ -69,6 +70,7 @@
                  newSimulatorInstance:(BOOL)newSimulatorInstance
             noResetSimulatorOnFailure:(BOOL)noResetSimulatorOnFailure
                          freshInstall:(BOOL)freshInstall
+                      waitForDebugger:(BOOL)waitForDebugger
                           testTimeout:(NSInteger)testTimeout
                             reporters:(NSArray *)reporters
                    processEnvironment:(NSDictionary *)processEnvironment;

--- a/xctool/xctool/OCUnitTestRunner.m
+++ b/xctool/xctool/OCUnitTestRunner.m
@@ -148,6 +148,7 @@ static NSString * const kEnvVarPassThroughPrefix = @"XCTOOL_TEST_ENV_";
                  newSimulatorInstance:(BOOL)newSimulatorInstance
             noResetSimulatorOnFailure:(BOOL)noResetSimulatorOnFailure
                          freshInstall:(BOOL)freshInstall
+                      waitForDebugger:(BOOL)waitForDebugger
                           testTimeout:(NSInteger)testTimeout
                             reporters:(NSArray *)reporters
                    processEnvironment:(NSDictionary *)processEnvironment
@@ -165,6 +166,7 @@ static NSString * const kEnvVarPassThroughPrefix = @"XCTOOL_TEST_ENV_";
     _newSimulatorInstance = newSimulatorInstance;
     _noResetSimulatorOnFailure = noResetSimulatorOnFailure;
     _freshInstall = freshInstall;
+    _waitForDebugger = waitForDebugger;
     _testTimeout = testTimeout;
     _reporters = [reporters copy];
     _framework = FrameworkInfoForTestBundleAtPath([_simulatorInfo productBundlePath]);
@@ -394,6 +396,10 @@ static NSString * const kEnvVarPassThroughPrefix = @"XCTOOL_TEST_ENV_";
   NSMutableDictionary *internalEnvironment = [NSMutableDictionary dictionary];
   if (_testTimeout > 0) {
     internalEnvironment[@"OTEST_SHIM_TEST_TIMEOUT"] = [@(_testTimeout) stringValue];
+  }
+
+  if (_waitForDebugger) {
+    internalEnvironment[@"XCTOOL_WAIT_FOR_DEBUGGER"] = @"YES";
   }
 
   NSArray *layers = @[

--- a/xctool/xctool/RunTestsAction.h
+++ b/xctool/xctool/RunTestsAction.h
@@ -60,6 +60,7 @@ typedef NS_ENUM(NSInteger, BucketBy) {
 @property (nonatomic, assign) BOOL parallelize;
 @property (nonatomic, assign) BOOL failOnEmptyTestBundles;
 @property (nonatomic, assign) BOOL listTestsOnly;
+@property (nonatomic, assign) BOOL waitForDebugger;
 @property (nonatomic, copy) NSString *testSDK;
 @property (nonatomic, strong) NSMutableArray *onlyList;
 @property (nonatomic, strong) NSMutableArray *omitList;

--- a/xctool/xctool/RunTestsAction.m
+++ b/xctool/xctool/RunTestsAction.m
@@ -206,6 +206,10 @@ NSArray *BucketizeTestCasesByTestClass(NSArray *testCases, int bucketSize)
                      description:@"Add a path to an app test bundle with the path to its host app"
                        paramName:@"BUNDLE:HOST_APP"
                            mapTo:@selector(addAppTest:)],
+    [Action actionOptionWithName:@"waitForDebugger"
+                         aliases:nil
+                     description:@"Spawned test processes will wait for a debugger to be attached before invoking tests. With the pretty reporter, a message will be displayed with the PID to attach. With the plain reporter, it will just halt."
+                         setFlag:@selector(setWaitForDebugger:)],
     ];
 }
 
@@ -681,6 +685,7 @@ typedef BOOL (^TestableBlock)(NSArray *reporters);
                                                              newSimulatorInstance:_newSimulatorInstance
                                                         noResetSimulatorOnFailure:_noResetSimulatorOnFailure
                                                                      freshInstall:_freshInstall
+                                                                  waitForDebugger:_waitForDebugger
                                                                       testTimeout:_testTimeout
                                                                         reporters:reporters
                                                                processEnvironment:[[NSProcessInfo processInfo] environment]];

--- a/xctool/xctool/TestAction.m
+++ b/xctool/xctool/TestAction.m
@@ -111,6 +111,10 @@
                          aliases:nil
                      description:@"Skip actual test running and list them only."
                          setFlag:@selector(setListTestsOnly:)],
+    [Action actionOptionWithName:@"waitForDebugger"
+                         aliases:nil
+                     description:@"Spawn tests but wait for debugger to attach."
+                         setFlag:@selector(setWaitForDebugger:)],
     [Action actionOptionWithName:@"testTimeout"
                          aliases:nil
                      description:
@@ -157,6 +161,11 @@
 - (void)setFreshInstall:(BOOL)freshInstall
 {
   [_runTestsAction setFreshInstall:freshInstall];
+}
+
+- (void)setWaitForDebugger:(BOOL)waitForDebugger
+{
+  [_runTestsAction setWaitForDebugger:waitForDebugger];
 }
 
 - (void)setParallelize:(BOOL)parallelize

--- a/xctool/xctool/TestRunState.m
+++ b/xctool/xctool/TestRunState.m
@@ -165,6 +165,16 @@
   }
 }
 
+- (void)beginStatus:(NSDictionary *)event
+{
+  [self publishEventToReporters:event];
+}
+
+- (void)endStatus:(NSDictionary *)event
+{
+  [self publishEventToReporters:event];
+}
+
 - (void)handleStartupError:(NSString *)startupError
 {
   [[_testSuiteState unstartedTests] makeObjectsPerformSelector:@selector(appendOutput:)


### PR DESCRIPTION
This resolves #614 and addresses the feedback in #629.

The `--wait-for-debugger` option doesn't actually work for launching iOS app test targets. My workaround that seems to work for all test targets is to simply print a message from within the test app just before starting to run tests, and then raise a SIGSTOP which halts execution.