### PR TITLE
Fix xctool crash on Mojave

### DIFF
--- a/Common/TaskUtil.m
+++ b/Common/TaskUtil.m
@@ -273,7 +273,6 @@ void ReadOutputsAndFeedOuputLinesToBlockOnQueue(
       if (info->data != NULL) {
         dispatch_release(info->data);
       }
-      close(info->fd);
       dispatch_io_close(info->io, DISPATCH_IO_STOP);
       dispatch_release(info->io);
     });

--- a/xctool/xctool/Version.m
+++ b/xctool/xctool/Version.m
@@ -16,4 +16,4 @@
 
 #import "Version.h"
 
-NSString * const XCToolVersionString = @"0.3.6";
+NSString * const XCToolVersionString = @"0.3.7";


### PR DESCRIPTION
Remove a double close in the pipe processing code. This crashes in Mojave with the error:

```
BUG IN CLIENT OF LIBDISPATCH: Unexpected EV_VANISHED (do not destroy random mach ports or file descriptors)
```

From what I could see, these are occasionally closed twice eg in `LaunchTaskAndCaptureOutput` which closes the handles after task completion but before dispatch source cleanup. Given the `ReadOutputsAndFeedOuputLinesToBlockOnQueue` was not responsible for opening the pipes, it did not seem valid for this function to be closing them, this should be left to the caller.