### PR TITLE
Xcode 11 fix (add --standalone to spawn) 

### DIFF
--- a/xctool/xctool/SimulatorWrapper/SimulatorTaskUtils.m
+++ b/xctool/xctool/SimulatorWrapper/SimulatorTaskUtils.m
@@ -33,10 +33,13 @@ NSTask *CreateTaskForSimulatorExecutable(NSString *sdkName,
 
   if ([sdkName hasPrefix:@"iphonesimulator"] ||
       [sdkName hasPrefix:@"appletvsimulator"]) {
-    [taskArgs addObjectsFromArray:@[
-      @"spawn",
-      [[[simulatorInfo simulatedDevice] UDID] UUIDString],
-    ]];
+    SimDevice *simulatedDevice = [simulatorInfo simulatedDevice];
+    [taskArgs addObject: @"spawn"];
+    if (ToolchainIsXcode10OrBetter() && [simulatedDevice state] != SimDeviceStateBooted) {
+      // If simulator is not booted, pass --standalone option, which is required by Xcode 11.
+      [taskArgs addObject: @"--standalone"];
+    }
+    [taskArgs addObject: [[simulatedDevice UDID] UUIDString]];
     [taskArgs addObject:launchPath];
     [taskArgs addObjectsFromArray:arguments];
 


### PR DESCRIPTION
This is to address #766 .

Before Xcode 11, `simctl spawn` will automatically run in standalone mode if the device is not booted. Xcode 11 starts requiring `--standalone` to be explicit. Since `--standalone` also works on older version of Xcode, I just simply add it to the `spawn` task.

If a simulator is already booted, passing `--standalone` will cause some test cases fail, so it's only added when simulator is not booted.