### PR TITLE
Fix simulator SDK not found in Xcode 8.3.3

### DIFF
--- a/xctool/xctool/SimulatorWrapper/SimulatorInfo.m
+++ b/xctool/xctool/SimulatorWrapper/SimulatorInfo.m
@@ -623,7 +623,7 @@ static NSMutableDictionary *__sdkInfoByPath = nil;
   }
   for (SimRuntime* runTime in runTimeArray) {
     if ([[runTime platformPath] isEqualToString:platformPath] &&
-        [[runTime versionString] isEqualToString:platformVersion]) {
+        [[runTime versionString] hasPrefix:platformVersion]) {
       return runTime;
     }
   }
@@ -632,7 +632,10 @@ static NSMutableDictionary *__sdkInfoByPath = nil;
 
 + (NSDictionary *)_sdkInfoForPlatform:(NSString *)platform sdkVersion:(NSString *)sdkVersion
 {
-  NSString *canonicalName = [platform stringByAppendingString:sdkVersion];
+  NSString *sdkMajorMinorVersion = [[[sdkVersion componentsSeparatedByString:@"."]
+                                     subarrayWithRange:(NSRange){0,2}]
+                                    componentsJoinedByString:@"."];
+  NSString *canonicalName = [platform stringByAppendingString:sdkMajorMinorVersion];
   return __sdkInfo[canonicalName];
 }
 


### PR DESCRIPTION
**background**
After upgrading to Xcode 8.3.3, xctool would fail when targeting simulators with "Unable to find SDK for platform iphonesimulator and sdk version 10.3.1", even though the 10.3 sdk was installed.

This issue is caused by `-[SimRuntime versionString]` including the patch version of the sdk, while the sdk's `SDKSettings.plist` includes only the major and minor version.

**change**
When comparing the version as reported by `SimRuntime` to the versions pulled from the sdk's plist, ignore the patch version.

**verification**
- [x] `xctool run-tests -logicTest /path/to/SomeTests.xctest -sdk iphonesimulator` works and uses an available simulator with sdk `iphonesimulator10.3`.