### PR TITLE
Update launchPath for xctest when run against Xcode 9

### DIFF
--- a/Common/TestingFramework.h
+++ b/Common/TestingFramework.h
@@ -30,7 +30,6 @@ typedef NS_ENUM(NSInteger, OTestExitCode) {
 // Internally, it just becomes 'extern'.
 FOUNDATION_EXPORT NSString *const kTestingFrameworkTestProbeClassName;
 FOUNDATION_EXPORT NSString *const kTestingFrameworkTestSuiteClassName;
-FOUNDATION_EXPORT NSString *const kTestingFrameworkIOSTestrunnerName;
 FOUNDATION_EXPORT NSString *const kTestingFrameworkOSXTestrunnerName;
 FOUNDATION_EXPORT NSString *const kTestingFrameworkInvertScopeKey;
 FOUNDATION_EXPORT NSString *const kTestingFrameworkFilterTestArgsKey;

--- a/Common/TestingFramework.m
+++ b/Common/TestingFramework.m
@@ -18,7 +18,6 @@
 
 NSString *const kTestingFrameworkTestProbeClassName = @"kTestingFrameworkTestProbeClassName";
 NSString *const kTestingFrameworkTestSuiteClassName = @"kTestingFrameworkTestSuiteClassName";
-NSString *const kTestingFrameworkIOSTestrunnerName = @"ios_executable";
 NSString *const kTestingFrameworkOSXTestrunnerName = @"osx_executable";
 NSString *const kTestingFrameworkInvertScopeKey = @"invertScope";
 NSString *const kTestingFrameworkFilterTestArgsKey = @"filterTestcasesArg";
@@ -32,7 +31,6 @@ NSDictionary *FrameworkInfoForExtension(NSString *extension)
       @"octest": @{
         kTestingFrameworkTestProbeClassName: @"SenTestProbe",
         kTestingFrameworkTestSuiteClassName: @"SenTestSuite",
-        kTestingFrameworkIOSTestrunnerName: @"usr/bin/otest",
         kTestingFrameworkOSXTestrunnerName: @"Tools/otest",
         kTestingFrameworkFilterTestArgsKey: @"SenTest",
         kTestingFrameworkInvertScopeKey: @"SenTestInvertScope"
@@ -40,7 +38,6 @@ NSDictionary *FrameworkInfoForExtension(NSString *extension)
       @"xctest": @{
         kTestingFrameworkTestProbeClassName: @"XCTestProbe",
         kTestingFrameworkTestSuiteClassName: @"XCTestSuite",
-        kTestingFrameworkIOSTestrunnerName: @"usr/bin/xctest",
         kTestingFrameworkOSXTestrunnerName: @"usr/bin/xctest",
         kTestingFrameworkFilterTestArgsKey: @"XCTest",
         kTestingFrameworkInvertScopeKey: @"XCTestInvertScope"

--- a/Common/XCToolUtil.h
+++ b/Common/XCToolUtil.h
@@ -127,6 +127,11 @@ BOOL ToolchainIsXcode8OrBetter(void);
 BOOL ToolchainIsXcode81OrBetter(void);
 
 /**
+ Returns YES if we're running with Xcode 8.1 or better.
+ */
+BOOL ToolchainIsXcode9OrBetter(void);
+
+/**
  Launches a task that will invoke xcodebuild.  It will automatically feed
  build events to the provided reporters.
 

--- a/Common/XCToolUtil.h
+++ b/Common/XCToolUtil.h
@@ -127,7 +127,7 @@ BOOL ToolchainIsXcode8OrBetter(void);
 BOOL ToolchainIsXcode81OrBetter(void);
 
 /**
- Returns YES if we're running with Xcode 8.1 or better.
+ Returns YES if we're running with Xcode 9.0 or better.
  */
 BOOL ToolchainIsXcode9OrBetter(void);
 

--- a/Common/XCToolUtil.m
+++ b/Common/XCToolUtil.m
@@ -876,6 +876,16 @@ BOOL ToolchainIsXcode81OrBetter(void)
   return result;
 }
 
+BOOL ToolchainIsXcode9OrBetter(void)
+{
+    static BOOL result;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        result = ToolchainIsXcodeVersionSameOrBetter(@"0900");
+    });
+    return result;
+}
+
 NSString *MakeTemporaryDirectory(NSString *nameTemplate)
 {
   NSMutableData *template = [[[NSTemporaryDirectory() stringByAppendingPathComponent:nameTemplate]

--- a/xctool/xctool/OCUnitIOSLogicTestRunner.m
+++ b/xctool/xctool/OCUnitIOSLogicTestRunner.m
@@ -44,7 +44,7 @@ static NSString * const XCTOOL_TMPDIR = @"TMPDIR";
     launchPath = [NSString pathWithComponents:@[
       _buildSettings[Xcode_SDKROOT],
       @"Developer",
-      _framework[kTestingFrameworkIOSTestrunnerName],
+      @"usr/bin/xctest",
     ]];
   }
 

--- a/xctool/xctool/OCUnitIOSLogicTestRunner.m
+++ b/xctool/xctool/OCUnitIOSLogicTestRunner.m
@@ -33,11 +33,20 @@ static NSString * const XCTOOL_TMPDIR = @"TMPDIR";
 
 - (NSTask *)otestTaskWithTestBundle:(NSString *)testBundlePath otestShimOutputPath:(NSString **)otestShimOutputPath
 {
-  NSString *launchPath = [NSString pathWithComponents:@[
-    _buildSettings[Xcode_SDKROOT],
-    @"Developer",
-    _framework[kTestingFrameworkIOSTestrunnerName],
-  ]];
+  NSString *launchPath = nil;
+  if (ToolchainIsXcode9OrBetter()) {
+    launchPath = [NSString pathWithComponents:@[
+      _buildSettings[Xcode_PLATFORM_DIR],
+      @"Developer",
+      @"Library/Xcode/Agents/xctest",
+    ]];
+  } else {
+    launchPath = [NSString pathWithComponents:@[
+      _buildSettings[Xcode_SDKROOT],
+      @"Developer",
+      _framework[kTestingFrameworkIOSTestrunnerName],
+    ]];
+  }
 
   NSArray *args = nil;
   NSMutableDictionary *env = [NSMutableDictionary dictionary];


### PR DESCRIPTION
As mentioned by @aaronclarke in #732, the path for `xctest` has changed in Xcode 9. This was my first pass at getting this to work. It might need further work since I think it's odd to leave `kTestingFrameworkIOSTestrunnerName` pointing to `usr/bin/xctest`, but I think I need a little more guidance from the project maintainers on how this should be done.